### PR TITLE
Remove dead code from menu, sidebar, and sessions

### DIFF
--- a/src/termia/main_menu.py
+++ b/src/termia/main_menu.py
@@ -15,48 +15,6 @@ from . import __version__
 
 
 class MainMenuMixin:
-    def build_configuration_menu(self) -> Gtk.Popover:
-        popover = Gtk.Popover()
-        popover.add_css_class("termia-menu-popover")
-        popover.set_has_arrow(False)
-        menu = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=4)
-        menu.add_css_class("termia-menu-panel")
-        menu.set_margin_top(6)
-        menu.set_margin_bottom(6)
-        menu.set_margin_start(6)
-        menu.set_margin_end(6)
-
-        general = Gtk.Button(label=self.t("general"))
-        general.set_halign(Gtk.Align.FILL)
-        general.connect("clicked", lambda _button: self.run_after_popover_closed(popover, self.on_app_preferences))
-        self.configure_write_action(general)
-        menu.append(general)
-
-        terminal = Gtk.Button(label=self.t("terminal"))
-        terminal.set_halign(Gtk.Align.FILL)
-        terminal.connect("clicked", lambda _button: self.run_after_popover_closed(popover, self.on_terminal_settings))
-        self.configure_write_action(terminal)
-        menu.append(terminal)
-
-        prompt = Gtk.Button(label=self.t("prompt"))
-        prompt.set_halign(Gtk.Align.FILL)
-        prompt.connect("clicked", lambda _button: self.run_after_popover_closed(popover, self.on_prompt_settings))
-        self.configure_write_action(prompt)
-        menu.append(prompt)
-
-        keybindings = Gtk.Button(label=self.t("keybindings"))
-        keybindings.set_halign(Gtk.Align.FILL)
-        keybindings.connect("clicked", lambda _button: self.run_after_popover_closed(popover, self.on_keybindings_settings))
-        self.configure_write_action(keybindings)
-        menu.append(keybindings)
-
-        connections_file = Gtk.MenuButton(label=self.t("connections_file"))
-        connections_file.set_halign(Gtk.Align.FILL)
-        connections_file.set_popover(self.build_connections_file_menu())
-        menu.append(connections_file)
-        popover.set_child(menu)
-        return popover
-
     def build_main_menu(self) -> Gtk.Popover:
         popover = Gtk.Popover()
         popover.add_css_class("termia-menu-popover")
@@ -240,20 +198,3 @@ class MainMenuMixin:
             child = child.get_next_sibling()
         return GLib.SOURCE_REMOVE
 
-    def build_connections_file_menu(self) -> Gtk.Popover:
-        popover = Gtk.Popover()
-        popover.add_css_class("termia-menu-popover")
-        popover.set_has_arrow(False)
-        menu = Gtk.ListBox()
-        menu.add_css_class("termia-menu-panel")
-        menu.set_selection_mode(Gtk.SelectionMode.NONE)
-        menu.set_margin_top(6)
-        menu.set_margin_bottom(6)
-        menu.set_margin_start(6)
-        menu.set_margin_end(6)
-        self.add_context_menu_item(menu, self.t("export_config"), self.on_export_config)
-        self.add_context_menu_item(menu, self.t("import_config"), self.on_import_config, enabled=not self.store.read_only)
-        self.add_context_menu_item(menu, self.t("import_asbru"), self.on_import_asbru_config, enabled=not self.store.read_only)
-        self.add_context_menu_item(menu, self.t("clear_config"), self.on_request_clear_config, destructive=True, enabled=not self.store.read_only)
-        popover.set_child(menu)
-        return popover

--- a/src/termia/sidebar.py
+++ b/src/termia/sidebar.py
@@ -558,15 +558,6 @@ class SidebarMixin:
         row.set_child(separator)
         menu.append(row)
 
-    def server_row(self, server: Server, groups_by_id: dict[str, Group]) -> RowObject:
-        group_name = groups_by_id.get(server.group_id).name if server.group_id in groups_by_id else "Sin grupo"
-        return RowObject("server", server.id, server.name, f"{server.user}@{server.host}:{server.port} · {group_name}")
-
-    def on_selection_changed(self, selection: Gtk.SingleSelection, _position: int, _n_items: int) -> None:
-        self.selected = selection.get_selected_item()
-        self.render_detail()
-        self.update_actions()
-
     def render_detail(self) -> None:
         if self.selected is None:
             self.title_label.set_label("Selecciona un servidor")
@@ -607,44 +598,3 @@ class SidebarMixin:
         if not self.ensure_writable():
             return
         self.show_server_dialog()
-
-    def on_edit(self, _button: Gtk.Button) -> None:
-        if self.selected is None:
-            return
-        if not self.ensure_writable():
-            return
-        if self.selected.kind == "group":
-            group = find_group(self.store.data.groups, self.selected.item_id)
-            if group:
-                self.show_group_dialog(group)
-        elif self.selected.kind == "server":
-            server = find_server(self.store.data.servers, self.selected.item_id)
-            if server:
-                self.show_server_dialog(server)
-
-    def on_delete(self, _button: Gtk.Button) -> None:
-        if self.selected is None:
-            return
-        if not self.ensure_writable():
-            return
-        if self.selected.kind == "group" and self.selected.item_id:
-            self.request_delete_group(self.selected.item_id)
-            return
-        elif self.selected.kind == "server":
-            server = find_server(self.store.data.servers, self.selected.item_id)
-            self.store.delete_server(self.selected.item_id)
-            self.toast_label.set_label(
-                f"Servidor eliminado: {server.name}" if server else "Servidor eliminado"
-            )
-            self.selected = None
-        self.refresh_list()
-        self.render_detail()
-
-    def on_connect(self, _button: Gtk.Button) -> None:
-        if self.selected is None or self.selected.kind != "server":
-            return
-        server = find_server(self.store.data.servers, self.selected.item_id)
-        if server is None:
-            return
-
-        self.open_terminal_tab(server)

--- a/src/termia/terminal_sessions.py
+++ b/src/termia/terminal_sessions.py
@@ -450,14 +450,6 @@ class TerminalSessionsMixin:
                 break
         self.set_active_session(sessions[(current + delta) % len(sessions)].id)
 
-    def focus_current_terminal_page_later(self) -> bool:
-        visible = self.terminal_stack.get_visible_child()
-        for session in self.open_tabs.values():
-            if session.page is visible:
-                session.terminal.grab_focus()
-                break
-        return GLib.SOURCE_REMOVE
-
     def should_show_session_status_bar(self) -> bool:
         return self.store.data.app.show_session_status_bar
 


### PR DESCRIPTION
Cleanup branch after a deeper dead-code review.

Summary:
- Removed an unused menu builder from main_menu.py.
- Removed unused sidebar callbacks and helpers.
- Removed an unused terminal focus helper.
- Verified the remaining candidate hooks are framework callbacks or still referenced.

Validation:
- python3 -m py_compile src/termia/main_menu.py src/termia/sidebar.py src/termia/terminal_sessions.py