### PR TITLE
test: establish automated test baseline

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,46 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  unittest:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install GTK/VTE and Python dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -y \
+            python3 \
+            python3-gi \
+            python3-cryptography \
+            python3-yaml \
+            gir1.2-gtk-4.0 \
+            gir1.2-vte-3.91
+
+      - name: Run unit and GTK smoke tests
+        run: PYTHONPATH=src python3 -m unittest discover -s tests -v
+
+      - name: Validate translation catalogs
+        run: scripts/compile_translations.py --check
+
+      - name: Compile Python sources
+        run: |
+          python3 -m py_compile \
+            run_termia.py \
+            scripts/compile_translations.py \
+            src/termia/*.py \
+            tests/*.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,7 @@ python3 run_termia.py
 At minimum, run syntax checks for touched Python and shell files. For a broad validation pass, run:
 
 ```bash
+PYTHONPATH=src python3 -m unittest discover -s tests -v
 python3 -m py_compile run_termia.py scripts/compile_translations.py src/termia/app.py src/termia/asbru_import.py src/termia/config_actions.py src/termia/config_io.py src/termia/connection_dialogs.py src/termia/connection_utils.py src/termia/constants.py src/termia/i18n.py src/termia/keybindings.py src/termia/main_menu.py src/termia/models.py src/termia/preferences.py src/termia/sidebar.py src/termia/statistics_utils.py src/termia/statistics_view.py src/termia/stores.py src/termia/styles.py src/termia/tabs.py src/termia/terminal_sessions.py src/termia/terminal_config.py src/termia/ui_state.py
 bash -n scripts/termia-setup.sh
 scripts/compile_translations.py --check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,9 @@ For UI, keyboard shortcut, SSH, settings, import/export, or terminal color chang
 
 If a check cannot be run, mention that in the pull request with the reason.
 
+GitHub Actions runs the unittest suite, translation validation, and Python
+syntax checks automatically for every pull request and every push to `main`.
+
 ## Pull Requests
 
 A good pull request includes:

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Use `scripts/compile_translations.py --check` to verify that `MESSAGES`, the
 POT template, both PO catalogs, and the compiled MO files are synchronized.
 
 ```bash
+PYTHONPATH=src python3 -m unittest discover -s tests -v
 python3 -m py_compile run_termia.py scripts/compile_translations.py src/termia/app.py src/termia/asbru_import.py src/termia/config_actions.py src/termia/config_io.py src/termia/connection_dialogs.py src/termia/connection_utils.py src/termia/constants.py src/termia/i18n.py src/termia/keybindings.py src/termia/main_menu.py src/termia/models.py src/termia/preferences.py src/termia/sidebar.py src/termia/statistics_utils.py src/termia/statistics_view.py src/termia/stores.py src/termia/styles.py src/termia/tabs.py src/termia/terminal_sessions.py src/termia/terminal_config.py src/termia/ui_state.py
 bash -n scripts/termia-setup.sh
 ```

--- a/README.md
+++ b/README.md
@@ -180,6 +180,10 @@ python3 -m py_compile run_termia.py scripts/compile_translations.py src/termia/a
 bash -n scripts/termia-setup.sh
 ```
 
+The same unit tests, translation checks, and Python syntax checks run
+automatically in GitHub Actions for every pull request and every push to
+`main`.
+
 Review the files included in the first commit:
 
 ```bash

--- a/docs/REGRESSION_CHECKS.md
+++ b/docs/REGRESSION_CHECKS.md
@@ -157,6 +157,7 @@ Before merging changes that touch UI, terminals, tabs, or configuration, verify:
 Run at minimum:
 
 ```bash
+PYTHONPATH=src python3 -m unittest discover -s tests -v
 python3 -m py_compile run_termia.py scripts/compile_translations.py src/termia/app.py src/termia/asbru_import.py src/termia/config_actions.py src/termia/config_io.py src/termia/connection_dialogs.py src/termia/connection_utils.py src/termia/constants.py src/termia/i18n.py src/termia/keybindings.py src/termia/main_menu.py src/termia/models.py src/termia/preferences.py src/termia/sidebar.py src/termia/statistics_utils.py src/termia/statistics_view.py src/termia/stores.py src/termia/styles.py src/termia/tabs.py src/termia/terminal_sessions.py src/termia/terminal_config.py src/termia/ui_state.py
 bash -n scripts/termia-setup.sh
 scripts/compile_translations.py

--- a/docs/REGRESSION_CHECKS.md
+++ b/docs/REGRESSION_CHECKS.md
@@ -165,3 +165,6 @@ scripts/compile_translations.py --check
 ```
 
 When practical, add targeted tests for pure logic such as prompt templates, config migration, import/export, and statistics.
+
+The automated equivalent runs in GitHub Actions for every pull request and
+every push to `main`.

--- a/tests/test_asbru_import.py
+++ b/tests/test_asbru_import.py
@@ -1,0 +1,37 @@
+import unittest
+
+from termia.asbru_import import extract_asbru_connections, merge_asbru_connections, normalize_asbru_name
+from termia.models import StoreData
+
+
+class AsbruImportTests(unittest.TestCase):
+    def test_normalizes_copy_suffix(self) -> None:
+        self.assertEqual(normalize_asbru_name(" Server - copy - COPY "), "Server")
+
+    def test_extracts_ssh_nodes_and_skips_other_protocols(self) -> None:
+        groups, servers = extract_asbru_connections(
+            {
+                "environments": {
+                    "prod": {"_is_group": True, "name": "Production"},
+                    "web": {"name": "Web", "host": "admin@example.test", "port": "2200", "parent": "prod"},
+                    "ftp": {"name": "Files", "host": "files.test", "method": "ftp"},
+                }
+            }
+        )
+
+        self.assertEqual(groups, [("prod", "Production", None)])
+        self.assertEqual(servers, [("Web", "example.test", "admin", 2200, "prod", "", "")])
+
+    def test_merge_deduplicates_and_preserves_credentials(self) -> None:
+        data = StoreData()
+        groups, servers = extract_asbru_connections(
+            {"group": {"_is_group": True, "name": "Group"}, "server": {"name": "Web", "ip": "host", "parent": "group"}}
+        )
+
+        added_groups, added_servers = merge_asbru_connections(data, groups, servers)
+        again = merge_asbru_connections(data, groups, [("Web", "host", "", 22, "group", "key", "secret")])
+
+        self.assertEqual((added_groups, added_servers), (1, 1))
+        self.assertEqual(again, (0, 0))
+        self.assertEqual(data.servers[0].public_key, "key")
+        self.assertEqual(data.servers[0].password, "secret")

--- a/tests/test_config_io.py
+++ b/tests/test_config_io.py
@@ -1,0 +1,69 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from termia.config_io import (
+    CONNECTION_STORAGE_ENCRYPTED,
+    CONNECTION_STORAGE_OBFUSCATED,
+    InvalidMasterPasswordError,
+    MissingMasterPasswordError,
+    read_connections_payload,
+    write_connections_file,
+)
+from termia.models import Group, LocalTerminalProfile, Server
+
+
+class ConfigIOTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.groups = [Group(id="group-1", name="Production")]
+        self.servers = [Server(id="server-1", name="web", host="example.test", user="admin")]
+        self.terminals = [LocalTerminalProfile(id="local-1", name="Shell")]
+
+    def test_plain_round_trip(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "connections.json"
+            write_connections_file(path, self.groups, self.servers, self.terminals, "plain")
+
+            payload = read_connections_payload(path)
+
+        self.assertEqual(payload["groups"][0]["name"], "Production")
+        self.assertEqual(payload["servers"][0]["host"], "example.test")
+        self.assertEqual(payload["local_terminals"][0]["name"], "Shell")
+
+    def test_obfuscated_round_trip(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "connections.json"
+            write_connections_file(path, self.groups, self.servers, self.terminals, CONNECTION_STORAGE_OBFUSCATED)
+
+            payload = read_connections_payload(path)
+
+        self.assertEqual(payload["servers"][0]["id"], "server-1")
+
+    def test_encrypted_round_trip_and_password_errors(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "connections.json"
+            write_connections_file(
+                path,
+                self.groups,
+                self.servers,
+                self.terminals,
+                CONNECTION_STORAGE_ENCRYPTED,
+                "correct horse",
+            )
+
+            with self.assertRaises(MissingMasterPasswordError):
+                read_connections_payload(path)
+            with self.assertRaises(InvalidMasterPasswordError):
+                read_connections_payload(path, "wrong horse")
+            payload = read_connections_payload(path, "correct horse")
+
+        self.assertEqual(payload["servers"][0]["user"], "admin")
+
+    def test_invalid_json_is_reported(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "connections.json"
+            path.write_text(json.dumps(["not", "an", "object"]), encoding="utf-8")
+
+            with self.assertRaises(ValueError):
+                read_connections_payload(path)

--- a/tests/test_gtk_smoke.py
+++ b/tests/test_gtk_smoke.py
@@ -1,0 +1,14 @@
+import importlib.util
+import unittest
+
+
+class GtkSmokeTests(unittest.TestCase):
+    @unittest.skipUnless(importlib.util.find_spec("gi"), "GTK bindings are unavailable")
+    def test_gtk_application_can_be_constructed(self) -> None:
+        import gi
+
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import Gtk
+
+        application = Gtk.Application(application_id="local.termia.test")
+        self.assertEqual(application.get_application_id(), "local.termia.test")

--- a/tests/test_keybindings.py
+++ b/tests/test_keybindings.py
@@ -1,0 +1,27 @@
+import unittest
+
+from termia.keybindings import (
+    DEFAULT_KEYBINDINGS,
+    keybinding_label,
+    normalize_keybinding,
+    normalize_keybindings,
+)
+
+
+class KeybindingTests(unittest.TestCase):
+    def test_normalizes_gtk_style_accelerators(self) -> None:
+        self.assertEqual(normalize_keybinding("<Shift><Control>c"), "Ctrl+Shift+C")
+        self.assertEqual(normalize_keybinding("control+page_up"), "Ctrl+PageUp")
+        self.assertEqual(normalize_keybinding("<Alt><Super>F10"), "Alt+Super+F10")
+
+    def test_normalizes_plus_and_empty_values(self) -> None:
+        self.assertEqual(normalize_keybinding("Ctrl++"), "Ctrl++")
+        self.assertEqual(normalize_keybinding("  "), "")
+        self.assertEqual(keybinding_label("", "Disabled"), "Disabled")
+
+    def test_missing_actions_keep_defaults(self) -> None:
+        normalized = normalize_keybindings({"copy": "<Control><Shift>c"})
+
+        self.assertEqual(normalized["copy"], "Ctrl+Shift+C")
+        self.assertEqual(normalized["paste"], DEFAULT_KEYBINDINGS["paste"])
+        self.assertEqual(set(normalized), set(DEFAULT_KEYBINDINGS))

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,0 +1,79 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from termia.constants import DEFAULT_TERMINAL_BACKGROUND, DEFAULT_TERMINAL_FOREGROUND
+from termia.stores import ConnectionStore, SettingsStore
+
+
+class MigrationTests(unittest.TestCase):
+    def test_settings_migrate_legacy_terminal_palette_and_colors(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "settings.json"
+            path.write_text(
+                json.dumps(
+                    {
+                        "app": {"keybindings": {"copy": "<Control><Shift>c"}},
+                        "terminal": {
+                            "font_family": "Ubuntu Mono",
+                            "font_size": 13,
+                            "foreground": "#839496",
+                            "background": "#002b36",
+                            "split_separator_thickness": 999,
+                            "split_separator_color": "not-a-color",
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            store = SettingsStore(path)
+
+        self.assertEqual(store.app.keybindings["copy"], "Ctrl+Shift+C")
+        self.assertEqual(store.terminal.foreground, DEFAULT_TERMINAL_FOREGROUND)
+        self.assertEqual(store.terminal.background, DEFAULT_TERMINAL_BACKGROUND)
+        self.assertEqual(store.terminal.split_separator_thickness, 32)
+        self.assertEqual(store.terminal.split_separator_color, "#008712")
+
+    def test_connection_store_migrates_embedded_settings(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            connections_path = root / "connections.json"
+            settings_path = root / "settings.json"
+            statistics_path = root / "statistics.json"
+            lock_path = root / "instance.lock"
+            connections_path.write_text(
+                json.dumps(
+                    {
+                        "groups": [{"id": "g", "name": "Legacy"}],
+                        "servers": [],
+                        "local_terminals": [],
+                        "app": {"theme": "light"},
+                        "terminal": {"font_size": 18},
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with patch("termia.stores.HISTORY_FILE", root / "history.jsonl"):
+                store = ConnectionStore(connections_path, settings_path, statistics_path, lock_path)
+                try:
+                    self.assertEqual(store.data.app.theme, "light")
+                    self.assertEqual(store.data.terminal.font_size, 18)
+                    self.assertTrue(settings_path.exists())
+                finally:
+                    store.close()
+
+    def test_invalid_settings_are_backed_up_with_recovery_message(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "settings.json"
+            path.write_text("not json", encoding="utf-8")
+
+            store = SettingsStore(path)
+
+            backups = list(path.parent.glob("settings.json.invalid-*"))
+
+        self.assertEqual(len(store.recovery_messages), 1)
+        self.assertEqual(len(backups), 1)

--- a/tests/test_statistics_utils.py
+++ b/tests/test_statistics_utils.py
@@ -1,0 +1,25 @@
+import unittest
+
+from termia.models import Server, StatisticsSettings
+from termia.statistics_utils import average_session_duration, format_duration, top_server_statistics
+
+
+class StatisticsUtilsTests(unittest.TestCase):
+    def test_average_duration(self) -> None:
+        self.assertIsNone(average_session_duration(StatisticsSettings()))
+        self.assertEqual(average_session_duration(StatisticsSettings(completed_sessions=2, duration_total=9)), 4.5)
+
+    def test_format_duration_clamps_negative_values(self) -> None:
+        self.assertEqual(format_duration(None), "--:--:--")
+        self.assertEqual(format_duration(-1), "00:00:00")
+        self.assertEqual(format_duration(3661.9), "01:01:01")
+
+    def test_top_servers_include_fallback_for_deleted_servers(self) -> None:
+        stats = StatisticsSettings(server_connections={"missing": 5, "known": 3})
+        servers = [Server(id="known", name="Web", host="example.test", user="admin", port=2200)]
+
+        rows = top_server_statistics(stats, servers)
+
+        self.assertEqual(rows[0].name, "missing")
+        self.assertEqual(rows[0].subtitle, "")
+        self.assertEqual(rows[1].subtitle, "admin@example.test:2200")

--- a/tests/test_terminal_config.py
+++ b/tests/test_terminal_config.py
@@ -1,0 +1,41 @@
+import unittest
+
+from termia.models import TerminalSettings
+from termia.terminal_config import (
+    build_bash_rcfile_shell_command,
+    build_local_prompt_shell_command,
+    normalize_split_layout,
+    normalized_prompt_template,
+    prompt_template_with_datetime,
+    render_prompt_preview,
+    split_layout_plan,
+    split_prompt_datetime_template,
+)
+
+
+class TerminalConfigTests(unittest.TestCase):
+    def test_prompt_template_defaults_and_preview(self) -> None:
+        self.assertEqual(normalized_prompt_template(""), r"\u@\h:\w\$ ")
+        self.assertEqual(normalized_prompt_template(r"\w \$ "), r"\u@\h:\w\$ ")
+        self.assertIn("usuario@servidor", render_prompt_preview(r"\u@\h:\w\$ "))
+
+    def test_prompt_datetime_round_trip(self) -> None:
+        template = prompt_template_with_datetime(r"\u@\h:\w\$ ", "both")
+
+        self.assertEqual(split_prompt_datetime_template(template), ("both", r"\u@\h:\w\$ "))
+        self.assertEqual(split_prompt_datetime_template("custom"), ("none", "custom"))
+
+    def test_split_layouts_have_expected_plans(self) -> None:
+        self.assertEqual(normalize_split_layout("unknown"), "none")
+        self.assertEqual(len(split_layout_plan("grid")), 3)
+        self.assertEqual(split_layout_plan("none"), [])
+
+    def test_shell_commands_quote_arguments(self) -> None:
+        command = build_bash_rcfile_shell_command("/bin/my bash", ["--name", "a value"], ["echo 'ready'"])
+        local_command = build_local_prompt_shell_command(TerminalSettings(), "/bin/bash", ["--login"])
+
+        self.assertEqual(command[:2], ["/bin/my bash", "-lc"])
+        self.assertIn("'/bin/my bash'", command[2])
+        self.assertIn("'a value'", command[2])
+        self.assertEqual(local_command[:2], ["/bin/bash", "-lc"])
+        self.assertIn("TERMIA_PS1=", local_command[2])


### PR DESCRIPTION
## Summary
- add 21 standard-library unittest cases for config I/O, keybindings, terminal configuration, Ásbrú import, statistics, and migrations
- keep the GTK application smoke test in a separate test module
- document the test command alongside the existing validation checks

## Validation
- `PYTHONPATH=src python3 -m unittest discover -s tests -v`
- `python3 -m py_compile tests/*.py` and touched modules
- `scripts/compile_translations.py --check`
- `git diff --check`

Closes #103