### PR TITLE
Add configurable terminal keybindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Catalan documentation: [docs/README.ca.md](docs/README.ca.md)
 - Open a statistics dashboard with metric cards, duration summaries, and the most used servers.
 - Show or hide the session status bar globally, hide it per session, and restore it from the terminal context menu.
 - Configure confirmation prompts for disconnecting sessions and closing Termia.
+- Configure terminal keybindings, including `Ctrl+Shift+C` for copy and `Ctrl+Shift+V` for paste.
 - Optionally send the saved SSH password to a remote terminal with `Ctrl+P`, with or without `Enter`.
 - Configure general options, VTE terminal font/colors, and PS1 prompt settings separately.
 - Customize local prompt colors, presets, and time/date prefixes without changing remote shell startup files or commands.
@@ -27,11 +28,13 @@ Catalan documentation: [docs/README.ca.md](docs/README.ca.md)
 
 ## Usage notes
 
-The `Configuration` menu is split into `General`, `Terminal`, and `Prompt`:
+The `Configuration` menu is split into `General`, `Terminal`, `Prompt`, `Keybindings`, and `Security`:
 
 - `General` controls the application theme, language, confirmations, startup behavior, password shortcut behavior, and the session status bar.
 - `Terminal` controls the embedded VTE terminal font, size, foreground/background colors, and color palettes.
 - `Prompt` customizes local terminal PS1 color, presets, and time/date prefixes. It does not alter SSH commands or modify remote shell startup files.
+- `Keybindings` shows the active terminal shortcuts and lets you change common actions such as copy, paste, tab switching, font zoom, and sending the saved password.
+- `Security` controls connection storage mode.
 
 Each session can show a status bar with its state, PID, elapsed time, a compact hide button, and disconnect. Enable or disable session status bars from `General`; if a session status bar is hidden, right-click inside the terminal and choose `Show session status bar` to restore it. The sidebar has its own header toggle.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,18 +2,20 @@
 
 ## Stored credentials
 
-Termia currently stores configured SSH passwords as plain text in:
+Termia stores configured SSH passwords in:
 
 ```text
 ~/.config/termia/connections.json
 ```
 
-The file is written with permissions `0600`, but this is not a replacement for a
-secret store. Do not publish, commit, or share this file. Prefer SSH keys where
-possible.
+The connection file can be kept as plain text or obfuscated from `Security`
+preferences. Obfuscation only reduces accidental readability of the file; it is
+not encryption and is not a replacement for a secret store. The file is written
+with permissions `0600`, but you should still not publish, commit, or share it.
+Prefer SSH keys where possible.
 
-Exported configuration files can also contain plain-text passwords. Treat them
-as sensitive files.
+Exported configuration files can also contain passwords. Treat them as sensitive
+files, even when the local connection file uses obfuscated storage.
 
 The optional `Ctrl+P` shortcut sends the saved SSH password directly to the
 active remote terminal process, with an optional trailing `Enter`. It does not use

--- a/docs/README.ca.md
+++ b/docs/README.ca.md
@@ -18,6 +18,7 @@ Documentació en castellà: [README.es.md](README.es.md)
 - Obrir un dashboard d'estadístiques amb targetes de mètriques, resum de durada i servidors més usats.
 - Mostrar o amagar globalment la barra d'estat de sessió, amagar-la per sessió i restaurar-la des del menú contextual del terminal.
 - Configurar confirmacions per desconnectar sessions i tancar Termia.
+- Configurar dreceres de terminal, incloent `Ctrl+Shift+C` per copiar i `Ctrl+Shift+V` per enganxar.
 - Enviar opcionalment la contrasenya SSH desada a un terminal remot amb `Ctrl+P`, amb `Enter` o sense.
 - Configurar per separat opcions generals, tipus de lletra i colors del terminal VTE, i el prompt PS1.
 - Personalitzar el prompt local amb colors, temes predefinits i prefixos d'hora o data sense canviar fitxers d'inici ni ordres remotes.
@@ -27,11 +28,13 @@ Documentació en castellà: [README.es.md](README.es.md)
 
 ## Notes d'ús
 
-El menú `Configuració` es divideix en `General`, `Terminal` i `Prompt`:
+El menú `Configuració` es divideix en `General`, `Terminal`, `Prompt`, `Dreceres` i `Seguretat`:
 
 - `General` controla tema, idioma, confirmacions, comportament en iniciar, dreceres de contrasenya i barra d'estat de sessió.
 - `Terminal` controla el tipus de lletra, mida, colors i paletes del terminal VTE incrustat.
 - `Prompt` personalitza el PS1 de terminals locals amb color, temes predefinits i prefixos d'hora o data. No altera ordres SSH ni modifica fitxers d'inici remots.
+- `Dreceres` mostra les dreceres actives del terminal i permet canviar accions habituals com copiar, enganxar, canviar de pestanya, zoom de lletra i enviar la contrasenya desada.
+- `Seguretat` controla el mode d'emmagatzematge de connexions.
 
 Cada sessió pot mostrar una barra d'estat amb estat, PID, temps transcorregut, botó compacte per amagar-la i desconnexió. Pots activar o desactivar les barres d'estat des de `General`; si amagues la barra d'una sessió, pots recuperar-la amb el botó dret dins del terminal i `Mostrar barra d'estat de la sessió`. La barra lateral de servidors té el seu propi botó a la capçalera.
 

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -18,6 +18,7 @@ Documentación en catalán: [README.ca.md](README.ca.md)
 - Abrir un dashboard de estadísticas con tarjetas de métricas, resumen de duración y servidores más usados.
 - Mostrar u ocultar globalmente la barra de estado de sesión, ocultarla por sesión y restaurarla desde el menú contextual del terminal.
 - Configurar confirmaciones para desconectar sesiones y cerrar Termia.
+- Configurar atajos de terminal, incluido `Ctrl+Shift+C` para copiar y `Ctrl+Shift+V` para pegar.
 - Enviar opcionalmente la contraseña SSH guardada a un terminal remoto con `Ctrl+P`, con o sin `Enter`.
 - Configurar por separado opciones generales, fuente y colores del terminal VTE, y el prompt PS1.
 - Personalizar el prompt local con colores, temas predefinidos y prefijos de hora o fecha sin cambiar ficheros de inicio ni comandos remotos.
@@ -27,11 +28,13 @@ Documentación en catalán: [README.ca.md](README.ca.md)
 
 ## Notas de uso
 
-El menú `Configuración` se divide en `General`, `Terminal` y `Prompt`:
+El menú `Configuración` se divide en `General`, `Terminal`, `Prompt`, `Atajos` y `Seguridad`:
 
 - `General` controla tema, idioma, confirmaciones, comportamiento al iniciar, atajos de contraseña y barra de estado de sesión.
 - `Terminal` controla la fuente, tamaño, colores y paletas del terminal VTE embebido.
 - `Prompt` personaliza el PS1 de terminales locales con color, temas predefinidos y prefijos de hora o fecha. No altera comandos SSH ni modifica ficheros de inicio remotos.
+- `Atajos` muestra los atajos activos del terminal y permite cambiar acciones habituales como copiar, pegar, cambiar de pestaña, zoom de fuente y enviar la contraseña guardada.
+- `Seguridad` controla el modo de almacenamiento de conexiones.
 
 Cada sesión puede mostrar una barra de estado con estado, PID, tiempo transcurrido, botón compacto para ocultarla y desconexión. Puedes activar o desactivar las barras de estado desde `General`; si ocultas la barra de una sesión, puedes recuperarla con botón derecho dentro del terminal y `Mostrar barra de estado de la sesión`. La barra lateral de servidores tiene su propio botón en la cabecera.
 

--- a/src/termia/i18n.py
+++ b/src/termia/i18n.py
@@ -20,7 +20,7 @@ def detect_system_language() -> str:
 TRANSLATIONS = {
     "es": {
         "servers": "Mostrar u ocultar listado de servidores", "new_group": "Nuevo grupo", "new_server": "Nuevo servidor",
-        "terminal": "Terminal", "prompt": "Prompt", "security": "Seguridad", "general": "General", "preferences": "Preferencias", "filter_servers": "Filtrar servidores",
+        "terminal": "Terminal", "prompt": "Prompt", "keybindings": "Atajos", "security": "Seguridad", "general": "General", "preferences": "Preferencias", "filter_servers": "Filtrar servidores",
         "connect": "Conectar", "edit_server": "Editar servidor", "delete_server": "Eliminar servidor", "clone_connection": "Clonar conexión",
         "edit_group": "Editar grupo", "delete_group": "Eliminar grupo", "no_group": "Sin grupo",
         "parent_group": "Grupo padre", "no_parent_group": "Sin grupo padre",
@@ -45,10 +45,21 @@ TRANSLATIONS = {
         "show_session_status_bar": "Mostrar barra de estado de la sesión", "hide_status_bar": "Ocultar",
         "statistics_enabled": "Registrar estadísticas locales de conexiones y duración",
         "confirm_disconnect": "Confirmar antes de desconectar o cerrar una sesión activa", "confirm_close_app": "Confirmar para cerrar Termia",
-        "sudo_password_shortcut": "Enviar contraseña con Ctrl+P",
+        "sudo_password_shortcut": "Permitir enviar contraseña con atajo",
         "sudo_password_enter": "Enviar contraseña y pulsar Enter",
         "sudo_password_sent": "Contraseña guardada enviada a la terminal",
         "sudo_password_unavailable": "Esta terminal no tiene una contraseña guardada",
+        "keybindings_description": "Configura atajos activos dentro del terminal. Deja una acción desactivada para que la combinación llegue al shell remoto.",
+        "keybindings_restore_defaults": "Restaurar valores",
+        "keybindings_settings_saved": "Atajos guardados",
+        "keybinding_disabled": "Desactivado",
+        "keybinding_action_copy": "Copiar selección",
+        "keybinding_action_paste": "Pegar portapapeles",
+        "keybinding_action_previous_tab": "Pestaña anterior",
+        "keybinding_action_next_tab": "Pestaña siguiente",
+        "keybinding_action_font_increase": "Aumentar fuente",
+        "keybinding_action_font_decrease": "Reducir fuente",
+        "keybinding_action_send_password": "Enviar contraseña guardada",
         "close_app": "Cerrar Termia", "close_app_confirm": "¿Quieres cerrar Termia?",
         "font_size": "Fuente y tamaño", "custom_prompt": "Personalizar prompt local", "prompt_template": "Plantilla PS1", "prompt_color": "Color del prompt", "prompt_presets": "Temas de prompt", "prompt_datetime": "Fecha y hora", "prompt_datetime_none": "Sin fecha/hora", "prompt_datetime_time": "Hora", "prompt_datetime_time_seconds": "Hora y segundos", "prompt_datetime_date": "Fecha", "prompt_datetime_both": "Fecha y hora", "prompt_settings_saved": "Configuración de prompt guardada", "terminal_settings_saved": "Preferencias de terminal guardadas", "security_settings_saved": "Preferencias de seguridad guardadas", "terminal_font_size_changed": "Tamaño de fuente del terminal: {size}", "foreground": "Foreground", "background": "Background", "palettes": "Paletas",
         "connection_storage_mode": "Almacenamiento de conexiones", "connection_storage_plain": "Texto plano", "connection_storage_obfuscated": "Ofuscado", "connection_storage_obfuscated_warning": "La ofuscación evita lecturas accidentales del fichero, pero no cifra ni protege frente a un atacante con acceso al código.", "configuration": "Configuración", "connections_file": "Importar/Exportar", "export_config": "Exportar configuración", "import_config": "Importar configuración",
@@ -70,7 +81,7 @@ TRANSLATIONS = {
             "- Abre conexiones y terminales locales en pestañas embebidas, compactas y desacoplables.\n"
             "- Muestra un dashboard de estadísticas con métricas globales, duración y servidores más usados, además de estadísticas por sesión.\n"
             "- La barra de estado de sesión muestra estado, PID, tiempo y desconexión; puede mostrarse desde General, ocultarse por sesión y restaurarse desde el menú contextual.\n"
-            "- Permite enviar opcionalmente la contraseña guardada con Ctrl+P.\n"
+            "- Permite configurar atajos de terminal, incluido copiar, pegar y enviar la contraseña guardada.\n"
             "- Configura por separado opciones generales, terminal VTE y prompt PS1.\n"
             "- El prompt local permite color, temas predefinidos, hora, fecha y previsualización sin modificar sesiones remotas.\n"
             "- Importa y exporta configuraciones, incluida la importación básica desde Ásbrú.\n\n"
@@ -84,7 +95,7 @@ TRANSLATIONS = {
     },
     "ca": {
         "servers": "Mostrar o amagar el llistat de servidors", "new_group": "Nou grup", "new_server": "Nou servidor",
-        "terminal": "Terminal", "prompt": "Prompt", "security": "Seguretat", "general": "General", "preferences": "Preferències", "filter_servers": "Filtrar servidors",
+        "terminal": "Terminal", "prompt": "Prompt", "keybindings": "Dreceres", "security": "Seguretat", "general": "General", "preferences": "Preferències", "filter_servers": "Filtrar servidors",
         "connect": "Connectar", "edit_server": "Editar servidor", "delete_server": "Eliminar servidor", "clone_connection": "Clonar connexió",
         "edit_group": "Editar grup", "delete_group": "Eliminar grup", "no_group": "Sense grup",
         "parent_group": "Grup pare", "no_parent_group": "Sense grup pare",
@@ -109,10 +120,21 @@ TRANSLATIONS = {
         "show_session_status_bar": "Mostrar barra d'estat de la sessió", "hide_status_bar": "Amagar",
         "statistics_enabled": "Registrar estadístiques locals de connexions i durada",
         "confirm_disconnect": "Confirmar abans de desconnectar o tancar una sessió activa", "confirm_close_app": "Confirmar per tancar Termia",
-        "sudo_password_shortcut": "Enviar contrasenya amb Ctrl+P",
+        "sudo_password_shortcut": "Permetre enviar contrasenya amb drecera",
         "sudo_password_enter": "Enviar contrasenya i prémer Enter",
         "sudo_password_sent": "Contrasenya desada enviada al terminal",
         "sudo_password_unavailable": "Aquest terminal no té cap contrasenya desada",
+        "keybindings_description": "Configura dreceres actives dins del terminal. Deixa una acció desactivada perquè la combinació arribi al shell remot.",
+        "keybindings_restore_defaults": "Restaurar valors",
+        "keybindings_settings_saved": "Dreceres desades",
+        "keybinding_disabled": "Desactivat",
+        "keybinding_action_copy": "Copiar selecció",
+        "keybinding_action_paste": "Enganxar porta-retalls",
+        "keybinding_action_previous_tab": "Pestanya anterior",
+        "keybinding_action_next_tab": "Pestanya següent",
+        "keybinding_action_font_increase": "Augmentar lletra",
+        "keybinding_action_font_decrease": "Reduir lletra",
+        "keybinding_action_send_password": "Enviar contrasenya desada",
         "close_app": "Tancar Termia", "close_app_confirm": "Vols tancar Termia?",
         "font_size": "Tipus de lletra i mida", "custom_prompt": "Personalitzar prompt local", "prompt_template": "Plantilla PS1", "prompt_color": "Color del prompt", "prompt_presets": "Temes de prompt", "prompt_datetime": "Data i hora", "prompt_datetime_none": "Sense data/hora", "prompt_datetime_time": "Hora", "prompt_datetime_time_seconds": "Hora i segons", "prompt_datetime_date": "Data", "prompt_datetime_both": "Data i hora", "prompt_settings_saved": "Configuració del prompt desada", "terminal_settings_saved": "Preferències del terminal desades", "security_settings_saved": "Preferències de seguretat desades", "terminal_font_size_changed": "Mida de la lletra del terminal: {size}", "foreground": "Primer pla", "background": "Fons", "palettes": "Paletes",
         "connection_storage_mode": "Emmagatzematge de connexions", "connection_storage_plain": "Text pla", "connection_storage_obfuscated": "Ofuscat", "connection_storage_obfuscated_warning": "L'ofuscació evita lectures accidentals del fitxer, però no xifra ni protegeix davant un atacant amb accés al codi.", "configuration": "Configuració", "connections_file": "Importar/Exportar", "export_config": "Exportar configuració", "import_config": "Importar configuració",
@@ -134,7 +156,7 @@ TRANSLATIONS = {
             "- Obre connexions i terminals locals en pestanyes incrustades, compactes i desacoblables.\n"
             "- Mostra un dashboard d'estadístiques amb mètriques globals, durada i servidors més usats, a més d'estadístiques per sessió.\n"
             "- La barra d'estat de sessió mostra estat, PID, temps i desconnexió; es pot mostrar des de General, amagar per sessió i restaurar des del menú contextual.\n"
-            "- Permet enviar opcionalment la contrasenya desada amb Ctrl+P.\n"
+            "- Permet configurar dreceres de terminal, incloent copiar, enganxar i enviar la contrasenya desada.\n"
             "- Configura per separat opcions generals, terminal VTE i prompt PS1.\n"
             "- El prompt local permet color, temes predefinits, hora, data i previsualització sense modificar sessions remotes.\n"
             "- Importa i exporta configuracions, inclosa la importació bàsica des d'Ásbrú.\n\n"
@@ -148,7 +170,7 @@ TRANSLATIONS = {
     },
     "en": {
         "servers": "Show or hide server list", "new_group": "New group", "new_server": "New server",
-        "terminal": "Terminal", "prompt": "Prompt", "security": "Security", "general": "General", "preferences": "Preferences", "filter_servers": "Filter servers",
+        "terminal": "Terminal", "prompt": "Prompt", "keybindings": "Keybindings", "security": "Security", "general": "General", "preferences": "Preferences", "filter_servers": "Filter servers",
         "connect": "Connect", "edit_server": "Edit server", "delete_server": "Delete server", "clone_connection": "Clone connection",
         "edit_group": "Edit group", "delete_group": "Delete group", "no_group": "No group",
         "parent_group": "Parent group", "no_parent_group": "No parent group",
@@ -173,10 +195,21 @@ TRANSLATIONS = {
         "show_session_status_bar": "Show session status bar", "hide_status_bar": "Hide",
         "statistics_enabled": "Record local connection and duration statistics",
         "confirm_disconnect": "Confirm before disconnecting or closing an active session", "confirm_close_app": "Confirm before closing Termia",
-        "sudo_password_shortcut": "Send password with Ctrl+P",
+        "sudo_password_shortcut": "Allow sending password with shortcut",
         "sudo_password_enter": "Send password and press Enter",
         "sudo_password_sent": "Saved password sent to the terminal",
         "sudo_password_unavailable": "This terminal does not have a saved password",
+        "keybindings_description": "Configure shortcuts active inside the terminal. Leave an action disabled to let the combination reach the remote shell.",
+        "keybindings_restore_defaults": "Restore defaults",
+        "keybindings_settings_saved": "Keybindings saved",
+        "keybinding_disabled": "Disabled",
+        "keybinding_action_copy": "Copy selection",
+        "keybinding_action_paste": "Paste clipboard",
+        "keybinding_action_previous_tab": "Previous tab",
+        "keybinding_action_next_tab": "Next tab",
+        "keybinding_action_font_increase": "Increase font",
+        "keybinding_action_font_decrease": "Decrease font",
+        "keybinding_action_send_password": "Send saved password",
         "close_app": "Close Termia", "close_app_confirm": "Do you want to close Termia?",
         "font_size": "Font and size", "custom_prompt": "Customize local prompt", "prompt_template": "PS1 template", "prompt_color": "Prompt color", "prompt_presets": "Prompt themes", "prompt_datetime": "Date and time", "prompt_datetime_none": "No date/time", "prompt_datetime_time": "Time", "prompt_datetime_time_seconds": "Time with seconds", "prompt_datetime_date": "Date", "prompt_datetime_both": "Date and time", "prompt_settings_saved": "Prompt settings saved", "terminal_settings_saved": "Terminal preferences saved", "security_settings_saved": "Security preferences saved", "terminal_font_size_changed": "Terminal font size: {size}", "foreground": "Foreground", "background": "Background", "palettes": "Palettes",
         "connection_storage_mode": "Connection storage", "connection_storage_plain": "Plain text", "connection_storage_obfuscated": "Obfuscated", "connection_storage_obfuscated_warning": "Obfuscation prevents accidental file reads, but it does not encrypt data or protect against an attacker with access to the code.", "configuration": "Configuration", "connections_file": "Import/Export", "export_config": "Export configuration", "import_config": "Import configuration",
@@ -198,7 +231,7 @@ TRANSLATIONS = {
             "- Open connections and local terminals in embedded, compact and detachable tabs.\n"
             "- View a statistics dashboard with global metrics, durations and most used servers, plus per-session statistics.\n"
             "- The session status bar shows status, PID, duration and disconnect controls; it can be enabled from General, hidden per session and restored from the context menu.\n"
-            "- Optionally send the saved password with Ctrl+P.\n"
+            "- Configure terminal keybindings, including copy, paste and sending the saved password.\n"
             "- Configure general options, the VTE terminal and the PS1 prompt separately.\n"
             "- The local prompt supports color, presets, time, date and live preview without modifying remote sessions.\n"
             "- Import and export configurations, including basic imports from Ásbrú.\n\n"

--- a/src/termia/keybindings.py
+++ b/src/termia/keybindings.py
@@ -1,0 +1,156 @@
+# SPDX-FileCopyrightText: 2026 Jordi Pons
+# SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import annotations
+
+DEFAULT_KEYBINDINGS: dict[str, str] = {
+    "copy": "Ctrl+Shift+C",
+    "paste": "Ctrl+Shift+V",
+    "previous_tab": "Ctrl+PageUp",
+    "next_tab": "Ctrl+PageDown",
+    "font_increase": "Ctrl++",
+    "font_decrease": "Ctrl+-",
+    "send_password": "Ctrl+P",
+}
+
+KEYBINDING_ACTIONS: tuple[tuple[str, str], ...] = (
+    ("copy", "keybinding_action_copy"),
+    ("paste", "keybinding_action_paste"),
+    ("previous_tab", "keybinding_action_previous_tab"),
+    ("next_tab", "keybinding_action_next_tab"),
+    ("font_increase", "keybinding_action_font_increase"),
+    ("font_decrease", "keybinding_action_font_decrease"),
+    ("send_password", "keybinding_action_send_password"),
+)
+
+KEYBINDING_CHOICES: tuple[str, ...] = (
+    "",
+    "Ctrl+Shift+C",
+    "Ctrl+Shift+V",
+    "Ctrl+PageUp",
+    "Ctrl+PageDown",
+    "Ctrl++",
+    "Ctrl+-",
+    "Ctrl+P",
+    "Ctrl+Shift+P",
+    "Alt+Left",
+    "Alt+Right",
+    "Alt+C",
+    "Alt+V",
+)
+
+_MODIFIER_ORDER = ("Ctrl", "Shift", "Alt", "Super")
+_MODIFIER_ALIASES = {
+    "ctrl": "Ctrl",
+    "control": "Ctrl",
+    "primary": "Ctrl",
+    "shift": "Shift",
+    "alt": "Alt",
+    "mod1": "Alt",
+    "super": "Super",
+    "meta": "Super",
+}
+_KEY_ALIASES = {
+    "pageup": "PageUp",
+    "page_up": "PageUp",
+    "prior": "PageUp",
+    "pagedown": "PageDown",
+    "page_down": "PageDown",
+    "next": "PageDown",
+    "plus": "+",
+    "equal": "+",
+    "kp_add": "+",
+    "minus": "-",
+    "underscore": "-",
+    "kp_subtract": "-",
+    "left": "Left",
+    "right": "Right",
+}
+_KEYVAL_ALIASES = {
+    "PageUp": {"page_up", "kp_page_up"},
+    "PageDown": {"page_down", "kp_page_down"},
+    "+": {"plus", "equal", "kp_add"},
+    "-": {"minus", "underscore", "kp_subtract"},
+    "Left": {"left", "kp_left"},
+    "Right": {"right", "kp_right"},
+}
+
+
+def normalize_keybinding(accelerator: str) -> str:
+    raw = accelerator.replace("<", "").replace(">", "+").strip()
+    if raw.endswith("+"):
+        parts = [part.strip() for part in raw[:-1].split("+")]
+        parts.append("+")
+    else:
+        parts = [part.strip() for part in raw.split("+")]
+    modifiers: list[str] = []
+    key = ""
+    for part in parts:
+        if not part:
+            continue
+        alias = _MODIFIER_ALIASES.get(part.lower())
+        if alias is not None:
+            if alias not in modifiers:
+                modifiers.append(alias)
+            continue
+        key = _KEY_ALIASES.get(part.lower(), part.upper() if len(part) == 1 else part)
+    if not key:
+        return ""
+    ordered = [modifier for modifier in _MODIFIER_ORDER if modifier in modifiers]
+    return "+".join([*ordered, key])
+
+
+def normalize_keybindings(keybindings: dict[str, str] | None) -> dict[str, str]:
+    normalized = DEFAULT_KEYBINDINGS.copy()
+    if not isinstance(keybindings, dict):
+        return normalized
+    for action in DEFAULT_KEYBINDINGS:
+        value = normalize_keybinding(str(keybindings.get(action, normalized[action])))
+        normalized[action] = value
+    return normalized
+
+
+def keybinding_label(accelerator: str, disabled_label: str) -> str:
+    normalized = normalize_keybinding(accelerator)
+    return normalized or disabled_label
+
+
+def keybinding_matches(accelerator: str, keyval: int, state: object) -> bool:
+    normalized = normalize_keybinding(accelerator)
+    if not normalized:
+        return False
+
+    from gi.repository import Gdk
+
+    if normalized.endswith("++"):
+        parts = [part for part in normalized[:-1].split("+") if part]
+        parts.append("+")
+    else:
+        parts = normalized.split("+")
+    key = parts[-1]
+    modifiers = set(parts[:-1])
+    modifier_masks = {
+        "Ctrl": Gdk.ModifierType.CONTROL_MASK,
+        "Shift": Gdk.ModifierType.SHIFT_MASK,
+        "Alt": Gdk.ModifierType.ALT_MASK,
+        "Super": Gdk.ModifierType.SUPER_MASK,
+    }
+    relevant_mask = (
+        Gdk.ModifierType.CONTROL_MASK
+        | Gdk.ModifierType.SHIFT_MASK
+        | Gdk.ModifierType.ALT_MASK
+        | Gdk.ModifierType.SUPER_MASK
+    )
+    required_mask = Gdk.ModifierType(0)
+    for modifier in modifiers:
+        required_mask |= modifier_masks[modifier]
+
+    pressed_mask = state & relevant_mask
+    if key in {"+", "-"} and "Shift" not in modifiers:
+        pressed_mask &= ~Gdk.ModifierType.SHIFT_MASK
+    if pressed_mask != required_mask:
+        return False
+
+    key_name = (Gdk.keyval_name(keyval) or "").lower()
+    if len(key) == 1 and key.isalpha():
+        return key_name == key.lower()
+    return key_name in _KEYVAL_ALIASES.get(key, {key.lower()})

--- a/src/termia/main_menu.py
+++ b/src/termia/main_menu.py
@@ -40,6 +40,11 @@ class MainMenuMixin:
         prompt.connect("clicked", lambda _button: self.run_after_popover_closed(popover, self.on_prompt_settings))
         menu.append(prompt)
 
+        keybindings = Gtk.Button(label=self.t("keybindings"))
+        keybindings.set_halign(Gtk.Align.FILL)
+        keybindings.connect("clicked", lambda _button: self.run_after_popover_closed(popover, self.on_keybindings_settings))
+        menu.append(keybindings)
+
         connections_file = Gtk.MenuButton(label=self.t("connections_file"))
         connections_file.set_halign(Gtk.Align.FILL)
         connections_file.set_popover(self.build_connections_file_menu())
@@ -76,6 +81,11 @@ class MainMenuMixin:
         prompt.set_halign(Gtk.Align.FILL)
         prompt.connect("clicked", lambda _button: self.run_after_popover_closed(popover, self.on_prompt_settings))
         menu.append(prompt)
+
+        keybindings = Gtk.Button(label=self.t("keybindings"))
+        keybindings.set_halign(Gtk.Align.FILL)
+        keybindings.connect("clicked", lambda _button: self.run_after_popover_closed(popover, self.on_keybindings_settings))
+        menu.append(keybindings)
 
         security = Gtk.Button(label=self.t("security"))
         security.set_halign(Gtk.Align.FILL)

--- a/src/termia/models.py
+++ b/src/termia/models.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 from .i18n import detect_system_language
+from .keybindings import DEFAULT_KEYBINDINGS
 
 DEFAULT_LS_COLORS = 'rs=0:di=01;34:ln=01;36:mh=00:pi=40;33:so=01;35:do=01;35:bd=40;33;01:cd=40;33;01:or=40;31;01:mi=00:su=37;41:sg=30;43:ca=00:tw=30;42:ow=34;42:st=37;44:ex=01;32:*.tar=01;31:*.tgz=01;31:*.arc=01;31:*.arj=01;31:*.taz=01;31:*.lha=01;31:*.lz4=01;31:*.lzh=01;31:*.lzma=01;31:*.tlz=01;31:*.txz=01;31:*.tzo=01;31:*.t7z=01;31:*.zip=01;31:*.z=01;31:*.dz=01;31:*.gz=01;31:*.lrz=01;31:*.lz=01;31:*.lzo=01;31:*.xz=01;31:*.zst=01;31:*.tzst=01;31:*.bz2=01;31:*.bz=01;31:*.tbz=01;31:*.tbz2=01;31:*.tz=01;31:*.deb=01;31:*.rpm=01;31:*.jar=01;31:*.war=01;31:*.ear=01;31:*.sar=01;31:*.rar=01;31:*.alz=01;31:*.ace=01;31:*.zoo=01;31:*.cpio=01;31:*.7z=01;31:*.rz=01;31:*.cab=01;31:*.wim=01;31:*.swm=01;31:*.dwm=01;31:*.esd=01;31:*.avif=01;35:*.jpg=01;35:*.jpeg=01;35:*.mjpg=01;35:*.mjpeg=01;35:*.gif=01;35:*.bmp=01;35:*.pbm=01;35:*.pgm=01;35:*.ppm=01;35:*.tga=01;35:*.xbm=01;35:*.xpm=01;35:*.tif=01;35:*.tiff=01;35:*.png=01;35:*.svg=01;35:*.svgz=01;35:*.mng=01;35:*.pcx=01;35:*.mov=01;35:*.mpg=01;35:*.mpeg=01;35:*.m2v=01;35:*.mkv=01;35:*.webm=01;35:*.webp=01;35:*.ogm=01;35:*.mp4=01;35:*.m4v=01;35:*.mp4v=01;35:*.vob=01;35:*.qt=01;35:*.nuv=01;35:*.wmv=01;35:*.asf=01;35:*.rm=01;35:*.rmvb=01;35:*.flc=01;35:*.avi=01;35:*.fli=01;35:*.flv=01;35:*.gl=01;35:*.dl=01;35:*.xcf=01;35:*.xwd=01;35:*.yuv=01;35:*.cgm=01;35:*.emf=01;35:*.ogv=01;35:*.ogx=01;35:*.aac=00;36:*.au=00;36:*.flac=00;36:*.m4a=00;36:*.mid=00;36:*.midi=00;36:*.mka=00;36:*.mp3=00;36:*.mpc=00;36:*.ogg=00;36:*.ra=00;36:*.wav=00;36:*.oga=00;36:*.opus=00;36:*.spx=00;36:*.xspf=00;36:*~=00;90:*#=00;90:*.bak=00;90:*.crdownload=00;90:*.dpkg-dist=00;90:*.dpkg-new=00;90:*.dpkg-old=00;90:*.dpkg-tmp=00;90:*.old=00;90:*.orig=00;90:*.part=00;90:*.rej=00;90:*.rpmnew=00;90:*.rpmorig=00;90:*.rpmsave=00;90:*.swp=00;90:*.tmp=00;90:*.ucf-dist=00;90:*.ucf-new=00;90:*.ucf-old=00;90:'
 DEFAULT_ANSI_PALETTE = ['#2e3436', '#b45d58', '#6f8f5f', '#aa8750', '#5f7f9f', '#8a6f8f', '#5f9292', '#c9c9c9', '#646b70', '#cf6f68', '#8fbf77', '#d2b45f', '#82a8c9', '#aa8aaa', '#83c4c4', '#eeeeec']
@@ -58,6 +59,7 @@ class AppSettings:
     sudo_password_enter: bool = False
     connection_storage_mode: str = "plain"
     statistics_enabled: bool = False
+    keybindings: dict[str, str] = field(default_factory=lambda: DEFAULT_KEYBINDINGS.copy())
 
 
 @dataclass

--- a/src/termia/preferences.py
+++ b/src/termia/preferences.py
@@ -10,6 +10,13 @@ from gi.repository import GLib, Gtk
 from .config_io import CONNECTION_STORAGE_OBFUSCATED, CONNECTION_STORAGE_PLAIN
 from .constants import APP_THEMES, PROMPT_PRESETS, TERMINAL_PALETTES
 from .i18n import LANGUAGES, detect_system_language
+from .keybindings import (
+    DEFAULT_KEYBINDINGS,
+    KEYBINDING_ACTIONS,
+    KEYBINDING_CHOICES,
+    keybinding_label,
+    normalize_keybinding,
+)
 from .terminal_config import (
     parse_color,
     prompt_template_with_datetime,
@@ -196,6 +203,62 @@ class PreferencesMixin:
         if response == Gtk.ResponseType.OK:
             self.store.update_connection_storage_mode(storage_combo.get_active_id() or CONNECTION_STORAGE_PLAIN)
             self.toast_label.set_label(self.t("security_settings_saved"))
+        dialog.destroy()
+
+    def on_keybindings_settings(self, _button: Gtk.Button) -> None:
+        dialog = Gtk.Dialog(title=self.t("keybindings"), transient_for=self, modal=True)
+        dialog.set_resizable(False)
+        dialog.set_default_size(520, -1)
+        self.add_dialog_action_buttons(dialog, self.t("save"))
+        self.add_dialog_action_button(dialog, self.t("keybindings_restore_defaults"), Gtk.ResponseType.APPLY)
+
+        content = dialog.get_content_area()
+        content.set_margin_top(16)
+        content.set_margin_bottom(16)
+        content.set_margin_start(16)
+        content.set_margin_end(16)
+        content.set_spacing(12)
+
+        description = Gtk.Label(label=self.t("keybindings_description"))
+        description.set_xalign(0)
+        description.set_wrap(True)
+        description.add_css_class("dim-label")
+        content.append(description)
+
+        grid = Gtk.Grid(column_spacing=12, row_spacing=10)
+        combos: list[tuple[str, Gtk.ComboBoxText]] = []
+        for index, (action, label_key) in enumerate(KEYBINDING_ACTIONS):
+            label = Gtk.Label(label=self.t(label_key))
+            label.set_xalign(0)
+            combo = Gtk.ComboBoxText()
+            for choice in KEYBINDING_CHOICES:
+                combo.append(choice, keybinding_label(choice, self.t("keybinding_disabled")))
+            current = normalize_keybinding(self.store.data.app.keybindings.get(action, DEFAULT_KEYBINDINGS[action]))
+            if current not in KEYBINDING_CHOICES:
+                combo.append(current, current)
+            combo.set_active_id(current)
+            combo.set_hexpand(True)
+            combos.append((action, combo))
+            grid.attach(label, 0, index, 1, 1)
+            grid.attach(combo, 1, index, 1, 1)
+        content.append(grid)
+
+        dialog.connect("response", self.on_keybindings_settings_response, combos)
+        dialog.present()
+
+    def on_keybindings_settings_response(
+        self,
+        dialog: Gtk.Dialog,
+        response: Gtk.ResponseType,
+        combos: list[tuple[str, Gtk.ComboBoxText]],
+    ) -> None:
+        if response == Gtk.ResponseType.APPLY:
+            for action, combo in combos:
+                combo.set_active_id(DEFAULT_KEYBINDINGS[action])
+            return
+        if response == Gtk.ResponseType.OK:
+            self.store.update_keybindings({action: combo.get_active_id() or "" for action, combo in combos})
+            self.toast_label.set_label(self.t("keybindings_settings_saved"))
         dialog.destroy()
 
     def on_terminal_settings(self, _button: Gtk.Button) -> None:

--- a/src/termia/stores.py
+++ b/src/termia/stores.py
@@ -17,6 +17,7 @@ from .config_io import (
     write_connections_file,
 )
 from .i18n import LANGUAGES, detect_system_language
+from .keybindings import normalize_keybindings
 from .models import (
     DEFAULT_ANSI_PALETTE,
     AppSettings,
@@ -59,7 +60,7 @@ class SettingsStore:
         payload = json.loads(self.path.read_text(encoding="utf-8"))
         app_payload = payload.get("app", {})
         app_fields = AppSettings.__dataclass_fields__
-        self.app = AppSettings(**{key: value for key, value in app_payload.items() if key in app_fields})
+        self.app = normalize_app_settings(AppSettings(**{key: value for key, value in app_payload.items() if key in app_fields}))
         self.terminal = normalize_terminal_settings(TerminalSettings(**payload.get("terminal", {})))
 
     def save(self) -> None:
@@ -70,6 +71,11 @@ class SettingsStore:
         }
         self.path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
         self.path.chmod(0o600)
+
+
+def normalize_app_settings(app: AppSettings) -> AppSettings:
+    app.keybindings = normalize_keybindings(app.keybindings)
+    return app
 
 
 def normalize_terminal_settings(terminal: TerminalSettings) -> TerminalSettings:
@@ -128,7 +134,7 @@ class ConnectionStore:
             if "app" in payload or "terminal" in payload:
                 app_payload = payload.get("app", {})
                 app_fields = AppSettings.__dataclass_fields__
-                app = AppSettings(**{key: value for key, value in app_payload.items() if key in app_fields})
+                app = normalize_app_settings(AppSettings(**{key: value for key, value in app_payload.items() if key in app_fields}))
                 terminal = normalize_terminal_settings(TerminalSettings(**payload.get("terminal", {})))
             app.connection_storage_mode = file_storage_mode
             self.settings_store.app = app
@@ -315,6 +321,7 @@ class ConnectionStore:
         open_local_terminal_on_startup: bool, show_sidebar_on_startup: bool, show_session_status_bar: bool,
         statistics_enabled: bool,
     ) -> None:
+        current = self.data.app
         self.data.app = AppSettings(
             theme=theme if theme in APP_THEMES else "system",
             language=language if language in LANGUAGES else detect_system_language(),
@@ -327,6 +334,12 @@ class ConnectionStore:
             confirm_close_app=confirm_close_app,
             sudo_password_shortcut=sudo_password_shortcut,
             sudo_password_enter=sudo_password_enter,
+            connection_storage_mode=current.connection_storage_mode,
             statistics_enabled=statistics_enabled,
+            keybindings=normalize_keybindings(current.keybindings),
         )
+        self.save_settings()
+
+    def update_keybindings(self, keybindings: dict[str, str]) -> None:
+        self.data.app.keybindings = normalize_keybindings(keybindings)
         self.save_settings()

--- a/src/termia/terminal_sessions.py
+++ b/src/termia/terminal_sessions.py
@@ -21,6 +21,7 @@ gi.require_version("Vte", "3.91")
 from gi.repository import Gdk, Gio, GLib, Gtk, Pango, Vte
 
 from .connection_utils import find_server
+from .keybindings import keybinding_matches
 from .models import DEFAULT_ANSI_PALETTE, Server
 from .terminal_config import (
     build_local_prompt_shell_command,
@@ -390,24 +391,27 @@ class TerminalSessionsMixin:
         if keyval in enter_keys and session.pending_reconnect:
             self.reconnect_session(session)
             return True
-        if state & Gdk.ModifierType.CONTROL_MASK:
-            if keyval in (Gdk.KEY_Page_Up, Gdk.KEY_KP_Page_Up):
-                self.move_terminal_tab_focus(session, -1)
-                return True
-            if keyval in (Gdk.KEY_Page_Down, Gdk.KEY_KP_Page_Down):
-                self.move_terminal_tab_focus(session, 1)
-                return True
-            if keyval in (Gdk.KEY_plus, Gdk.KEY_equal, Gdk.KEY_KP_Add):
-                self.change_terminal_font_size(1)
-                return True
-            if keyval in (Gdk.KEY_minus, Gdk.KEY_underscore, Gdk.KEY_KP_Subtract):
-                self.change_terminal_font_size(-1)
-                return True
-        required_modifiers = Gdk.ModifierType.CONTROL_MASK
-        if (
-            self.store.data.app.sudo_password_shortcut
-            and keyval in (Gdk.KEY_p, Gdk.KEY_P)
-            and state & required_modifiers == required_modifiers
+        keybindings = self.store.data.app.keybindings
+        if keybinding_matches(keybindings.get("copy", ""), keyval, state):
+            session.terminal.copy_clipboard_format(Vte.Format.TEXT)
+            return True
+        if keybinding_matches(keybindings.get("paste", ""), keyval, state):
+            session.terminal.paste_clipboard()
+            return True
+        if keybinding_matches(keybindings.get("previous_tab", ""), keyval, state):
+            self.move_terminal_tab_focus(session, -1)
+            return True
+        if keybinding_matches(keybindings.get("next_tab", ""), keyval, state):
+            self.move_terminal_tab_focus(session, 1)
+            return True
+        if keybinding_matches(keybindings.get("font_increase", ""), keyval, state):
+            self.change_terminal_font_size(1)
+            return True
+        if keybinding_matches(keybindings.get("font_decrease", ""), keyval, state):
+            self.change_terminal_font_size(-1)
+            return True
+        if self.store.data.app.sudo_password_shortcut and keybinding_matches(
+            keybindings.get("send_password", ""), keyval, state
         ):
             self.send_saved_password(session)
             return True


### PR DESCRIPTION
## Summary
- Add configurable terminal keybindings from the Configuration menu
- Add Ctrl+Shift+C for copy and Ctrl+Shift+V for paste by default
- Persist keybindings in settings.json
- Update documentation, including connection-file obfuscation notes

## Tests
- python3 -m py_compile run_termia.py src/termia/app.py src/termia/asbru_import.py src/termia/config_actions.py src/termia/config_io.py src/termia/connection_dialogs.py src/termia/connection_utils.py src/termia/constants.py src/termia/i18n.py src/termia/keybindings.py src/termia/main_menu.py src/termia/models.py src/termia/preferences.py src/termia/sidebar.py src/termia/statistics_utils.py src/termia/statistics_view.py src/termia/stores.py src/termia/styles.py src/termia/tabs.py src/termia/terminal_sessions.py src/termia/terminal_config.py src/termia/ui_state.py
- Keybinding normalization/matching smoke checks
- Settings persistence smoke check

Closes #24
Closes #25