### PR TITLE
Fix split tab close after final pane exits

### DIFF
--- a/docs/REGRESSION_CHECKS.md
+++ b/docs/REGRESSION_CHECKS.md
@@ -51,6 +51,7 @@ Protected behavior does not mean the code cannot change. It means regressions sh
 - Exiting an SSH session with `exit` must only close the tab when the relevant preference is enabled, and only after the last terminal in the tab has exited with no split panes remaining.
 - Exiting a local shell must follow the configured local terminal close behavior.
 - Exiting a split shell with `exit` must remove only that split pane and keep sibling panes usable.
+- When close-on-exit is enabled, a split tab must close after the last pane exits regardless of whether the original terminal or a split exits last.
 
 ### Focus and Keyboard
 

--- a/src/termia/terminal_sessions.py
+++ b/src/termia/terminal_sessions.py
@@ -117,6 +117,7 @@ class TerminalSessionsMixin:
             status_bar=toolbar,
             started_at=time.monotonic(),
         )
+        session.active_terminal_ids.add(id(terminal))
         return session, focus_button
 
     def open_process_terminal_tab(
@@ -162,13 +163,14 @@ class TerminalSessionsMixin:
     def on_process_terminal_exited(self, terminal: Vte.Terminal, _status: int, session: TerminalSession) -> None:
         self.record_session_duration(session)
         self.save_statistics_now()
+        self.mark_terminal_inactive(terminal, session)
         session.connected = False
         session.disconnect_button.set_sensitive(False)
         if session.disconnect_requested:
             session.status_label.set_label(self.t("session_disconnected_status").format(title=session.title))
             return
         if self.child_status_successful(_status):
-            if self.store.data.app.close_tab_on_ssh_exit and not session.split_terminals:
+            if self.should_close_tab_after_terminal_exit(session):
                 self.close_tab(session.id, session.page, disconnect=False)
                 self.toast_label.set_label(self.t("local_terminal_closed").format(title=session.title))
                 return
@@ -793,6 +795,7 @@ class TerminalSessionsMixin:
         terminal = self.create_configured_terminal()
         self.configure_terminal_interactions(terminal, session)
         session.split_terminals.append(terminal)
+        session.active_terminal_ids.add(id(terminal))
         return terminal
 
     def wrap_terminal_in_scroller(self, terminal: Vte.Terminal) -> Gtk.ScrolledWindow:
@@ -912,6 +915,7 @@ class TerminalSessionsMixin:
 
     def on_split_terminal_exited(self, terminal: Vte.Terminal, _status: int, session: TerminalSession) -> None:
         session.split_child_pids.pop(id(terminal), None)
+        self.mark_terminal_inactive(terminal, session)
         if terminal in session.split_terminals:
             session.split_terminals.remove(terminal)
         GLib.idle_add(self.remove_split_terminal_pane, terminal, session)
@@ -928,7 +932,7 @@ class TerminalSessionsMixin:
         if sibling is None:
             return GLib.SOURCE_REMOVE
         self.replace_split_container(parent, sibling)
-        if not session.connected and not session.split_terminals and self.store.data.app.close_tab_on_ssh_exit:
+        if self.should_close_tab_after_terminal_exit(session):
             self.close_tab(session.id, session.page, disconnect=False)
             return GLib.SOURCE_REMOVE
         if session.split_terminals:
@@ -945,6 +949,12 @@ class TerminalSessionsMixin:
         if not isinstance(parent, Gtk.Paned):
             return
         GLib.idle_add(self.remove_split_terminal_pane, terminal, session)
+
+    def mark_terminal_inactive(self, terminal: Vte.Terminal, session: TerminalSession) -> None:
+        session.active_terminal_ids.discard(id(terminal))
+
+    def should_close_tab_after_terminal_exit(self, session: TerminalSession) -> bool:
+        return self.store.data.app.close_tab_on_ssh_exit and not session.active_terminal_ids
 
     def replace_split_container(self, paned: Gtk.Paned, replacement: Gtk.Widget) -> bool:
         parent = paned.get_parent()
@@ -1411,6 +1421,7 @@ class TerminalSessionsMixin:
     ) -> None:
         self.record_session_duration(session)
         self.save_statistics_now()
+        self.mark_terminal_inactive(terminal, session)
         session.connected = False
         session.disconnect_button.set_sensitive(False)
         if session.disconnect_requested:
@@ -1418,7 +1429,7 @@ class TerminalSessionsMixin:
             self.toast_label.set_label(self.t("session_disconnected_toast").format(title=session.title))
             return
         if self.child_status_successful(_status):
-            if self.store.data.app.close_tab_on_ssh_exit and not session.split_terminals:
+            if self.should_close_tab_after_terminal_exit(session):
                 self.close_tab(session.id, session.page, disconnect=False)
                 self.toast_label.set_label(self.t("session_closed_toast").format(title=server.name))
                 return

--- a/src/termia/terminal_sessions.py
+++ b/src/termia/terminal_sessions.py
@@ -918,6 +918,9 @@ class TerminalSessionsMixin:
         self.mark_terminal_inactive(terminal, session)
         if terminal in session.split_terminals:
             session.split_terminals.remove(terminal)
+        if self.should_close_tab_after_terminal_exit(session):
+            self.close_tab(session.id, session.page, disconnect=False)
+            return
         GLib.idle_add(self.remove_split_terminal_pane, terminal, session)
 
     def remove_split_terminal_pane(self, terminal: Vte.Terminal, session: TerminalSession) -> bool:

--- a/src/termia/ui_state.py
+++ b/src/termia/ui_state.py
@@ -44,3 +44,4 @@ class TerminalSession:
     duration_recorded: bool = False
     split_terminals: list[Vte.Terminal] = field(default_factory=list)
     split_child_pids: dict[int, int] = field(default_factory=dict)
+    active_terminal_ids: set[int] = field(default_factory=set)


### PR DESCRIPTION
Summary:
- Track active terminal panes per session.
- Close tabs only after the final active pane exits when close-on-exit is enabled.
- Handle the case where the original terminal exits before the final split pane.
- Add a regression checklist item for this behavior.

Validation:
- python3 -m py_compile src/termia/terminal_sessions.py src/termia/ui_state.py
- Manual check: SSH tab with a split closes after exiting the original terminal first and the remaining split last.

Closes #56