### PR TITLE
test: make history persistence injectable

### DIFF
--- a/src/termia/stores.py
+++ b/src/termia/stores.py
@@ -411,16 +411,18 @@ class ConnectionStore:
         settings_path: Path = SETTINGS_FILE,
         statistics_path: Path = STATISTICS_FILE,
         lock_path: Path = INSTANCE_LOCK_FILE,
+        history_path: Path = HISTORY_FILE,
     ) -> None:
         self.path = path
         self.instance_lock = InstanceWriteLock(lock_path)
         self.read_only = self.instance_lock.read_only
         self.settings_store = SettingsStore(settings_path, read_only=self.read_only)
         self.statistics_store = StatisticsStore(statistics_path, read_only=self.read_only)
-        self.history_store = ConnectionHistoryStore(HISTORY_FILE, read_only=self.read_only)
+        self.history_store = ConnectionHistoryStore(history_path, read_only=self.read_only)
         self.recovery_messages: list[str] = [
             *self.settings_store.recovery_messages,
             *self.statistics_store.recovery_messages,
+            *self.history_store.recovery_messages,
         ]
         self.encryption_locked = False
         self.encryption_error = ""

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,0 +1,95 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from termia.models import ConnectionHistoryEvent
+from termia.stores import ConnectionHistoryStore, ConnectionStore
+
+
+class HistoryPersistenceTests(unittest.TestCase):
+    def test_missing_and_empty_history_are_valid_empty_states(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            missing = ConnectionHistoryStore(root / "missing.jsonl")
+            empty_path = root / "empty.jsonl"
+            empty_path.touch()
+            empty = ConnectionHistoryStore(empty_path)
+
+        for store in (missing, empty):
+            self.assertEqual(store.events, [])
+            self.assertEqual(store.entries, [])
+            self.assertEqual(store.recovery_messages, [])
+
+    def test_unreadable_history_reports_recovery_path(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "history.jsonl"
+            path.mkdir()
+
+            store = ConnectionHistoryStore(path)
+
+        self.assertEqual(store.events, [])
+        self.assertEqual(store.recovery_messages, [str(path)])
+
+    def test_malformed_lines_are_ignored(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "history.jsonl"
+            path.write_text("not json\n[]\n{\"session_id\": \"valid\", \"event\": \"started\"}\n", encoding="utf-8")
+
+            store = ConnectionHistoryStore(path)
+
+        self.assertEqual([event.session_id for event in store.events], ["valid"])
+        self.assertEqual(store.recovery_messages, [])
+
+    def test_partially_valid_history_rebuilds_entries(self) -> None:
+        event = ConnectionHistoryEvent(
+            session_id="session-1",
+            event="ended",
+            timestamp="2026-07-22T10:00:00+02:00",
+            title="Web",
+            server_id="server-1",
+            server_name="Web",
+            host="example.test",
+            user="admin",
+            port=22,
+            result="success",
+            duration_seconds=3.5,
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "history.jsonl"
+            path.write_text(
+                "\n".join(
+                    [
+                        json.dumps({"session_id": "session-1", "event": "started", "timestamp": "2026-07-22T09:59:56+02:00"}),
+                        "invalid line",
+                        json.dumps(event.__dict__),
+                    ]
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            store = ConnectionHistoryStore(path)
+
+        self.assertEqual(len(store.events), 2)
+        self.assertEqual(len(store.entries), 1)
+        self.assertEqual(store.entries[0].result, "success")
+        self.assertEqual(store.entries[0].duration_seconds, 3.5)
+
+    def test_connection_store_uses_injected_history_and_aggregates_recovery(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            history_path = root / "history.jsonl"
+            history_path.mkdir()
+            store = ConnectionStore(
+                root / "connections.json",
+                settings_path=root / "settings.json",
+                statistics_path=root / "statistics.json",
+                lock_path=root / "instance.lock",
+                history_path=history_path,
+            )
+            try:
+                self.assertIs(store.history_store.path, history_path)
+                self.assertIn(str(history_path), store.recovery_messages)
+            finally:
+                store.close()


### PR DESCRIPTION
## Summary
- inject the connection history path into `ConnectionStore`
- aggregate history recovery messages with settings and statistics recovery messages
- add isolated tests for missing, empty, unreadable, malformed, and partially valid history files

## Validation
- `PYTHONPATH=src python3 -m unittest discover -s tests -v` (27 tests)
- Python syntax checks for touched files
- `scripts/compile_translations.py --check`
- `git diff --check`

Closes #107