### PR TITLE
refactor: centralize terminal commands and spawning

### DIFF
--- a/src/termia/session_commands.py
+++ b/src/termia/session_commands.py
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2026 Jordi Pons
+# SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import annotations
+
+from pathlib import Path
+
+from .models import Server
+
+
+def build_ssh_command(server: Server, ssh_path: str, *, sshpass_path: str | None = None) -> list[str]:
+    command = [ssh_path, "-p", str(server.port)]
+    if server.public_key:
+        command.extend(["-i", str(Path(server.public_key).expanduser())])
+    command.append(f"{server.user}@{server.host}")
+    if sshpass_path is not None:
+        command = [sshpass_path, "-e", *command]
+    return command

--- a/src/termia/terminal_processes.py
+++ b/src/termia/terminal_processes.py
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: 2026 Jordi Pons
+# Copyright (C) 2026 Jordi Pons
+# This file is distributed under the terms of the GNU General Public License.
+from __future__ import annotations
+
+import gi
+
+gi.require_version("Vte", "3.91")
+from gi.repository import GLib, Vte
+
+
+def spawn_terminal_process(
+    terminal: Vte.Terminal,
+    working_directory: str | None,
+    command: list[str],
+    environment: list[str],
+) -> int:
+    _ok, child_pid = terminal.spawn_sync(
+        Vte.PtyFlags.DEFAULT,
+        working_directory,
+        command,
+        environment,
+        GLib.SpawnFlags.DEFAULT,
+        None,
+        None,
+        None,
+    )
+    return child_pid

--- a/src/termia/terminal_sessions.py
+++ b/src/termia/terminal_sessions.py
@@ -26,12 +26,14 @@ from .connection_utils import find_local_terminal_profile, find_server
 from .file_transfer import FileTransferController
 from .keybindings import is_unmodified_function_key, keybinding_matches
 from .models import DEFAULT_ANSI_PALETTE, LocalTerminalProfile, Server
+from .session_commands import build_ssh_command
 from .terminal_config import (
     build_local_prompt_shell_command,
     build_terminal_environment,
     parse_color,
     split_layout_plan,
 )
+from .terminal_processes import spawn_terminal_process
 from .ui_state import TerminalSession
 
 
@@ -208,9 +210,11 @@ class TerminalSessionsMixin:
         terminal.grab_focus()
         self.store.record_history_start(session, "local")
         try:
-            _ok, child_pid = terminal.spawn_sync(
-                Vte.PtyFlags.DEFAULT, working_directory, command, envv or build_terminal_environment(self.store.data.terminal.ls_colors),
-                GLib.SpawnFlags.DEFAULT, None, None, None,
+            child_pid = spawn_terminal_process(
+                terminal,
+                working_directory,
+                command,
+                envv or build_terminal_environment(self.store.data.terminal.ls_colors),
             )
         except GLib.Error as exc:
             message = self.t("local_terminal_start_failed").format(error=exc.message)
@@ -292,11 +296,6 @@ class TerminalSessionsMixin:
             self.mark_session_for_reconnect(session, server, message)
             return
 
-        ssh_target = f"{server.user}@{server.host}"
-        command = [ssh_path, "-p", str(server.port)]
-        if server.public_key:
-            command.extend(["-i", str(Path(server.public_key).expanduser())])
-        command.append(ssh_target)
         envv = build_terminal_environment(self.store.data.terminal.ls_colors, server.password)
         use_sshpass = bool(server.password)
         if server.password and not self.has_known_host_key(server.host, server.port):
@@ -313,20 +312,13 @@ class TerminalSessionsMixin:
                 self.store.record_history_end(session, "failed", detail=message)
                 self.mark_session_for_reconnect(session, server, message)
                 return
-            command = [sshpass_path, "-e", *command]
+            command = build_ssh_command(server, ssh_path, sshpass_path=sshpass_path)
+        else:
+            command = build_ssh_command(server, ssh_path)
         terminal.feed(f"{self.t('ssh_connecting_command').format(command=' '.join(command))}\r\n\r\n".encode())
         terminal.grab_focus()
         try:
-            _ok, child_pid = terminal.spawn_sync(
-                Vte.PtyFlags.DEFAULT,
-                None,
-                command,
-                envv,
-                GLib.SpawnFlags.DEFAULT,
-                None,
-                None,
-                None,
-            )
+            child_pid = spawn_terminal_process(terminal, None, command, envv)
         except GLib.Error as exc:
             message = self.t("ssh_start_failed").format(error=exc.message)
             terminal.feed(f"{message}\r\n".encode())
@@ -722,15 +714,11 @@ class TerminalSessionsMixin:
                 command = build_local_prompt_shell_command(self.store.data.terminal, bash_path)
         working_directory = self.local_terminal_working_directory(source_terminal, fallback_working_directory)
         try:
-            _ok, child_pid = terminal.spawn_sync(
-                Vte.PtyFlags.DEFAULT,
+            child_pid = spawn_terminal_process(
+                terminal,
                 working_directory,
                 command,
                 build_terminal_environment(self.store.data.terminal.ls_colors),
-                GLib.SpawnFlags.DEFAULT,
-                None,
-                None,
-                None,
             )
         except GLib.Error as exc:
             message = self.t("local_terminal_start_failed").format(error=exc.message)
@@ -755,11 +743,6 @@ class TerminalSessionsMixin:
             self.toast_label.set_label(message)
             return
 
-        ssh_target = f"{server.user}@{server.host}"
-        command = [ssh_path, "-p", str(server.port)]
-        if server.public_key:
-            command.extend(["-i", str(Path(server.public_key).expanduser())])
-        command.append(ssh_target)
         envv = build_terminal_environment(self.store.data.terminal.ls_colors, server.password)
         use_sshpass = bool(server.password)
         if server.password and not self.has_known_host_key(server.host, server.port):
@@ -774,19 +757,12 @@ class TerminalSessionsMixin:
                 terminal.feed(f"{message}\r\n".encode())
                 self.toast_label.set_label(message)
                 return
-            command = [sshpass_path, "-e", *command]
+            command = build_ssh_command(server, ssh_path, sshpass_path=sshpass_path)
+        else:
+            command = build_ssh_command(server, ssh_path)
         terminal.feed(f"{self.t('ssh_connecting_command').format(command=' '.join(command))}\r\n\r\n".encode())
         try:
-            _ok, child_pid = terminal.spawn_sync(
-                Vte.PtyFlags.DEFAULT,
-                None,
-                command,
-                envv,
-                GLib.SpawnFlags.DEFAULT,
-                None,
-                None,
-                None,
-            )
+            child_pid = spawn_terminal_process(terminal, None, command, envv)
         except GLib.Error as exc:
             message = self.t("ssh_start_failed").format(error=exc.message)
             terminal.feed(f"{message}\r\n".encode())

--- a/tests/test_session_commands.py
+++ b/tests/test_session_commands.py
@@ -1,0 +1,38 @@
+import unittest
+from pathlib import Path
+
+from termia.models import Server
+from termia.session_commands import build_ssh_command
+
+
+class SessionCommandTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.server = Server(
+            id="server-1",
+            name="Web",
+            host="example.test",
+            user="admin",
+            port=2200,
+            public_key="~/.ssh/id_ed25519",
+        )
+
+    def test_builds_ssh_command_with_identity_file(self) -> None:
+        command = build_ssh_command(self.server, "/usr/bin/ssh")
+
+        self.assertEqual(
+            command,
+            [
+                "/usr/bin/ssh",
+                "-p",
+                "2200",
+                "-i",
+                str(Path("~/.ssh/id_ed25519").expanduser()),
+                "admin@example.test",
+            ],
+        )
+
+    def test_wraps_ssh_command_with_sshpass_as_argv(self) -> None:
+        command = build_ssh_command(self.server, "/usr/bin/ssh", sshpass_path="/usr/bin/sshpass")
+
+        self.assertEqual(command[:2], ["/usr/bin/sshpass", "-e"])
+        self.assertEqual(command[-1], "admin@example.test")

--- a/tests/test_terminal_processes.py
+++ b/tests/test_terminal_processes.py
@@ -1,0 +1,21 @@
+import unittest
+
+from termia.terminal_processes import spawn_terminal_process
+
+
+class FakeTerminal:
+    def spawn_sync(self, *args: object) -> tuple[bool, int]:
+        self.args = args
+        return True, 4242
+
+
+class TerminalProcessTests(unittest.TestCase):
+    def test_spawn_helper_centralizes_vte_arguments(self) -> None:
+        terminal = FakeTerminal()
+        environment = ["TERM=xterm-256color"]
+
+        child_pid = spawn_terminal_process(terminal, "/tmp", ["/bin/bash", "-l"], environment)
+
+        self.assertEqual(child_pid, 4242)
+        self.assertEqual(terminal.args[1:5], ("/tmp", ["/bin/bash", "-l"], environment, 0))
+        self.assertEqual(terminal.args[5:], (None, None, None))


### PR DESCRIPTION
## Summary
- centralize SSH command construction for normal and split sessions
- centralize the common VTE process-launch invocation
- add focused tests for SSH argv construction, sshpass wrapping, and VTE spawn arguments

## Validation
- `PYTHONPATH=src python3 -m unittest discover -s tests -v` (32 tests)
- Python syntax checks for touched files
- `scripts/compile_translations.py --check`
- `git diff --check`

Closes #111