### PR TITLE
Separate Termia settings from connection data

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,18 +129,15 @@ Remove the launcher without deleting settings or connections:
 
 ## User data and security
 
-Termia stores settings and connections outside the repository:
+Termia stores connection data, settings, and statistics outside the repository:
 
 ```text
-~/.config/termia/connections.json
-```
-
-Saved passwords are currently stored as plain text. Exported configuration files
-can also contain passwords. Aggregate usage counters are stored separately in:
-
-```text
+~/.config/termia/connections.json   # groups and servers
+~/.config/termia/settings.json      # app and terminal settings
 ~/.local/state/termia/statistics.json
 ```
+
+Saved passwords are currently stored as plain text in `connections.json`. Exported connection files can also contain passwords. Aggregate usage counters are stored separately in `statistics.json`.
 
 Termia does not store typed text, command contents, or clipboard contents. Statistics
 are flushed at most every 30 seconds while typing, when sessions end, and when Termia

--- a/docs/README.ca.md
+++ b/docs/README.ca.md
@@ -93,18 +93,17 @@ Elimina únicament el llançador d'escriptori:
 
 ## Dades de l'usuari i seguretat
 
-Les connexions i preferències es desen fora del repositori:
+Les connexions, preferències i estadístiques es desen fora del repositori:
 
 ```text
-~/.config/termia/connections.json
-```
-
-Les contrasenyes desades i els fitxers exportats poden contenir credencials en
-text pla. Els comptadors locals agregats es desen per separat a:
-
-```text
+~/.config/termia/connections.json   # grups i servidors
+~/.config/termia/settings.json      # configuració de l'aplicació i del terminal
 ~/.local/state/termia/statistics.json
 ```
+
+Les contrasenyes desades s'emmagatzemen en text pla a `connections.json`.
+Els fitxers de connexions exportats també poden contenir credencials.
+Els comptadors locals agregats es desen per separat a `statistics.json`.
 
 Termia no desa el text escrit, el contingut de les ordres ni el contingut del
 porta-retalls. Les estadístiques s'escriuen com a màxim cada 30 segons mentre

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -93,18 +93,17 @@ Elimina únicamente el lanzador de escritorio:
 
 ## Datos del usuario y seguridad
 
-Las conexiones y preferencias se guardan fuera del repositorio:
+Las conexiones, preferencias y estadísticas se guardan fuera del repositorio:
 
 ```text
-~/.config/termia/connections.json
-```
-
-Las contraseñas guardadas y los ficheros exportados pueden contener credenciales
-en texto plano. Los contadores locales agregados se guardan por separado en:
-
-```text
+~/.config/termia/connections.json   # grupos y servidores
+~/.config/termia/settings.json      # configuración de la app y del terminal
 ~/.local/state/termia/statistics.json
 ```
+
+Las contraseñas guardadas se almacenan en texto plano en `connections.json`.
+Los ficheros de conexiones exportados también pueden contener credenciales.
+Los contadores locales agregados se guardan por separado en `statistics.json`.
 
 Termia no guarda el texto escrito, el contenido de los comandos ni el contenido del
 portapapeles. Las estadísticas se escriben como máximo cada 30 segundos mientras se

--- a/docs/REGRESSION_CHECKS.md
+++ b/docs/REGRESSION_CHECKS.md
@@ -75,7 +75,8 @@ Protected behavior does not mean the code cannot change. It means regressions sh
 
 ### Configuration and Data
 
-- Existing `connections.json` files must remain loadable when new settings are added.
+- Existing combined `connections.json` files must remain loadable and migrate app/terminal settings into `settings.json` without losing groups, servers, or preferences.
+- New `connections.json` writes must contain only groups and servers; app and terminal preferences must be written to `settings.json`.
 - Import/export configuration must preserve groups, subgroups, servers, SSH user, port, host, password, and private key path where available.
 - Importing Asbru configuration must not add unwanted suffixes such as `- copy`.
 - Clearing configuration must require confirmation.

--- a/src/termia/config_actions.py
+++ b/src/termia/config_actions.py
@@ -31,7 +31,7 @@ class ConfigActionsMixin:
             return
         self.store.data.groups = []
         self.store.data.servers = []
-        self.store.save()
+        self.store.save_connections()
         self.selected = None
         self.refresh_list()
         self.toast_label.set_label(self.t("clear_config"))
@@ -47,7 +47,7 @@ class ConfigActionsMixin:
         except GLib.Error:
             return
         if file and file.get_path():
-            self.store.save()
+            self.store.save_connections()
             export_connections_file(self.store.path, Path(file.get_path()))
             self.toast_label.set_label("Configuración exportada")
 
@@ -62,12 +62,12 @@ class ConfigActionsMixin:
             return
         if file and file.get_path():
             try:
-                imported = load_store_data_from_json(Path(file.get_path()), self.store.data.statistics)
+                imported = load_store_data_from_json(Path(file.get_path()), self.store.data)
             except (OSError, ValueError, TypeError) as exc:
                 self.toast_label.set_label(f"No se pudo importar JSON: {exc}")
                 return
             self.store.data = imported
-            self.store.save()
+            self.store.save_connections()
             self.apply_app_theme()
             self.refresh_list()
             self.toast_label.set_label("Configuración importada")
@@ -95,6 +95,6 @@ class ConfigActionsMixin:
             payload = payload["__PAC__EXPORTED__PARTIAL_CONF"]
         imported_groups, imported_servers = extract_asbru_connections(payload)
         added_groups, added_servers = merge_asbru_connections(self.store.data, imported_groups, imported_servers)
-        self.store.save()
+        self.store.save_connections()
         self.refresh_list()
         self.toast_label.set_label(f"Ásbrú: {added_groups} grupos y {added_servers} servidores importados")

--- a/src/termia/config_io.py
+++ b/src/termia/config_io.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from .models import AppSettings, Group, Server, StatisticsSettings, StoreData, TerminalSettings
+from .models import Group, Server, StoreData
 
 
 def export_connections_file(source: Path, destination: Path) -> None:
@@ -13,12 +13,12 @@ def export_connections_file(source: Path, destination: Path) -> None:
     destination.chmod(0o600)
 
 
-def load_store_data_from_json(path: Path, statistics: StatisticsSettings) -> StoreData:
+def load_store_data_from_json(path: Path, current: StoreData) -> StoreData:
     payload = json.loads(path.read_text(encoding="utf-8"))
     return StoreData(
         groups=[Group(**item) for item in payload.get("groups", [])],
         servers=[Server(**item) for item in payload.get("servers", [])],
-        terminal=TerminalSettings(**payload.get("terminal", {})),
-        app=AppSettings(**payload.get("app", {})),
-        statistics=statistics,
+        terminal=current.terminal,
+        app=current.app,
+        statistics=current.statistics,
     )

--- a/src/termia/constants.py
+++ b/src/termia/constants.py
@@ -9,7 +9,9 @@ from gi.repository import GLib
 
 APP_ID = "local.termia"
 APP_DIR = Path(__file__).resolve().parent
-DATA_FILE = Path(GLib.get_user_config_dir()) / "termia" / "connections.json"
+CONFIG_DIR = Path(GLib.get_user_config_dir()) / "termia"
+DATA_FILE = CONFIG_DIR / "connections.json"
+SETTINGS_FILE = CONFIG_DIR / "settings.json"
 STATE_DIR = Path(os.environ.get("XDG_STATE_HOME", str(Path.home() / ".local" / "state")))
 STATISTICS_FILE = STATE_DIR / "termia" / "statistics.json"
 ABOUT_IMAGE = APP_DIR / "assets" / "termia.svg"

--- a/src/termia/stores.py
+++ b/src/termia/stores.py
@@ -7,7 +7,7 @@ from dataclasses import asdict
 from pathlib import Path
 from uuid import uuid4
 
-from .constants import APP_THEMES, LEGACY_ANSI_PALETTE, STATISTICS_FILE
+from .constants import APP_THEMES, LEGACY_ANSI_PALETTE, SETTINGS_FILE, STATISTICS_FILE
 from .i18n import LANGUAGES, detect_system_language
 from .models import (
     DEFAULT_ANSI_PALETTE,
@@ -37,16 +37,71 @@ class StatisticsStore:
         self.path.chmod(0o600)
 
 
-class ConnectionStore:
-    def __init__(self, path: Path, statistics_path: Path = STATISTICS_FILE) -> None:
+class SettingsStore:
+    def __init__(self, path: Path) -> None:
         self.path = path
-        self.statistics_store = StatisticsStore(statistics_path)
-        self.data = StoreData(statistics=self.statistics_store.data)
+        self.app = AppSettings()
+        self.terminal = TerminalSettings()
         self.load()
 
     def load(self) -> None:
         if not self.path.exists():
-            self.data = StoreData(statistics=self.statistics_store.data)
+            return
+        payload = json.loads(self.path.read_text(encoding="utf-8"))
+        app_payload = payload.get("app", {})
+        app_fields = AppSettings.__dataclass_fields__
+        self.app = AppSettings(**{key: value for key, value in app_payload.items() if key in app_fields})
+        self.terminal = normalize_terminal_settings(TerminalSettings(**payload.get("terminal", {})))
+
+    def save(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "app": asdict(self.app),
+            "terminal": asdict(self.terminal),
+        }
+        self.path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        self.path.chmod(0o600)
+
+
+def normalize_terminal_settings(terminal: TerminalSettings) -> TerminalSettings:
+    if (
+        terminal.font_family == "Ubuntu Mono"
+        and terminal.font_size == 13
+        and terminal.foreground == "#839496"
+        and terminal.background == "#002b36"
+    ):
+        terminal.font_family = "JetBrains Mono"
+        terminal.foreground = "#eeeeec"
+        terminal.background = "#2e3436"
+    if terminal.ansi_palette == LEGACY_ANSI_PALETTE:
+        terminal.ansi_palette = DEFAULT_ANSI_PALETTE.copy()
+    return terminal
+
+
+class ConnectionStore:
+    def __init__(
+        self,
+        path: Path,
+        settings_path: Path = SETTINGS_FILE,
+        statistics_path: Path = STATISTICS_FILE,
+    ) -> None:
+        self.path = path
+        self.settings_store = SettingsStore(settings_path)
+        self.statistics_store = StatisticsStore(statistics_path)
+        self.data = StoreData(
+            terminal=self.settings_store.terminal,
+            app=self.settings_store.app,
+            statistics=self.statistics_store.data,
+        )
+        self.load()
+
+    def load(self) -> None:
+        if not self.path.exists():
+            self.data = StoreData(
+                terminal=self.settings_store.terminal,
+                app=self.settings_store.app,
+                statistics=self.statistics_store.data,
+            )
             return
 
         payload = json.loads(self.path.read_text(encoding="utf-8"))
@@ -54,33 +109,30 @@ class ConnectionStore:
         if legacy_statistics and not self.statistics_store.path.exists():
             self.statistics_store.data = StatisticsSettings(**legacy_statistics)
             self.statistics_store.save()
-        app_payload = payload.get("app", {})
-        app_fields = AppSettings.__dataclass_fields__
-        terminal = TerminalSettings(**payload.get("terminal", {}))
-        repaired = False
-        if (
-            terminal.font_family == "Ubuntu Mono"
-            and terminal.font_size == 13
-            and terminal.foreground == "#839496"
-            and terminal.background == "#002b36"
-        ):
-            terminal.font_family = "JetBrains Mono"
-            terminal.foreground = "#eeeeec"
-            terminal.background = "#2e3436"
-            repaired = True
-        if terminal.ansi_palette == LEGACY_ANSI_PALETTE:
-            terminal.ansi_palette = DEFAULT_ANSI_PALETTE.copy()
-            repaired = True
+
+        app = self.settings_store.app
+        terminal = self.settings_store.terminal
+        settings_migrated = False
+        if not self.settings_store.path.exists() and ("app" in payload or "terminal" in payload):
+            app_payload = payload.get("app", {})
+            app_fields = AppSettings.__dataclass_fields__
+            app = AppSettings(**{key: value for key, value in app_payload.items() if key in app_fields})
+            terminal = normalize_terminal_settings(TerminalSettings(**payload.get("terminal", {})))
+            self.settings_store.app = app
+            self.settings_store.terminal = terminal
+            self.settings_store.save()
+            settings_migrated = True
+
         self.data = StoreData(
             groups=[Group(**item) for item in payload.get("groups", [])],
             servers=[Server(**item) for item in payload.get("servers", [])],
             terminal=terminal,
-            app=AppSettings(**{key: value for key, value in app_payload.items() if key in app_fields}),
+            app=app,
             statistics=self.statistics_store.data,
         )
-        repaired = self.repair_references() or repaired
-        if "statistics" in payload or repaired:
-            self.save()
+        repaired = self.repair_references()
+        if "statistics" in payload or "app" in payload or "terminal" in payload or repaired or settings_migrated:
+            self.save_connections()
 
     def repair_references(self) -> bool:
         group_ids = {group.id for group in self.data.groups}
@@ -95,16 +147,23 @@ class ConnectionStore:
                 repaired = True
         return repaired
 
-    def save(self) -> None:
+    def save_connections(self) -> None:
         self.path.parent.mkdir(parents=True, exist_ok=True)
         payload = {
             "groups": [asdict(group) for group in self.data.groups],
             "servers": [asdict(server) for server in self.data.servers],
-            "terminal": asdict(self.data.terminal),
-            "app": asdict(self.data.app),
         }
         self.path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
         self.path.chmod(0o600)
+
+    def save_settings(self) -> None:
+        self.settings_store.app = self.data.app
+        self.settings_store.terminal = self.data.terminal
+        self.settings_store.save()
+
+    def save(self) -> None:
+        self.save_connections()
+        self.save_settings()
 
     def save_statistics(self) -> None:
         self.statistics_store.data = self.data.statistics
@@ -113,7 +172,7 @@ class ConnectionStore:
     def add_group(self, name: str, parent_id: str | None = None) -> Group:
         group = Group(id=str(uuid4()), name=name.strip(), parent_id=parent_id)
         self.data.groups.append(group)
-        self.save()
+        self.save_connections()
         return group
 
     def update_group(self, group_id: str, name: str, parent_id: str | None = None) -> None:
@@ -122,7 +181,7 @@ class ConnectionStore:
                 group.name = name.strip()
                 group.parent_id = parent_id
                 break
-        self.save()
+        self.save_connections()
 
     def delete_group(self, group_id: str) -> None:
         group_ids = {group_id}
@@ -137,7 +196,7 @@ class ConnectionStore:
             pending.extend(child_ids)
         self.data.groups = [group for group in self.data.groups if group.id not in group_ids]
         self.data.servers = [server for server in self.data.servers if server.group_id not in group_ids]
-        self.save()
+        self.save_connections()
 
     def add_server(
         self,
@@ -160,7 +219,7 @@ class ConnectionStore:
             public_key=public_key,
         )
         self.data.servers.append(server)
-        self.save()
+        self.save_connections()
         return server
 
     def update_server(
@@ -184,11 +243,11 @@ class ConnectionStore:
                 server.password = password
                 server.public_key = public_key
                 break
-        self.save()
+        self.save_connections()
 
     def delete_server(self, server_id: str) -> None:
         self.data.servers = [server for server in self.data.servers if server.id != server_id]
-        self.save()
+        self.save_connections()
 
     def update_terminal_settings(
         self,
@@ -213,7 +272,7 @@ class ConnectionStore:
             prompt_template=(prompt_template if prompt_template is not None else current.prompt_template) if (prompt_template if prompt_template is not None else current.prompt_template).strip() else r"\u@\h:\w\$ ",
             prompt_color=(prompt_color if prompt_color is not None else current.prompt_color).strip() or "#8ae234",
         )
-        self.save()
+        self.save_settings()
 
     def update_prompt_settings(self, enabled: bool, template: str, color: str) -> None:
         current = self.data.terminal
@@ -228,7 +287,7 @@ class ConnectionStore:
             prompt_template=template if template.strip() else r"\u@\h:\w\$ ",
             prompt_color=color.strip() or "#8ae234",
         )
-        self.save()
+        self.save_settings()
 
     def update_app_settings(
         self, theme: str, language: str, close_tab_on_disconnect: bool,
@@ -249,4 +308,4 @@ class ConnectionStore:
             sudo_password_shortcut=sudo_password_shortcut,
             sudo_password_enter=sudo_password_enter,
         )
-        self.save()
+        self.save_settings()


### PR DESCRIPTION
## Summary

- split Termia persistence into connection data and app settings files
- migrate legacy combined connections.json files into the new layout
- keep connection import/export scoped to groups and servers
- document the new file layout and regression checks

Fixes #16

## Verification

- python3 -m py_compile run_termia.py src/termia/app.py src/termia/asbru_import.py src/termia/config_actions.py src/termia/config_io.py src/termia/connection_dialogs.py src/termia/connection_utils.py src/termia/constants.py src/termia/i18n.py src/termia/main_menu.py src/termia/models.py src/termia/preferences.py src/termia/sidebar.py src/termia/statistics_utils.py src/termia/statistics_view.py src/termia/stores.py src/termia/styles.py src/termia/tabs.py src/termia/terminal_sessions.py src/termia/terminal_config.py src/termia/ui_state.py
- legacy config migration smoke test
- connection-only import smoke test