### PR TITLE
Polish split menus and prepare 0.2.0-alpha.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Catalan documentation: [docs/README.ca.md](docs/README.ca.md)
 - Filter servers and open multiple tabbed sessions to the same host.
 - Use embedded, width-sharing tabs and move a tab to a separate window.
 - Open embedded local terminal tabs.
+- Split a terminal tab into multiple panes from the terminal context menu.
 - Optionally track aggregate connection, session-duration, and per-server usage statistics locally.
 - Open a statistics dashboard with metric cards, duration summaries, and the most used servers.
 - Show or hide the session status bar globally, hide it per session, and restore it from the terminal context menu.
@@ -36,7 +37,7 @@ The `Configuration` menu is split into `General`, `Terminal`, `Prompt`, `Keybind
 - `Keybindings` shows the active terminal shortcuts and lets you change common actions such as copy, paste, tab switching, font zoom, and sending the saved password.
 - `Security` controls connection storage mode.
 
-Each session can show a status bar with its state, PID, elapsed time, a compact hide button, and disconnect. Enable or disable session status bars from `General`; if a session status bar is hidden, right-click inside the terminal and choose `Show session status bar` to restore it. The sidebar has its own header toggle.
+Each session can show a status bar with its state, PID, elapsed time, a compact hide button, and disconnect. Enable or disable session status bars from `General`; if a session status bar is hidden, right-click inside the terminal and choose `Show session status bar` to restore it. The sidebar has its own header toggle. Right-click inside a terminal to access translated `Split` and `Tab` submenus; split panes can be created up, down, left, or right, and a pane disappears automatically when its shell exits.
 
 ## Tested environment
 

--- a/docs/README.ca.md
+++ b/docs/README.ca.md
@@ -14,6 +14,7 @@ Documentació en castellà: [README.es.md](README.es.md)
 - Filtrar servidors i obrir diverses sessions al mateix host en pestanyes.
 - Usar pestanyes incrustades que reparteixen l'amplada disponible i moure una pestanya a una finestra independent.
 - Obrir terminals locals incrustats.
+- Dividir una pestanya de terminal en diversos panells des del menú contextual del terminal.
 - Registrar opcionalment estadístiques locals agregades de connexions, durada i ús per servidor.
 - Obrir un dashboard d'estadístiques amb targetes de mètriques, resum de durada i servidors més usats.
 - Mostrar o amagar globalment la barra d'estat de sessió, amagar-la per sessió i restaurar-la des del menú contextual del terminal.
@@ -36,7 +37,7 @@ El menú `Configuració` es divideix en `General`, `Terminal`, `Prompt`, `Drecer
 - `Dreceres` mostra les dreceres actives del terminal i permet canviar accions habituals com copiar, enganxar, canviar de pestanya, zoom de lletra i enviar la contrasenya desada.
 - `Seguretat` controla el mode d'emmagatzematge de connexions.
 
-Cada sessió pot mostrar una barra d'estat amb estat, PID, temps transcorregut, botó compacte per amagar-la i desconnexió. Pots activar o desactivar les barres d'estat des de `General`; si amagues la barra d'una sessió, pots recuperar-la amb el botó dret dins del terminal i `Mostrar barra d'estat de la sessió`. La barra lateral de servidors té el seu propi botó a la capçalera.
+Cada sessió pot mostrar una barra d'estat amb estat, PID, temps transcorregut, botó compacte per amagar-la i desconnexió. Pots activar o desactivar les barres d'estat des de `General`; si amagues la barra d'una sessió, pots recuperar-la amb el botó dret dins del terminal i `Mostrar barra d'estat de la sessió`. La barra lateral de servidors té el seu propi botó a la capçalera. Amb el botó dret dins del terminal pots obrir els submenús traduïts de `Dividir` i `Pestanya`; els panells es poden crear amunt, avall, a l'esquerra o a la dreta, i desapareixen automàticament quan la seva shell acaba.
 
 ## Entorn provat
 

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -14,6 +14,7 @@ Documentación en catalán: [README.ca.md](README.ca.md)
 - Filtrar servidores y abrir varias sesiones al mismo host en pestañas.
 - Usar pestañas embebidas que reparten el ancho disponible y mover una pestaña a una ventana independiente.
 - Abrir terminales locales embebidas.
+- Dividir una pestaña de terminal en varios paneles desde el menú contextual del terminal.
 - Registrar opcionalmente estadísticas locales agregadas de conexiones, duración y uso por servidor.
 - Abrir un dashboard de estadísticas con tarjetas de métricas, resumen de duración y servidores más usados.
 - Mostrar u ocultar globalmente la barra de estado de sesión, ocultarla por sesión y restaurarla desde el menú contextual del terminal.
@@ -36,7 +37,7 @@ El menú `Configuración` se divide en `General`, `Terminal`, `Prompt`, `Atajos`
 - `Atajos` muestra los atajos activos del terminal y permite cambiar acciones habituales como copiar, pegar, cambiar de pestaña, zoom de fuente y enviar la contraseña guardada.
 - `Seguridad` controla el modo de almacenamiento de conexiones.
 
-Cada sesión puede mostrar una barra de estado con estado, PID, tiempo transcurrido, botón compacto para ocultarla y desconexión. Puedes activar o desactivar las barras de estado desde `General`; si ocultas la barra de una sesión, puedes recuperarla con botón derecho dentro del terminal y `Mostrar barra de estado de la sesión`. La barra lateral de servidores tiene su propio botón en la cabecera.
+Cada sesión puede mostrar una barra de estado con estado, PID, tiempo transcurrido, botón compacto para ocultarla y desconexión. Puedes activar o desactivar las barras de estado desde `General`; si ocultas la barra de una sesión, puedes recuperarla con botón derecho dentro del terminal y `Mostrar barra de estado de la sesión`. La barra lateral de servidores tiene su propio botón en la cabecera. Con botón derecho dentro del terminal puedes abrir los submenús traducidos de `Dividir` y `Pestaña`; los paneles se pueden crear arriba, abajo, a la izquierda o a la derecha, y desaparecen automáticamente cuando su shell termina.
 
 ## Entorno probado
 

--- a/docs/REGRESSION_CHECKS.md
+++ b/docs/REGRESSION_CHECKS.md
@@ -50,6 +50,7 @@ Protected behavior does not mean the code cannot change. It means regressions sh
 - Pressing Enter on a failed SSH tab must reconnect to the same server.
 - Exiting an SSH session with `exit` must only close the tab when the relevant preference is enabled.
 - Exiting a local shell must follow the configured local terminal close behavior.
+- Exiting a split shell with `exit` must remove only that split pane and keep sibling panes usable.
 
 ### Focus and Keyboard
 
@@ -64,6 +65,9 @@ Protected behavior does not mean the code cannot change. It means regressions sh
 - Opening dialogs from popovers must close or defer the popover first to avoid GTK grabbing-popup hangs.
 - Context menus must not cause sidebar scroll jumps or horizontal scroll movement.
 - Context menu actions must operate on the selected/right-clicked item, not a stale selection.
+- Terminal context menus must keep the translated `Split` submenu above the `Tab` submenu, with a visual separator before the split actions.
+- Terminal context-menu submenus must share the same hover behavior: open on pointer movement over the submenu row, stay usable while moving into the submenu panel, close when leaving the row and panel, and never close the whole terminal menu unexpectedly.
+- Future terminal context-menu submenus must use the shared nested-menu helper instead of building independent popovers with custom hover behavior.
 
 ### Server Tree
 
@@ -91,6 +95,7 @@ Protected behavior does not mean the code cannot change. It means regressions sh
 - Context menus and popovers must use readable foreground/background colors and must not inherit terminal colors.
 - Sidebar group/server selection colors must remain readable and must preserve the distinction between folders/groups and server entries.
 - New CSS rules must be scoped to Termia classes where practical and must not unintentionally override GTK/VTE internals.
+- Split pane separators must remain visible, narrow, and readable on both light and dark themes.
 
 ### Terminal Appearance
 
@@ -121,6 +126,9 @@ Before merging changes that touch UI, terminals, tabs, or configuration, verify:
 - Open two SSH sessions and duplicate one of them.
 - Close a tab and confirm focus moves to the next terminal.
 - Right-click a terminal and open the context menu.
+- From the terminal context menu, confirm the translated `Split` submenu appears above `Tab` and is separated by a thin divider.
+- Create split panes in all four directions and confirm each new pane opens a working shell.
+- Run `exit` inside a split pane and confirm only that pane disappears while the sibling pane keeps focus and remains usable.
 - Right-click a server/group in the tree and open the context menu.
 - Edit a server and confirm collapsed groups stay collapsed.
 - Search for a group, subgroup, and server in the sidebar filter.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "termia"
-version = "0.1.0"
+dynamic = ["version"]
 description = "GTK SSH connection manager with embedded terminals"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -21,6 +21,9 @@ termia = "termia.app:main"
 
 [tool.setuptools]
 package-dir = { "" = "src" }
+
+[tool.setuptools.dynamic]
+version = { attr = "termia.__version__" }
 
 [tool.setuptools.package-data]
 termia = ["assets/*"]

--- a/src/termia/__init__.py
+++ b/src/termia/__init__.py
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 """Termia SSH connection manager."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0-alpha.1"

--- a/src/termia/i18n.py
+++ b/src/termia/i18n.py
@@ -39,7 +39,7 @@ TRANSLATIONS = {
         "delete_group_confirm_detail": "¿Quieres eliminar {name}? También se eliminarán todos sus subgrupos y servidores. Esta acción no se puede deshacer.",
         "group_deleted": "Grupo eliminado: {name}",
         "theme": "Tema", "language": "Idioma", "restart_language": "El idioma se aplicará al reiniciar la aplicación.",
-        "split": "Split", "split_up": "Split up", "split_down": "Split down", "split_right": "Split right", "split_left": "Split left", "tab": "Pestaña", "close_tab": "Cerrar pestaña", "disconnect": "Desconectar", "connecting": "Conectando",
+        "split": "Dividir", "split_up": "Dividir arriba", "split_down": "Dividir abajo", "split_right": "Dividir a la derecha", "split_left": "Dividir a la izquierda", "tab": "Pestaña", "close_tab": "Cerrar pestaña", "disconnect": "Desconectar", "connecting": "Conectando",
         "close_session_title": "Cerrar sesión", "close_ssh_session_confirm": "¿Quieres cerrar esta sesión SSH? La conexión se desconectará.", "close_local_session_confirm": "¿Quieres cerrar este terminal local? El proceso en ejecución se finalizará.",
         "close_tab_on_disconnect": "Cerrar la pestaña al desconectar una sesión",
         "show_session_status_bar": "Mostrar barra de estado de la sesión", "hide_status_bar": "Ocultar",
@@ -120,9 +120,7 @@ TRANSLATIONS = {
             "- Importa y exporta configuraciones, incluida la importación básica desde Ásbrú.\n\n"
             "Uso rápido:\n"
             "Utiliza los iconos del panel lateral para crear grupos o servidores. Haz doble clic "
-            "sobre un servidor para conectar. Usa el botón derecho en servidores, pestañas o terminales "
-            "para ver acciones contextuales como duplicar, desconectar, copiar, pegar, mostrar la barra "
-            "de estado o ver estadísticas."
+            "sobre un servidor para conectar. Usa el botón derecho en servidores, pestañas o terminales para ver acciones contextuales como duplicar, dividir paneles, desconectar, copiar, pegar, mostrar la barra de estado o ver estadísticas."
         ),
         "about_content": "Gestor de conexiones SSH con terminales embebidas",
     },
@@ -147,7 +145,7 @@ TRANSLATIONS = {
         "delete_group_confirm_detail": "Vols eliminar {name}? També s'eliminaran tots els subgrups i servidors. Aquesta acció no es pot desfer.",
         "group_deleted": "Grup eliminat: {name}",
         "theme": "Tema", "language": "Idioma", "restart_language": "L'idioma s'aplicarà en reiniciar l'aplicació.",
-        "split": "Split", "split_up": "Split up", "split_down": "Split down", "split_right": "Split right", "split_left": "Split left", "tab": "Pestanya", "close_tab": "Tancar pestanya", "disconnect": "Desconnectar", "connecting": "Connectant",
+        "split": "Dividir", "split_up": "Dividir amunt", "split_down": "Dividir avall", "split_right": "Dividir a la dreta", "split_left": "Dividir a l'esquerra", "tab": "Pestanya", "close_tab": "Tancar pestanya", "disconnect": "Desconnectar", "connecting": "Connectant",
         "close_session_title": "Tancar sessió", "close_ssh_session_confirm": "Vols tancar aquesta sessió SSH? La connexió es desconnectarà.", "close_local_session_confirm": "Vols tancar aquest terminal local? El procés en execució es finalitzarà.",
         "close_tab_on_disconnect": "Tancar la pestanya en desconnectar una sessió",
         "show_session_status_bar": "Mostrar barra d'estat de la sessió", "hide_status_bar": "Amagar",
@@ -228,9 +226,7 @@ TRANSLATIONS = {
             "- Importa i exporta configuracions, inclosa la importació bàsica des d'Ásbrú.\n\n"
             "Ús ràpid:\n"
             "Utilitza les icones del panell lateral per crear grups o servidors. Fes doble clic "
-            "sobre un servidor per connectar. Utilitza el botó dret en servidors, pestanyes o terminals "
-            "per veure accions contextuals com duplicar, desconnectar, copiar, enganxar, mostrar la barra "
-            "d'estat o veure estadístiques."
+            "sobre un servidor per connectar. Utilitza el botó dret en servidors, pestanyes o terminals per veure accions contextuals com duplicar, dividir panells, desconnectar, copiar, enganxar, mostrar la barra d'estat o veure estadístiques."
         ),
         "about_content": "Gestor de connexions SSH amb terminals incrustats",
     },
@@ -336,8 +332,7 @@ TRANSLATIONS = {
             "- Import and export configurations, including basic imports from Ásbrú.\n\n"
             "Quick start:\n"
             "Use the sidebar icons to create groups or servers. Double-click a server to connect. "
-            "Right-click servers, tabs or terminals to access contextual actions such as duplicate, "
-            "disconnect, copy, paste, show the status bar or view statistics."
+            "Right-click servers, tabs or terminals to access contextual actions such as duplicate, split panes, disconnect, copy, paste, show the status bar or view statistics."
         ),
         "about_content": "SSH connection manager with embedded terminals",
     },

--- a/src/termia/main_menu.py
+++ b/src/termia/main_menu.py
@@ -11,6 +11,7 @@ gi.require_version("Gtk", "4.0")
 from gi.repository import Gdk, GLib, Gtk
 
 from .constants import ABOUT_IMAGE, ISSUES_URL
+from . import __version__
 
 
 class MainMenuMixin:
@@ -207,7 +208,7 @@ class MainMenuMixin:
     def on_about(self, _button: Gtk.Button) -> None:
         dialog = Gtk.AboutDialog(transient_for=self, modal=True)
         dialog.set_program_name("Termia")
-        dialog.set_version("0.1.0")
+        dialog.set_version(__version__)
         dialog.set_copyright("Copyright © 2026 Jordi Pons")
         dialog.set_license_type(Gtk.License.GPL_3_0)
         dialog.set_comments(self.t("about_content"))

--- a/src/termia/sidebar.py
+++ b/src/termia/sidebar.py
@@ -614,6 +614,15 @@ class SidebarMixin:
         row.add_controller(click)
         menu.append(row)
 
+    def add_context_menu_separator(self, menu: Gtk.ListBox) -> None:
+        row = Gtk.ListBoxRow()
+        row.set_activatable(False)
+        row.set_selectable(False)
+        separator = Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL)
+        separator.add_css_class("termia-menu-separator")
+        row.set_child(separator)
+        menu.append(row)
+
     def server_row(self, server: Server, groups_by_id: dict[str, Group]) -> RowObject:
         group_name = groups_by_id.get(server.group_id).name if server.group_id in groups_by_id else "Sin grupo"
         return RowObject("server", server.id, server.name, f"{server.user}@{server.host}:{server.port} · {group_name}")

--- a/src/termia/styles.py
+++ b/src/termia/styles.py
@@ -13,7 +13,7 @@ def build_application_css(menu_background: str) -> bytes:
         "headerbar:backdrop { background: @headerbar_backdrop_color; } "
         ".termia-session-tabs { background: @headerbar_backdrop_color; padding: 4px 4px 3px 4px; "
         "border: 0; box-shadow: none; } "
-        ".termia-terminal-stack { border: 0; box-shadow: none; } .termia-split-pane separator { background: #c8c8c8; background-color: #c8c8c8; min-width: 1px; min-height: 1px; } .termia-split-pane separator:hover { background: #d4d4d4; background-color: #d4d4d4; } "
+        ".termia-terminal-stack { border: 0; box-shadow: none; } .termia-menu-separator { min-height: 0; border-top: 1px solid rgba(128, 128, 128, 0.35); margin: 4px 12px; } "
         "popover.termia-menu-popover > contents { background: @termia_menu_bg; "
         "background-color: @termia_menu_bg; background-image: none; opacity: 1; } "
         ".termia-menu-panel { background: @termia_menu_bg; "

--- a/src/termia/terminal_sessions.py
+++ b/src/termia/terminal_sessions.py
@@ -506,6 +506,7 @@ class TerminalSessionsMixin:
         popover = Gtk.Popover()
         popover.add_css_class("termia-menu-popover")
         popover.set_has_arrow(False)
+        popover.set_autohide(True)
         popover.set_parent(terminal)
         rect = Gdk.Rectangle()
         rect.x = int(x)
@@ -520,6 +521,8 @@ class TerminalSessionsMixin:
         menu.set_margin_bottom(6)
         menu.set_margin_start(6)
         menu.set_margin_end(6)
+        active_submenu: dict[str, Gtk.Popover | None] = {"popover": None}
+        popover.connect("closed", lambda *_args: self.close_active_terminal_submenu(active_submenu))
         self.add_context_menu_item(menu, self.t("disconnect"), lambda: self.disconnect_from_terminal_menu(popover, session))
         if not session.status_bar.get_visible():
             self.add_context_menu_item(
@@ -537,10 +540,11 @@ class TerminalSessionsMixin:
             self.store.data.app.keybindings.get("paste", ""),
             lambda: self.paste_terminal_clipboard(popover, terminal),
         )
-        self.add_terminal_split_menu(menu, popover, session, terminal)
         self.add_context_menu_item(menu, self.t("configure_terminal"), lambda: self.configure_terminal_from_menu(popover))
         self.add_context_menu_item(menu, self.t("session_statistics"), lambda: self.show_session_statistics(popover, session))
-        self.add_terminal_tab_menu(menu, popover, session)
+        self.add_context_menu_separator(menu)
+        self.add_terminal_split_menu(menu, popover, session, terminal, active_submenu)
+        self.add_terminal_tab_menu(menu, popover, session, active_submenu)
         popover.set_child(menu)
         popover.popup()
 
@@ -580,72 +584,47 @@ class TerminalSessionsMixin:
         parent_popover: Gtk.Popover,
         session: TerminalSession,
         terminal: Vte.Terminal,
+        active_submenu: dict[str, Gtk.Popover | None],
     ) -> None:
-        row = Gtk.ListBoxRow()
-        label_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12)
-        label_box.set_margin_top(8)
-        label_box.set_margin_bottom(8)
-        label_box.set_margin_start(12)
-        label_box.set_margin_end(12)
-        label = Gtk.Label(label=self.t("split"))
-        label.set_xalign(0)
-        label.set_hexpand(True)
-        arrow = Gtk.Label(label=">")
-        arrow.add_css_class("dim-label")
-        label_box.append(label)
-        label_box.append(arrow)
-        row.set_child(label_box)
-
-        submenu = Gtk.Popover()
-        submenu.add_css_class("termia-menu-popover")
-        submenu.set_has_arrow(False)
-        submenu.set_position(Gtk.PositionType.RIGHT)
-        submenu.set_parent(row)
-        submenu_box = Gtk.ListBox()
-        submenu_box.add_css_class("termia-menu-panel")
-        submenu_box.set_selection_mode(Gtk.SelectionMode.NONE)
-        submenu_box.set_margin_top(6)
-        submenu_box.set_margin_bottom(6)
-        submenu_box.set_margin_start(6)
-        submenu_box.set_margin_end(6)
-        for label_key, direction in (
-            ("split_up", "up"),
-            ("split_down", "down"),
-            ("split_right", "right"),
-            ("split_left", "left"),
-        ):
-            self.add_context_menu_item(
-                submenu_box,
-                self.t(label_key),
-                lambda current_direction=direction: self.split_terminal_from_menu(
-                    parent_popover, session, terminal, current_direction
-                ),
-            )
-        submenu.set_child(submenu_box)
-
-        motion = Gtk.EventControllerMotion.new()
-        motion.connect("motion", lambda *_args: submenu.popup())
-        row.add_controller(motion)
-
-        click = Gtk.GestureClick.new()
-        click.set_button(1)
-        click.connect("released", lambda *_args: submenu.popup())
-        row.add_controller(click)
-        menu.append(row)
+        submenu_items = [
+            (self.t("split_up"), lambda: self.split_terminal_from_menu(parent_popover, session, terminal, "up")),
+            (self.t("split_down"), lambda: self.split_terminal_from_menu(parent_popover, session, terminal, "down")),
+            (self.t("split_right"), lambda: self.split_terminal_from_menu(parent_popover, session, terminal, "right")),
+            (self.t("split_left"), lambda: self.split_terminal_from_menu(parent_popover, session, terminal, "left")),
+        ]
+        self.add_terminal_nested_menu(menu, self.t("split"), submenu_items, active_submenu)
 
     def add_terminal_tab_menu(
         self,
         menu: Gtk.ListBox,
         parent_popover: Gtk.Popover,
         session: TerminalSession,
+        active_submenu: dict[str, Gtk.Popover | None],
     ) -> None:
+        submenu_items = [
+            (self.t("rename_tab"), lambda: self.show_rename_tab_dialog(parent_popover, session)),
+            (self.t("duplicate_tab"), lambda: self.duplicate_tab(parent_popover, session)),
+            (self.t("new_tab"), lambda: self.new_tab_from_terminal_menu(parent_popover)),
+            (self.t("close_tab"), lambda: self.close_tab_from_terminal_menu(parent_popover, session)),
+        ]
+        self.add_terminal_nested_menu(menu, self.t("tab"), submenu_items, active_submenu)
+
+    def add_terminal_nested_menu(
+        self,
+        menu: Gtk.ListBox,
+        label_text: str,
+        submenu_items: list[tuple[str, Any]],
+        active_submenu: dict[str, Gtk.Popover | None],
+    ) -> None:
+        # All terminal context-menu submenus must go through this helper so
+        # hover/open/close behavior stays consistent when new submenus are added.
         row = Gtk.ListBoxRow()
         label_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12)
         label_box.set_margin_top(8)
         label_box.set_margin_bottom(8)
         label_box.set_margin_start(12)
         label_box.set_margin_end(12)
-        label = Gtk.Label(label=self.t("tab"))
+        label = Gtk.Label(label=label_text)
         label.set_xalign(0)
         label.set_hexpand(True)
         arrow = Gtk.Label(label=">")
@@ -657,6 +636,7 @@ class TerminalSessionsMixin:
         submenu = Gtk.Popover()
         submenu.add_css_class("termia-menu-popover")
         submenu.set_has_arrow(False)
+        submenu.set_autohide(False)
         submenu.set_position(Gtk.PositionType.RIGHT)
         submenu.set_parent(row)
         submenu_box = Gtk.ListBox()
@@ -666,30 +646,115 @@ class TerminalSessionsMixin:
         submenu_box.set_margin_bottom(6)
         submenu_box.set_margin_start(6)
         submenu_box.set_margin_end(6)
-        self.add_context_menu_item(
-            submenu_box,
-            self.t("rename_tab"),
-            lambda: self.show_rename_tab_dialog(parent_popover, session),
-        )
-        self.add_context_menu_item(submenu_box, self.t("duplicate_tab"), lambda: self.duplicate_tab(parent_popover, session))
-        self.add_context_menu_item(submenu_box, self.t("new_tab"), lambda: self.new_tab_from_terminal_menu(parent_popover))
-        self.add_context_menu_item(
-            submenu_box,
-            self.t("close_tab"),
-            lambda: self.close_tab_from_terminal_menu(parent_popover, session),
-        )
+        for item_label, callback in submenu_items:
+            self.add_context_menu_item(submenu_box, item_label, callback)
         submenu.set_child(submenu_box)
 
-        motion = Gtk.EventControllerMotion.new()
-        motion.connect("motion", lambda *_args: submenu.popup())
-        row.add_controller(motion)
+        row_motion = Gtk.EventControllerMotion.new()
+        row_motion.connect("motion", lambda *_args: self.set_terminal_submenu_row_hover(active_submenu, submenu, True))
+        row_motion.connect("leave", lambda *_args: self.set_terminal_submenu_row_hover(active_submenu, submenu, False))
+        row.add_controller(row_motion)
+
+        submenu_motion = Gtk.EventControllerMotion.new()
+        submenu_motion.connect("motion", lambda *_args: self.set_terminal_submenu_panel_hover(active_submenu, submenu, True))
+        submenu_motion.connect("leave", lambda *_args: self.set_terminal_submenu_panel_hover(active_submenu, submenu, False))
+        submenu_box.add_controller(submenu_motion)
 
         click = Gtk.GestureClick.new()
         click.set_button(1)
-        click.connect("released", lambda *_args: submenu.popup())
+        click.connect("released", lambda *_args: self.set_terminal_submenu_row_hover(active_submenu, submenu, True))
         row.add_controller(click)
 
         menu.append(row)
+
+    def close_active_terminal_submenu(self, active_submenu: dict[str, Gtk.Popover | None]) -> None:
+        close_id = active_submenu.get("close_id")
+        if close_id is not None:
+            GLib.source_remove(close_id)
+            active_submenu["close_id"] = None
+        submenu = active_submenu.get("popover")
+        if submenu is not None:
+            submenu.popdown()
+        active_submenu["popover"] = None
+        active_submenu["row_hover"] = False
+        active_submenu["panel_hover"] = False
+
+    def popup_terminal_submenu(
+        self,
+        active_submenu: dict[str, Gtk.Popover | None],
+        submenu: Gtk.Popover,
+    ) -> None:
+        close_id = active_submenu.get("close_id")
+        if close_id is not None:
+            GLib.source_remove(close_id)
+            active_submenu["close_id"] = None
+        current = active_submenu.get("popover")
+        if current is not submenu:
+            if current is not None:
+                current.popdown()
+            active_submenu["popover"] = submenu
+            active_submenu["row_hover"] = False
+            active_submenu["panel_hover"] = False
+        submenu.popup()
+
+    def set_terminal_submenu_row_hover(
+        self,
+        active_submenu: dict[str, Gtk.Popover | None],
+        submenu: Gtk.Popover,
+        hovered: bool,
+    ) -> None:
+        if hovered:
+            self.popup_terminal_submenu(active_submenu, submenu)
+            active_submenu["row_hover"] = True
+            return
+        if active_submenu.get("popover") is submenu:
+            active_submenu["row_hover"] = False
+            self.schedule_terminal_submenu_close(active_submenu, submenu)
+
+    def set_terminal_submenu_panel_hover(
+        self,
+        active_submenu: dict[str, Gtk.Popover | None],
+        submenu: Gtk.Popover,
+        hovered: bool,
+    ) -> None:
+        if hovered:
+            self.popup_terminal_submenu(active_submenu, submenu)
+            active_submenu["panel_hover"] = True
+            return
+        if active_submenu.get("popover") is submenu:
+            active_submenu["panel_hover"] = False
+            self.schedule_terminal_submenu_close(active_submenu, submenu)
+
+    def schedule_terminal_submenu_close(
+        self,
+        active_submenu: dict[str, Gtk.Popover | None],
+        submenu: Gtk.Popover,
+    ) -> None:
+        close_id = active_submenu.get("close_id")
+        if close_id is not None:
+            GLib.source_remove(close_id)
+        active_submenu["close_id"] = GLib.timeout_add(
+            120,
+            self.close_terminal_submenu_if_inactive,
+            active_submenu,
+            submenu,
+        )
+
+    def close_terminal_submenu_if_inactive(
+        self,
+        active_submenu: dict[str, Gtk.Popover | None],
+        submenu: Gtk.Popover,
+    ) -> bool:
+        active_submenu["close_id"] = None
+        if active_submenu.get("popover") is not submenu:
+            return GLib.SOURCE_REMOVE
+        if active_submenu.get("row_hover") or active_submenu.get("panel_hover"):
+            return GLib.SOURCE_REMOVE
+        submenu.popdown()
+        active_submenu["popover"] = None
+        active_submenu["row_hover"] = False
+        active_submenu["panel_hover"] = False
+        return GLib.SOURCE_REMOVE
 
     def split_terminal_from_menu(
         self,


### PR DESCRIPTION
Closes #39

## Summary
- polish the terminal Split and Tab submenus and keep the shared nested-menu behavior
- document split pane behavior and protect it in regression checks
- translate split actions for supported languages
- centralize Termia versioning and bump to 0.2.0-alpha.1

## Testing
- python3 -m py_compile run_termia.py src/termia/app.py src/termia/asbru_import.py src/termia/config_actions.py src/termia/config_io.py src/termia/connection_dialogs.py src/termia/connection_utils.py src/termia/constants.py src/termia/i18n.py src/termia/keybindings.py src/termia/main_menu.py src/termia/models.py src/termia/preferences.py src/termia/sidebar.py src/termia/statistics_utils.py src/termia/statistics_view.py src/termia/stores.py src/termia/styles.py src/termia/tabs.py src/termia/terminal_sessions.py src/termia/terminal_config.py src/termia/ui_state.py src/termia/__init__.py
- git diff --check