### PR TITLE
Import saved passwords from Ásbrú YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Roadmap: [ROADMAP.md](ROADMAP.md)
 - Customize local prompt colors, presets, and time/date prefixes without changing remote shell startup files or commands.
 - Use the interface in English, Spanish, or Catalan. The initial language follows the system locale when supported.
 - Import and export Termia configuration files.
-- Import basic connection and nested group data from Asbru YAML files.
+- Import basic connection, nested group, and saved password data from Asbru YAML files when available.
 
 ## Usage notes
 
@@ -159,7 +159,7 @@ Termia stores connection data, settings, and statistics outside the repository:
 ~/.local/state/termia/statistics.json
 ```
 
-Saved passwords are stored in `connections.json`; the file can be kept as plain text or obfuscated from Security preferences. Obfuscation is not encryption. Exported connection files can also contain passwords. Aggregate usage counters are stored separately in `statistics.json`. When several Termia processes are open at the same time, only the instance holding `instance.lock` writes connections, settings, or statistics; later instances stay read-only to avoid corrupting these files.
+Saved passwords are stored in `connections.json`; the file can be kept as plain text or obfuscated from Security preferences. Obfuscation is not encryption. Imported Ásbrú passwords are stored the same way when the source YAML exposes them in a `pass` field. Exported connection files can also contain passwords. Aggregate usage counters are stored separately in `statistics.json`. When several Termia processes are open at the same time, only the instance holding `instance.lock` writes connections, settings, or statistics; later instances stay read-only to avoid corrupting these files.
 Recent connections are stored separately in `recent_connections.jsonl` so the sidebar can keep a small, deduplicated Recent section based on the latest successful SSH connections.
 
 Termia does not store typed text, command contents, clipboard contents, command counters, or keystroke counters. Statistics are disabled by default and can be enabled from General preferences. When enabled, they track only aggregate connections, per-server usage, and session durations; they are flushed at most every 30 seconds, when sessions end, and when Termia closes. See [SECURITY.md](SECURITY.md).

--- a/docs/README.ca.md
+++ b/docs/README.ca.md
@@ -30,7 +30,7 @@ Documentació en castellà: [README.es.md](README.es.md)
 - Personalitzar el prompt local amb colors, temes predefinits i prefixos d'hora o data sense canviar fitxers d'inici ni ordres remotes.
 - Usar la interfície en castellà, català o anglès. L'idioma inicial segueix el locale del sistema quan està suportat.
 - Importar i exportar configuracions de Termia.
-- Importar connexions i grups imbricats bàsics des de YAML d'Asbru.
+- Importar connexions, grups imbricats i contrasenyes desades des de YAML d'Asbru quan estiguin disponibles.
 
 ## Notes d'ús
 
@@ -116,7 +116,7 @@ Les connexions, preferències i estadístiques es desen fora del repositori:
 ~/.local/state/termia/statistics.json
 ```
 
-Les contrasenyes desades s'emmagatzemen a `connections.json`; el fitxer es pot mantenir en text pla o ofuscat des de les preferències de Seguretat. L'ofuscació no és xifratge.
+Les contrasenyes desades s'emmagatzemen a `connections.json`; el fitxer es pot mantenir en text pla o ofuscat des de les preferències de Seguretat. L'ofuscació no és xifratge. Les contrasenyes importades des d'Ásbrú es desaran igual quan el YAML d'origen les exposi al camp `pass`.
 Els fitxers de connexions exportats també poden contenir credencials.
 Els comptadors locals agregats es desen per separat a `statistics.json`, venen desactivats per defecte i es poden activar o desactivar des de les preferències generals. Quan hi ha diversos processos de Termia oberts al mateix temps, només la instància que manté `instance.lock` escriu connexions, ajustos o estadístiques; les següents romanen en només lectura per evitar corrompre aquests fitxers.
 Les connexions recents es desen a part a `recent_connections.jsonl` perquè la barra lateral pugui mostrar una secció Recent petita i sense duplicats basada en les últimes connexions SSH correctes.

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -30,7 +30,7 @@ Documentación en catalán: [README.ca.md](README.ca.md)
 - Personalizar el prompt local con colores, temas predefinidos y prefijos de hora o fecha sin cambiar ficheros de inicio ni comandos remotos.
 - Usar la interfaz en español, catalán o inglés. El idioma inicial sigue el locale del sistema cuando está soportado.
 - Importar y exportar configuraciones de Termia.
-- Importar conexiones y grupos anidados básicos desde YAML de Asbru.
+- Importar conexiones, grupos anidados y contraseñas guardadas desde YAML de Asbru cuando estén disponibles.
 
 ## Notas de uso
 
@@ -116,7 +116,7 @@ Las conexiones, preferencias y estadísticas se guardan fuera del repositorio:
 ~/.local/state/termia/statistics.json
 ```
 
-Las contraseñas guardadas se almacenan en `connections.json`; el fichero puede mantenerse en texto plano u ofuscado desde las preferencias de Seguridad. La ofuscación no es cifrado.
+Las contraseñas guardadas se almacenan en `connections.json`; el fichero puede mantenerse en texto plano u ofuscado desde las preferencias de Seguridad. La ofuscación no es cifrado. Las contraseñas importadas desde Ásbrú se guardan igual cuando el YAML de origen las expone en el campo `pass`.
 Los ficheros de conexiones exportados también pueden contener credenciales.
 Los contadores locales agregados se guardan por separado en `statistics.json`, vienen desactivados por defecto y se pueden activar o desactivar desde las preferencias generales. Cuando hay varios procesos de Termia abiertos al mismo tiempo, solo la instancia que mantiene `instance.lock` escribe conexiones, ajustes o estadísticas; las siguientes permanecen en solo lectura para evitar corromper esos ficheros.
 Las conexiones recientes se guardan aparte en `recent_connections.jsonl` para que la barra lateral pueda mostrar una sección Recent pequeña y sin duplicados basada en las últimas conexiones SSH correctas.

--- a/src/termia/asbru_import.py
+++ b/src/termia/asbru_import.py
@@ -18,13 +18,13 @@ def normalize_asbru_name(value: str) -> str:
 
 def extract_asbru_connections(
     payload: Any,
-) -> tuple[list[tuple[str, str, str | None]], list[tuple[str, str, str, int, str | None, str]]]:
+) -> tuple[list[tuple[str, str, str | None]], list[tuple[str, str, str, int, str | None, str, str]]]:
     environments = payload.get("environments", payload) if isinstance(payload, dict) else {}
     if not isinstance(environments, dict):
         return [], []
 
     groups: list[tuple[str, str, str | None]] = []
-    servers: list[tuple[str, str, str, int, str | None, str]] = []
+    servers: list[tuple[str, str, str, int, str | None, str, str]] = []
     group_uuids = {
         str(uuid)
         for uuid, node in environments.items()
@@ -53,14 +53,16 @@ def extract_asbru_connections(
         except (TypeError, ValueError):
             port = 22
         public_key = str(node.get("public key") or "").strip()
-        servers.append((name, host, user, port, parent_uuid, public_key))
+        password_value = node.get("pass")
+        password = "" if password_value is None else str(password_value)
+        servers.append((name, host, user, port, parent_uuid, public_key, password))
     return groups, servers
 
 
 def merge_asbru_connections(
     data: StoreData,
     groups: list[tuple[str, str, str | None]],
-    servers: list[tuple[str, str, str, int, str | None, str]],
+    servers: list[tuple[str, str, str, int, str | None, str, str]],
 ) -> tuple[int, int]:
     groups_by_path: dict[tuple[str | None, str], Group] = {
         (group.parent_id, group.name): group for group in data.groups
@@ -95,24 +97,31 @@ def merge_asbru_connections(
                 added_groups += 1
             imported_ids[source_id] = group.id
 
-    existing = {(server.host, server.user, server.port, server.group_id) for server in data.servers}
+    existing = {
+        (server.host, server.user, server.port, server.group_id): server for server in data.servers
+    }
     added_servers = 0
-    for name, host, user, port, source_group_id, public_key in servers:
+    for name, host, user, port, source_group_id, public_key, password in servers:
         group_id = imported_ids.get(source_group_id)
         key = (host, user, port, group_id)
-        if key in existing:
+        existing_server = existing.get(key)
+        if existing_server is not None:
+            if public_key and not existing_server.public_key:
+                existing_server.public_key = public_key
+            if password and not existing_server.password:
+                existing_server.password = password
             continue
-        data.servers.append(
-            Server(
-                id=str(uuid4()),
-                name=normalize_asbru_name(name),
-                host=host,
-                user=user,
-                port=port,
-                group_id=group_id,
-                public_key=public_key,
-            )
+        server = Server(
+            id=str(uuid4()),
+            name=normalize_asbru_name(name),
+            host=host,
+            user=user,
+            port=port,
+            group_id=group_id,
+            public_key=public_key,
+            password=password,
         )
-        existing.add(key)
+        data.servers.append(server)
+        existing[key] = server
         added_servers += 1
     return added_groups, added_servers


### PR DESCRIPTION
Closes #71

Summary:
- Import saved passwords from Ásbrú YAML `pass` fields into Termia servers.
- Preserve existing passwords and public keys when matching servers already exist.
- Document the new behavior in the English, Spanish, and Catalan docs.

Validation:
- python3 -m py_compile src/termia/asbru_import.py src/termia/config_actions.py src/termia/models.py
- Verified with an Ásbrú YAML example that contains `pass` fields.