### PR TITLE
refactor: simplify sidebar row state

### DIFF
--- a/src/termia/stores.py
+++ b/src/termia/stores.py
@@ -597,11 +597,6 @@ class ConnectionStore:
         self.statistics_store.data = self.data.statistics
         self.statistics_store.save()
 
-    def save_history(self) -> None:
-        if self.read_only:
-            return
-        self.history_store.rebuild_entries()
-
     def clear_history(self) -> None:
         self.ensure_writable()
         self.history_store.clear()

--- a/src/termia/ui_state.py
+++ b/src/termia/ui_state.py
@@ -8,16 +8,15 @@ import gi
 
 gi.require_version("Gtk", "4.0")
 gi.require_version("Vte", "3.91")
-from gi.repository import GObject, Gtk, Vte
+from gi.repository import Gtk, Vte
 
 
-class RowObject(GObject.Object):
-    def __init__(self, kind: str, item_id: str, title: str, subtitle: str = "") -> None:
-        super().__init__()
-        self.kind = kind
-        self.item_id = item_id
-        self.title = title
-        self.subtitle = subtitle
+@dataclass
+class RowObject:
+    kind: str
+    item_id: str
+    title: str
+    subtitle: str = ""
 
 
 @dataclass

--- a/tests/test_ui_state.py
+++ b/tests/test_ui_state.py
@@ -1,0 +1,18 @@
+import unittest
+from dataclasses import is_dataclass
+
+from gi.repository import GObject
+from termia.ui_state import RowObject
+
+
+class RowObjectTests(unittest.TestCase):
+    def test_row_object_is_plain_value_state(self) -> None:
+        row = RowObject("server", "server-1", "Web", "admin@example.test:22")
+
+        self.assertEqual(row.kind, "server")
+        self.assertEqual(row.item_id, "server-1")
+        self.assertEqual(row.title, "Web")
+        self.assertEqual(row.subtitle, "admin@example.test:22")
+        self.assertEqual(row, RowObject("server", "server-1", "Web", "admin@example.test:22"))
+        self.assertTrue(is_dataclass(row))
+        self.assertFalse(isinstance(row, GObject.Object))


### PR DESCRIPTION
## Summary
- remove the unused `ConnectionStore.save_history()` method
- replace the sidebar `RowObject` GObject wrapper with a plain dataclass
- add focused coverage for the row state contract

## Validation
- `PYTHONPATH=src python3 -m unittest discover -s tests -v` (22 tests)
- Python syntax checks for touched files
- `scripts/compile_translations.py --check`
- `git diff --check`

Manual GTK/sidebar regression areas reviewed: selection, keyboard navigation, context menus, and row rendering.

Closes #105