### PR TITLE
Fix split separator color corruption

### DIFF
--- a/src/termia/preferences.py
+++ b/src/termia/preferences.py
@@ -906,12 +906,12 @@ class PreferencesMixin:
         if response == Gtk.ResponseType.OK:
             try:
                 self.store.update_terminal_settings(
-                    self.selected_terminal_font_family(font_combo),
-                    int(font_size_spin.get_value()),
-                    foreground_button.get_rgba().to_string(),
-                    background_button.get_rgba().to_string(),
-                    split_separator_color_button.get_rgba().to_string(),
-                    int(split_separator_thickness_spin.get_value()),
+                    font_family=self.selected_terminal_font_family(font_combo),
+                    font_size=int(font_size_spin.get_value()),
+                    foreground=foreground_button.get_rgba().to_string(),
+                    background=background_button.get_rgba().to_string(),
+                    split_separator_color=split_separator_color_button.get_rgba().to_string(),
+                    split_separator_thickness=int(split_separator_thickness_spin.get_value()),
                 )
             except ReadOnlyStoreError:
                 self.toast_label.set_label(self.t("read_only_mode_enabled"))

--- a/src/termia/stores.py
+++ b/src/termia/stores.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import fcntl
 import json
 import os
+import re
 import time
 from dataclasses import asdict
 from datetime import datetime
@@ -384,8 +385,20 @@ def normalize_terminal_settings(terminal: TerminalSettings) -> TerminalSettings:
             MAX_SPLIT_SEPARATOR_THICKNESS,
         ),
     )
-    terminal.split_separator_color = terminal.split_separator_color.strip() or DEFAULT_SPLIT_SEPARATOR_COLOR
+    terminal.split_separator_color = normalize_css_color(
+        terminal.split_separator_color,
+        DEFAULT_SPLIT_SEPARATOR_COLOR,
+    )
     return terminal
+
+
+def normalize_css_color(value: str, default: str) -> str:
+    color = value.strip()
+    if re.fullmatch(r"#[0-9a-fA-F]{3,8}", color):
+        return color
+    if re.fullmatch(r"rgba?\([0-9., %]+\)", color):
+        return color
+    return default
 
 
 class ConnectionStore:

--- a/src/termia/terminal_sessions.py
+++ b/src/termia/terminal_sessions.py
@@ -550,11 +550,11 @@ class TerminalSessionsMixin:
         if new_size == settings.font_size:
             return
         self.store.update_terminal_settings(
-            settings.font_family,
-            new_size,
-            settings.foreground,
-            settings.background,
-            settings.ls_colors,
+            font_family=settings.font_family,
+            font_size=new_size,
+            foreground=settings.foreground,
+            background=settings.background,
+            ls_colors=settings.ls_colors,
         )
         self.apply_terminal_settings_to_open_tabs()
         self.toast_label.set_label(self.t("terminal_font_size_changed").format(size=new_size))


### PR DESCRIPTION
## Summary
- Use keyword arguments when updating terminal settings so LS_COLORS cannot be passed as split separator color.
- Normalize invalid split separator colors back to the default color when loading settings.

## Protected behavior impact
- Touches terminal appearance settings and split separator styling.
- Preserves existing valid hex/rgb/rgba separator colors and repairs invalid stored values.

## Validation
- python3 -m py_compile src/termia/terminal_sessions.py src/termia/preferences.py src/termia/stores.py
- split separator color normalization smoke test
- git diff --check

Closes #85