### PR TITLE
Bump Termia to 0.5.0-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Fix terminal function key handling.
 - Fix terminal menu separator color in split panes.
 - Rename the Spanish language label.
-- Add gettext-backed translations and bump the project version to `0.4.0-alpha`.
+- Add gettext-backed translations and bump the project version to `0.5.0-beta`.
 
 ### Added
 

--- a/src/termia/__init__.py
+++ b/src/termia/__init__.py
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 """Termia SSH connection manager."""
 
-__version__ = "0.4.0-alpha"
+__version__ = "0.5.0-beta"


### PR DESCRIPTION
## Summary
- Bump the project version from 0.4.0-alpha to 0.5.0-beta.
- Update the unreleased changelog entry to reference the beta version.

## Validation
- python3 -m py_compile src/termia/__init__.py
- git diff --check

Closes #81