### PR TITLE
refactor: extract split panes and terminal views

### DIFF
--- a/src/termia/split_panes.py
+++ b/src/termia/split_panes.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: 2026 Jordi Pons
+# SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import gi
+
+gi.require_version("Gtk", "4.0")
+gi.require_version("Vte", "3.91")
+from gi.repository import GLib, Gtk, Vte
+
+from .ui_state import TerminalSession
+
+
+class SplitPaneController:
+    def __init__(
+        self,
+        create_terminal: Callable[[TerminalSession], Vte.Terminal],
+        wrap_terminal: Callable[[Vte.Terminal], Gtk.ScrolledWindow],
+        replace_terminal: Callable[[Gtk.Widget, Gtk.Widget], bool],
+    ) -> None:
+        self.create_terminal = create_terminal
+        self.wrap_terminal = wrap_terminal
+        self.replace_terminal = replace_terminal
+
+    def split_terminal(
+        self,
+        session: TerminalSession,
+        terminal: Vte.Terminal,
+        direction: str,
+    ) -> Vte.Terminal | None:
+        target = terminal.get_parent()
+        if not isinstance(target, Gtk.Widget):
+            return None
+
+        new_terminal = self.create_terminal(session)
+        new_scroller = self.wrap_terminal(new_terminal)
+        orientation = Gtk.Orientation.HORIZONTAL if direction in {"left", "right"} else Gtk.Orientation.VERTICAL
+        paned = Gtk.Paned(orientation=orientation)
+        paned.add_css_class("termia-split-pane")
+        paned.set_wide_handle(False)
+        paned.set_hexpand(True)
+        paned.set_vexpand(True)
+        paned.set_resize_start_child(True)
+        paned.set_resize_end_child(True)
+        paned.set_shrink_start_child(False)
+        paned.set_shrink_end_child(False)
+
+        if not self.replace_terminal(target, paned):
+            session.split_terminals.remove(new_terminal)
+            session.active_terminal_ids.discard(id(new_terminal))
+            return None
+
+        if direction in {"left", "up"}:
+            paned.set_start_child(new_scroller)
+            paned.set_end_child(target)
+        else:
+            paned.set_start_child(target)
+            paned.set_end_child(new_scroller)
+
+        def center_split() -> bool:
+            size = paned.get_width() if orientation == Gtk.Orientation.HORIZONTAL else paned.get_height()
+            if size > 0:
+                paned.set_position(size // 2)
+            new_terminal.grab_focus()
+            return GLib.SOURCE_REMOVE
+
+        GLib.timeout_add(80, center_split)
+        return new_terminal

--- a/src/termia/terminal_sessions.py
+++ b/src/termia/terminal_sessions.py
@@ -17,23 +17,22 @@ import gi
 gi.require_version("Gdk", "4.0")
 gi.require_version("Gio", "2.0")
 gi.require_version("Gtk", "4.0")
-gi.require_version("Pango", "1.0")
 gi.require_version("Vte", "3.91")
-from gi.repository import Gdk, Gio, GLib, Gtk, Pango, Vte
+from gi.repository import Gdk, Gio, GLib, Gtk, Vte
 
-from .constants import DEFAULT_TERMINAL_BACKGROUND, DEFAULT_TERMINAL_FOREGROUND
 from .connection_utils import find_local_terminal_profile, find_server
 from .file_transfer import FileTransferController
 from .keybindings import is_unmodified_function_key, keybinding_matches
-from .models import DEFAULT_ANSI_PALETTE, LocalTerminalProfile, Server
+from .models import LocalTerminalProfile, Server
 from .session_commands import build_ssh_command
+from .split_panes import SplitPaneController
 from .terminal_config import (
     build_local_prompt_shell_command,
     build_terminal_environment,
-    parse_color,
     split_layout_plan,
 )
 from .terminal_processes import spawn_terminal_process
+from .terminal_view import TerminalViewFactory
 from .ui_state import TerminalSession
 
 
@@ -101,13 +100,7 @@ class TerminalSessionsMixin:
         return Path(shell).name == "bash"
 
     def create_configured_terminal(self) -> Vte.Terminal:
-        terminal = Vte.Terminal()
-        terminal.set_hexpand(True)
-        terminal.set_vexpand(True)
-        terminal.set_cursor_blink_mode(Vte.CursorBlinkMode.ON)
-        terminal.set_scrollback_lines(10000)
-        self.apply_terminal_settings(terminal)
-        return terminal
+        return TerminalViewFactory(self.resolved_terminal_font_family).create(self.store.data.terminal)
 
     def build_session_status_bar(
         self,
@@ -569,44 +562,11 @@ class TerminalSessionsMixin:
         terminal: Vte.Terminal,
         direction: str,
     ) -> Vte.Terminal | None:
-        target = terminal.get_parent()
-        if not isinstance(target, Gtk.Widget):
-            return None
-
-        new_terminal = self.create_split_terminal(session)
-        new_scroller = self.wrap_terminal_in_scroller(new_terminal)
-        orientation = Gtk.Orientation.HORIZONTAL if direction in {"left", "right"} else Gtk.Orientation.VERTICAL
-        paned = Gtk.Paned(orientation=orientation)
-        paned.add_css_class("termia-split-pane")
-        paned.set_wide_handle(False)
-        paned.set_hexpand(True)
-        paned.set_vexpand(True)
-        paned.set_resize_start_child(True)
-        paned.set_resize_end_child(True)
-        paned.set_shrink_start_child(False)
-        paned.set_shrink_end_child(False)
-
-        if not self.replace_terminal_pane(target, paned):
-            session.split_terminals.remove(new_terminal)
-            session.active_terminal_ids.discard(id(new_terminal))
-            return None
-
-        if direction in {"left", "up"}:
-            paned.set_start_child(new_scroller)
-            paned.set_end_child(target)
-        else:
-            paned.set_start_child(target)
-            paned.set_end_child(new_scroller)
-
-        def center_split() -> bool:
-            size = paned.get_width() if orientation == Gtk.Orientation.HORIZONTAL else paned.get_height()
-            if size > 0:
-                paned.set_position(size // 2)
-            new_terminal.grab_focus()
-            return GLib.SOURCE_REMOVE
-
-        GLib.timeout_add(80, center_split)
-        return new_terminal
+        return SplitPaneController(
+            self.create_split_terminal,
+            self.wrap_terminal_in_scroller,
+            self.replace_terminal_pane,
+        ).split_terminal(session, terminal, direction)
 
     def start_split_child_terminal(
         self,
@@ -958,15 +918,7 @@ class TerminalSessionsMixin:
         self.update_session_tab_title(session, title)
 
     def apply_terminal_settings(self, terminal: Vte.Terminal) -> None:
-        settings = self.store.data.terminal
-        font_family = self.resolved_terminal_font_family(settings.font_family)
-        font = Pango.FontDescription(f"{font_family} {settings.font_size}")
-        foreground = parse_color(settings.foreground, DEFAULT_TERMINAL_FOREGROUND)
-        background = parse_color(settings.background, DEFAULT_TERMINAL_BACKGROUND)
-        palette_values = settings.ansi_palette or DEFAULT_ANSI_PALETTE
-        palette = [parse_color(color, fallback) for color, fallback in zip(palette_values, DEFAULT_ANSI_PALETTE)]
-        terminal.set_font(font)
-        terminal.set_colors(foreground, background, palette)
+        TerminalViewFactory(self.resolved_terminal_font_family).apply_settings(terminal, self.store.data.terminal)
 
     def apply_terminal_settings_to_open_tabs(self) -> None:
         for session in self.open_tabs.values():

--- a/src/termia/terminal_view.py
+++ b/src/termia/terminal_view.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2026 Jordi Pons
+# SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import gi
+
+gi.require_version("Pango", "1.0")
+gi.require_version("Vte", "3.91")
+from gi.repository import Pango, Vte
+
+from .constants import DEFAULT_TERMINAL_BACKGROUND, DEFAULT_TERMINAL_FOREGROUND
+from .models import DEFAULT_ANSI_PALETTE, TerminalSettings
+from .terminal_config import parse_color
+
+
+class TerminalViewFactory:
+    def __init__(self, resolve_font_family: Callable[[str], str]) -> None:
+        self.resolve_font_family = resolve_font_family
+
+    def create(self, settings: TerminalSettings) -> Vte.Terminal:
+        terminal = Vte.Terminal()
+        terminal.set_hexpand(True)
+        terminal.set_vexpand(True)
+        terminal.set_cursor_blink_mode(Vte.CursorBlinkMode.ON)
+        terminal.set_scrollback_lines(10000)
+        self.apply_settings(terminal, settings)
+        return terminal
+
+    def apply_settings(self, terminal: Vte.Terminal, settings: TerminalSettings) -> None:
+        font_family = self.resolve_font_family(settings.font_family)
+        font = Pango.FontDescription(f"{font_family} {settings.font_size}")
+        foreground = parse_color(settings.foreground, DEFAULT_TERMINAL_FOREGROUND)
+        background = parse_color(settings.background, DEFAULT_TERMINAL_BACKGROUND)
+        palette_values = settings.ansi_palette or DEFAULT_ANSI_PALETTE
+        palette = [parse_color(color, fallback) for color, fallback in zip(palette_values, DEFAULT_ANSI_PALETTE)]
+        terminal.set_font(font)
+        terminal.set_colors(foreground, background, palette)

--- a/tests/test_terminal_view.py
+++ b/tests/test_terminal_view.py
@@ -1,0 +1,48 @@
+import unittest
+
+from gi.repository import Pango
+from termia.models import TerminalSettings
+from termia.terminal_view import TerminalViewFactory
+
+
+class FakeTerminal:
+    def set_hexpand(self, value: bool) -> None:
+        self.hexpand = value
+
+    def set_vexpand(self, value: bool) -> None:
+        self.vexpand = value
+
+    def set_cursor_blink_mode(self, value: object) -> None:
+        self.cursor_blink_mode = value
+
+    def set_scrollback_lines(self, value: int) -> None:
+        self.scrollback_lines = value
+
+    def set_font(self, value: object) -> None:
+        self.font = value
+
+    def set_colors(self, foreground: object, background: object, palette: list[object]) -> None:
+        self.foreground = foreground
+        self.background = background
+        self.palette = palette
+
+
+class TerminalViewTests(unittest.TestCase):
+    def test_apply_settings_resolves_font_and_applies_palette(self) -> None:
+        terminal = FakeTerminal()
+        settings = TerminalSettings(
+            font_family="Preferred",
+            font_size=15,
+            foreground="#ffffff",
+            background="#000000",
+            ansi_palette=["#111111", "#222222"],
+        )
+        factory = TerminalViewFactory(lambda family: f"Resolved {family}")
+
+        factory.apply_settings(terminal, settings)
+
+        self.assertEqual(terminal.font.get_family(), "Resolved Preferred")
+        self.assertEqual(terminal.font.get_size() // Pango.SCALE, 15)
+        self.assertEqual(terminal.foreground.red, 1.0)
+        self.assertEqual(terminal.background.blue, 0.0)
+        self.assertEqual(len(terminal.palette), 2)


### PR DESCRIPTION
## Summary
- extract VTE terminal creation and settings application into `terminal_view.py`
- extract split-pane widget placement into `split_panes.py`
- keep session lifecycle, process startup, history, statistics, and layout orchestration in the mixin
- add focused terminal-view coverage while retaining GTK smoke coverage

## Validation
- `PYTHONPATH=src python3 -m unittest discover -s tests -v` (33 tests)
- Python syntax checks for touched files
- `scripts/compile_translations.py --check`
- `git diff --check`

Closes #113