### PR TITLE
refactor: separate sidebar data projection

### DIFF
--- a/src/termia/sidebar.py
+++ b/src/termia/sidebar.py
@@ -18,12 +18,11 @@ from .connection_utils import (
     find_server,
     group_descendant_ids,
     group_matches_query,
-    server_matches_query,
     unique_local_terminal_clone_name,
     unique_server_clone_name,
 )
 from .models import Group, LocalTerminalProfile, Server
-from .ui_state import RowObject
+from .sidebar_projection import SidebarRow as RowObject, build_sidebar_projection
 
 GROUP_START_CONFIRMATION_THRESHOLD = 10
 
@@ -267,32 +266,30 @@ class SidebarMixin:
         self.tree_widgets = {}
         self.selected_tree_widget = None
 
-        children_by_parent: dict[str | None, list[Group]] = {}
-        for group in self.store.data.groups:
-            children_by_parent.setdefault(group.parent_id, []).append(group)
-        servers_by_group: dict[str | None, list[Server]] = {}
-        for server in self.store.data.servers:
-            if server_matches_query(server, query):
-                servers_by_group.setdefault(server.group_id, []).append(server)
-
-        self.visible_tree_rows = self.build_visible_tree_rows(children_by_parent, servers_by_group, query)
-        local_terminal_profiles = self.local_terminal_profiles(query)
-        if local_terminal_profiles:
-            self.server_list.append(self.build_local_terminals_widget(local_terminal_profiles, query))
-        recent_servers = self.recent_servers(query)
-        if recent_servers:
-            self.server_list.append(self.build_recent_widget(recent_servers, query))
-        favorite_servers = self.favorite_servers(query)
-        if favorite_servers:
-            self.server_list.append(self.build_favorites_widget(favorite_servers, query))
-        for group in sorted(children_by_parent.get(None, []), key=lambda item: item.name.lower()):
-            widget = self.build_group_widget(group, children_by_parent, servers_by_group, query)
+        projection = build_sidebar_projection(
+            self.store.data.groups,
+            self.store.data.servers,
+            self.store.data.local_terminals,
+            self.store.recent_server_ids(),
+            query,
+            self.group_expanded_state,
+            self.collapse_groups_on_startup,
+        )
+        self.sidebar_projection = projection
+        self.visible_tree_rows = projection.rows
+        if projection.local_terminal_profiles:
+            self.server_list.append(self.build_local_terminals_widget(projection.local_terminal_profiles, query))
+        if projection.recent_servers:
+            self.server_list.append(self.build_recent_widget(projection.recent_servers, query))
+        if projection.favorite_servers:
+            self.server_list.append(self.build_favorites_widget(projection.favorite_servers, query))
+        for group in projection.root_groups:
+            widget = self.build_group_widget(group, projection.children_by_parent, projection.servers_by_group, query)
             if widget is not None:
                 self.server_list.append(widget)
 
-        ungrouped = servers_by_group.get(None, [])
-        if ungrouped:
-            self.server_list.append(self.build_ungrouped_widget(ungrouped, query))
+        if projection.ungrouped_servers:
+            self.server_list.append(self.build_ungrouped_widget(projection.ungrouped_servers, query))
 
         root_groups = len([group for group in self.store.data.groups if group.parent_id is None])
         subgroups = len(self.store.data.groups) - root_groups
@@ -300,98 +297,9 @@ class SidebarMixin:
             self.t("summary").format(groups=root_groups, subgroups=subgroups, servers=len(self.store.data.servers))
         )
 
-    def favorite_servers(self, query: str) -> list[Server]:
-        return sorted(
-            [server for server in self.store.data.servers if server.favorite and server_matches_query(server, query)],
-            key=lambda item: (item.name.lower(), item.host.lower(), item.user.lower(), item.port),
-        )
-
-    def recent_servers(self, query: str) -> list[Server]:
-        servers_by_id = {
-            server.id: server
-            for server in self.store.data.servers
-            if server_matches_query(server, query)
-        }
-        recent_servers: list[Server] = []
-        seen: set[str] = set()
-        for server_id in self.store.recent_server_ids():
-            if server_id in seen:
-                continue
-            server = servers_by_id.get(server_id)
-            if server is None:
-                continue
-            seen.add(server_id)
-            recent_servers.append(server)
-        return recent_servers
-
-    def build_visible_tree_rows(
-        self,
-        children_by_parent: dict[str | None, list[Group]],
-        servers_by_group: dict[str | None, list[Server]],
-        query: str,
-    ) -> list[RowObject]:
-        rows: list[RowObject] = []
-        rows.extend(self.build_local_terminal_row_objects(query))
-        if query or self.get_group_expanded("__recent__", query):
-            for server in self.recent_servers(query):
-                rows.append(self.build_server_row_object(server, "recent"))
-        if query or self.get_group_expanded("__favorites__", query):
-            for server in self.favorite_servers(query):
-                rows.append(self.build_server_row_object(server, "favorite"))
-        for group in sorted(children_by_parent.get(None, []), key=lambda item: item.name.lower()):
-            rows.extend(self.collect_visible_group_rows(group, children_by_parent, servers_by_group, query))
-        for server in sorted(servers_by_group.get(None, []), key=lambda item: item.name.lower()):
-            rows.append(self.build_server_row_object(server))
-        return rows
-
-    def local_terminal_profiles(self, query: str) -> list[LocalTerminalProfile]:
-        profiles = sorted(self.store.data.local_terminals, key=lambda item: item.name.lower())
-        if not query:
-            return profiles
-        return [profile for profile in profiles if self.local_terminal_profile_matches_query(profile, query)]
-
-    def local_terminal_profile_matches_query(self, profile: LocalTerminalProfile, query: str) -> bool:
-        haystack = " ".join(
-            str(value)
-            for value in (
-                profile.name,
-                profile.working_directory,
-                profile.shell,
-                profile.arguments,
-                profile.command_on_start,
-                profile.tab_title,
-            )
-            if value
-        ).casefold()
-        return query in haystack
-
-    def build_local_terminal_row_objects(self, query: str) -> list[RowObject]:
-        return [self.build_local_terminal_row_object(profile) for profile in self.local_terminal_profiles(query)]
-
     def build_local_terminal_row_object(self, profile: LocalTerminalProfile) -> RowObject:
         title = profile.name or self.t("local_terminal")
         return RowObject("local_terminal", profile.id, title)
-
-    def collect_visible_group_rows(
-        self,
-        group: Group,
-        children_by_parent: dict[str | None, list[Group]],
-        servers_by_group: dict[str | None, list[Server]],
-        query: str,
-    ) -> list[RowObject]:
-        child_rows: list[RowObject] = []
-        if query or self.get_group_expanded(group.id, query):
-            for child in sorted(children_by_parent.get(group.id, []), key=lambda item: item.name.lower()):
-                child_rows.extend(self.collect_visible_group_rows(child, children_by_parent, servers_by_group, query))
-            for server in sorted(servers_by_group.get(group.id, []), key=lambda item: item.name.lower()):
-                child_rows.append(self.build_server_row_object(server))
-
-        group_matches = group_matches_query(group, query)
-        if query and not group_matches and not child_rows:
-            return []
-
-        descendant_servers = sum(1 for row in child_rows if row.kind == "server")
-        return [RowObject("group", group.id, group.name, f"{descendant_servers} servidor(es)"), *child_rows]
 
     def build_server_row_object(self, server: Server, row_kind: str = "server") -> RowObject:
         return RowObject(row_kind, server.id, server.name, self.get_server_connection_text(server))

--- a/src/termia/sidebar_projection.py
+++ b/src/termia/sidebar_projection.py
@@ -1,0 +1,130 @@
+# SPDX-FileCopyrightText: 2026 Jordi Pons
+# SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .connection_utils import group_matches_query, server_matches_query
+from .models import Group, LocalTerminalProfile, Server
+
+
+@dataclass(frozen=True)
+class SidebarRow:
+    kind: str
+    item_id: str
+    title: str
+    subtitle: str = ""
+
+
+@dataclass
+class SidebarProjection:
+    rows: list[SidebarRow]
+    children_by_parent: dict[str | None, list[Group]]
+    servers_by_group: dict[str | None, list[Server]]
+    local_terminal_profiles: list[LocalTerminalProfile]
+    recent_servers: list[Server]
+    favorite_servers: list[Server]
+    root_groups: list[Group]
+    ungrouped_servers: list[Server]
+
+
+def server_connection_text(server: Server) -> str:
+    return f"{server.user}@{server.host}:{server.port}" if server.user else f"{server.host}:{server.port}"
+
+
+def local_terminal_profile_matches_query(profile: LocalTerminalProfile, query: str) -> bool:
+    haystack = " ".join(
+        str(value)
+        for value in (
+            profile.name,
+            profile.working_directory,
+            profile.shell,
+            profile.arguments,
+            profile.command_on_start,
+            profile.tab_title,
+        )
+        if value
+    ).casefold()
+    return query in haystack
+
+
+def build_sidebar_projection(
+    groups: list[Group],
+    servers: list[Server],
+    local_terminal_profiles: list[LocalTerminalProfile],
+    recent_server_ids: list[str],
+    query: str,
+    expanded_groups: dict[str, bool],
+    collapse_groups_on_startup: bool,
+) -> SidebarProjection:
+    children_by_parent: dict[str | None, list[Group]] = {}
+    for group in groups:
+        children_by_parent.setdefault(group.parent_id, []).append(group)
+
+    filtered_servers = [server for server in servers if server_matches_query(server, query)]
+    servers_by_group: dict[str | None, list[Server]] = {}
+    for server in filtered_servers:
+        servers_by_group.setdefault(server.group_id, []).append(server)
+
+    profiles = sorted(local_terminal_profiles, key=lambda item: item.name.lower())
+    if query:
+        profiles = [profile for profile in profiles if local_terminal_profile_matches_query(profile, query)]
+
+    servers_by_id = {server.id: server for server in filtered_servers}
+    recent: list[Server] = []
+    seen: set[str] = set()
+    for server_id in recent_server_ids:
+        if server_id in seen:
+            continue
+        server = servers_by_id.get(server_id)
+        if server is not None:
+            seen.add(server_id)
+            recent.append(server)
+
+    favorites = sorted(
+        [server for server in filtered_servers if server.favorite],
+        key=lambda item: (item.name.lower(), item.host.lower(), item.user.lower(), item.port),
+    )
+    root_groups = sorted(children_by_parent.get(None, []), key=lambda item: item.name.lower())
+    ungrouped = servers_by_group.get(None, [])
+
+    def is_expanded(group_id: str) -> bool:
+        if query:
+            return True
+        default = True if group_id in {"__recent__", "__favorites__", "__local_terminals__"} else not collapse_groups_on_startup
+        return expanded_groups.get(group_id, default)
+
+    def server_row(server: Server, kind: str = "server") -> SidebarRow:
+        return SidebarRow(kind, server.id, server.name, server_connection_text(server))
+
+    def collect_group_rows(group: Group) -> list[SidebarRow]:
+        child_rows: list[SidebarRow] = []
+        if is_expanded(group.id):
+            for child in sorted(children_by_parent.get(group.id, []), key=lambda item: item.name.lower()):
+                child_rows.extend(collect_group_rows(child))
+            for server in sorted(servers_by_group.get(group.id, []), key=lambda item: item.name.lower()):
+                child_rows.append(server_row(server))
+        if query and not group_matches_query(group, query) and not child_rows:
+            return []
+        descendant_servers = sum(1 for row in child_rows if row.kind == "server")
+        return [SidebarRow("group", group.id, group.name, f"{descendant_servers} servidor(es)"), *child_rows]
+
+    rows = [SidebarRow("local_terminal", profile.id, profile.name or "Local terminal") for profile in profiles]
+    if is_expanded("__recent__"):
+        rows.extend(server_row(server, "recent") for server in recent)
+    if is_expanded("__favorites__"):
+        rows.extend(server_row(server, "favorite") for server in favorites)
+    for group in root_groups:
+        rows.extend(collect_group_rows(group))
+    rows.extend(server_row(server) for server in sorted(ungrouped, key=lambda item: item.name.lower()))
+
+    return SidebarProjection(
+        rows=rows,
+        children_by_parent=children_by_parent,
+        servers_by_group=servers_by_group,
+        local_terminal_profiles=profiles,
+        recent_servers=recent,
+        favorite_servers=favorites,
+        root_groups=root_groups,
+        ungrouped_servers=ungrouped,
+    )

--- a/src/termia/ui_state.py
+++ b/src/termia/ui_state.py
@@ -10,13 +10,7 @@ gi.require_version("Gtk", "4.0")
 gi.require_version("Vte", "3.91")
 from gi.repository import Gtk, Vte
 
-
-@dataclass
-class RowObject:
-    kind: str
-    item_id: str
-    title: str
-    subtitle: str = ""
+from .sidebar_projection import SidebarRow as RowObject
 
 
 @dataclass

--- a/tests/test_sidebar_projection.py
+++ b/tests/test_sidebar_projection.py
@@ -1,0 +1,82 @@
+import unittest
+
+from termia.models import Group, LocalTerminalProfile, Server
+from termia.sidebar_projection import build_sidebar_projection
+
+
+class SidebarProjectionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.groups = [
+            Group(id="prod", name="Production"),
+            Group(id="nested", name="Nested", parent_id="prod"),
+        ]
+        self.servers = [
+            Server(id="web", name="Web", host="web.test", user="admin", group_id="nested", favorite=True),
+            Server(id="db", name="Database", host="db.test", user="db", group_id="prod"),
+            Server(id="loose", name="Loose", host="loose.test", user="user"),
+        ]
+        self.profiles = [
+            LocalTerminalProfile(id="z", name="Zulu"),
+            LocalTerminalProfile(id="a", name="Alpha", working_directory="/srv/projects"),
+        ]
+
+    def build(self, **kwargs: object):
+        options = {
+            "groups": self.groups,
+            "servers": self.servers,
+            "local_terminal_profiles": self.profiles,
+            "recent_server_ids": ["db", "db", "missing", "web"],
+            "query": "",
+            "expanded_groups": {},
+            "collapse_groups_on_startup": False,
+        }
+        options.update(kwargs)
+        return build_sidebar_projection(**options)
+
+    def test_projection_indexes_sections_and_rows_in_one_result(self) -> None:
+        projection = self.build()
+
+        self.assertEqual([profile.id for profile in projection.local_terminal_profiles], ["a", "z"])
+        self.assertEqual([server.id for server in projection.recent_servers], ["db", "web"])
+        self.assertEqual([server.id for server in projection.favorite_servers], ["web"])
+        self.assertEqual([group.id for group in projection.root_groups], ["prod"])
+        self.assertEqual([server.id for server in projection.ungrouped_servers], ["loose"])
+        self.assertEqual(
+            [(row.kind, row.item_id) for row in projection.rows],
+            [
+                ("local_terminal", "a"),
+                ("local_terminal", "z"),
+                ("recent", "db"),
+                ("recent", "web"),
+                ("favorite", "web"),
+                ("group", "prod"),
+                ("group", "nested"),
+                ("server", "web"),
+                ("server", "db"),
+                ("server", "loose"),
+            ],
+        )
+
+    def test_collapsed_groups_are_hidden_from_navigation_rows(self) -> None:
+        projection = self.build(expanded_groups={"prod": False})
+
+        self.assertEqual(
+            [(row.kind, row.item_id) for row in projection.rows],
+            [
+                ("local_terminal", "a"),
+                ("local_terminal", "z"),
+                ("recent", "db"),
+                ("recent", "web"),
+                ("favorite", "web"),
+                ("group", "prod"),
+                ("server", "loose"),
+            ],
+        )
+
+    def test_query_expands_matching_hierarchy_and_filters_sections(self) -> None:
+        projection = self.build(query="projects", expanded_groups={"prod": False})
+
+        self.assertEqual([profile.id for profile in projection.local_terminal_profiles], ["a"])
+        self.assertEqual(projection.recent_servers, [])
+        self.assertEqual(projection.favorite_servers, [])
+        self.assertEqual([(row.kind, row.item_id) for row in projection.rows], [("local_terminal", "a")])


### PR DESCRIPTION
## Summary
- add a GTK-independent sidebar projection for groups, servers, favorites, recent connections, and local terminals
- reuse one projection for keyboard-visible rows and section rendering
- move the plain sidebar row value type out of the GTK-heavy session state module
- add focused projection tests for filtering, ordering, hierarchy, expansion, favorites, and recent servers

## Validation
- `PYTHONPATH=src python3 -m unittest discover -s tests -v` (36 tests)
- Python syntax checks for touched files
- `scripts/compile_translations.py --check`
- `git diff --check`

Closes #115