### PR TITLE
Allow cloning local terminal profiles

### DIFF
--- a/src/termia/connection_utils.py
+++ b/src/termia/connection_utils.py
@@ -30,6 +30,17 @@ def unique_server_clone_name(servers: list[Server], name: str) -> str:
     return f"{base_name}-{index}"
 
 
+def unique_local_terminal_clone_name(profiles: list[LocalTerminalProfile], name: str) -> str:
+    existing_names = {profile.name for profile in profiles}
+    base_name = f"{name}-clone"
+    if base_name not in existing_names:
+        return base_name
+    index = 2
+    while f"{base_name}-{index}" in existing_names:
+        index += 1
+    return f"{base_name}-{index}"
+
+
 def server_matches_query(server: Server, query: str) -> bool:
     if not query:
         return True

--- a/src/termia/sidebar.py
+++ b/src/termia/sidebar.py
@@ -19,6 +19,7 @@ from .connection_utils import (
     group_descendant_ids,
     group_matches_query,
     server_matches_query,
+    unique_local_terminal_clone_name,
     unique_server_clone_name,
 )
 from .models import Group, LocalTerminalProfile, Server
@@ -874,6 +875,12 @@ class SidebarMixin:
             )
             self.add_context_menu_item(
                 menu,
+                self.t("clone_connection"),
+                lambda: self.on_local_terminal_context_clone(popover, row.item_id),
+                enabled=not self.store.read_only,
+            )
+            self.add_context_menu_item(
+                menu,
                 self.t("delete_local_terminal"),
                 lambda: self.on_local_terminal_context_delete(popover, row.item_id),
                 destructive=True,
@@ -943,6 +950,27 @@ class SidebarMixin:
         profile = find_local_terminal_profile(self.store.data.local_terminals, profile_id)
         if profile is not None:
             self.show_local_terminal_dialog(profile)
+
+    def on_local_terminal_context_clone(self, popover: Gtk.Popover, profile_id: str) -> None:
+        popover.popdown()
+        if not self.ensure_writable():
+            return
+        profile = find_local_terminal_profile(self.store.data.local_terminals, profile_id)
+        if profile is None:
+            return
+        clone = self.store.add_local_terminal(
+            unique_local_terminal_clone_name(self.store.data.local_terminals, profile.name),
+            profile.working_directory,
+            profile.shell,
+            profile.arguments,
+            profile.command_on_start,
+            profile.tab_title,
+            profile.split_layout,
+        )
+        self.selected = RowObject("local_terminal", clone.id, clone.name)
+        self.toast_label.set_label(f"{self.t('local_terminal_settings_saved')}: {clone.name}")
+        self.refresh_list()
+        self.render_detail()
 
     def on_local_terminal_context_delete(self, popover: Gtk.Popover, profile_id: str) -> None:
         popover.popdown()


### PR DESCRIPTION
## Summary\n- Add a clone action for local terminal profiles in the sidebar context menu.\n- Copy the full profile, including split layout settings, and assign a unique clone name.\n\n## Validation\n- python3 -m py_compile src/termia/connection_utils.py src/termia/sidebar.py\n\nCloses #65