### PR TITLE
refactor: add explicit storage schema migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Changes merged after `0.5.0-beta` (2026-07-21 to 2026-07-23).
 
 ### Refactored
 
+- Introduce explicit schema versioning and named migrations for connections, settings, statistics, and history files.
 - Establish an automated unit-test and GTK smoke-test baseline (`#104`).
 - Simplify sidebar row state and introduce a normalized sidebar projection (`#106`, `#116`).
 - Make history persistence injectable and expose history recovery messages (`#108`).

--- a/docs/STORAGE_MIGRATIONS.md
+++ b/docs/STORAGE_MIGRATIONS.md
@@ -1,0 +1,29 @@
+# Storage schema migrations
+
+Termia stores connections, settings, statistics, and connection history in
+separate local files. Each format now carries schema version `1` where the
+format is an object or event payload.
+
+## Compatibility policy
+
+- Unversioned files are treated as schema `0` and are migrated to schema `1`
+  when loaded and subsequently saved.
+- The oldest supported format is the unversioned legacy format shipped before
+  schema versioning was introduced.
+- Schema migrations must preserve user data and remain in the code while that
+  legacy format is supported.
+- Removing a migration requires a documented support-policy change and a
+  major release or explicit user-data migration plan.
+- Files with a schema newer than the application understand are rejected and
+  backed up through the existing recovery path; Termia must not silently
+  discard fields from a future format.
+
+## Current schemas
+
+- `connections.json`: object schema `1`; embedded legacy settings and
+  statistics are extracted into their dedicated files.
+- `settings.json`: object schema `1`; legacy terminal palette and color values
+  are normalized by a named migration.
+- `statistics.json`: object schema `1`.
+- `history.jsonl`: each event uses schema `1`; unversioned events remain
+  readable and receive the current version when rewritten.

--- a/src/termia/config_io.py
+++ b/src/termia/config_io.py
@@ -15,6 +15,7 @@ from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 
 from .models import Group, LocalTerminalProfile, Server, StoreData
+from .migrations import CURRENT_SCHEMA_VERSION, migrate_connections_payload
 
 CONNECTION_STORAGE_PLAIN = "plain"
 CONNECTION_STORAGE_OBFUSCATED = "obfuscated"
@@ -43,6 +44,7 @@ def connections_payload(
     master_password: str | None = None,
 ) -> dict[str, object]:
     payload = {
+        "schema_version": CURRENT_SCHEMA_VERSION,
         "groups": [asdict(group) for group in groups],
         "servers": [asdict(server) for server in servers],
         "local_terminals": [asdict(profile) for profile in local_terminals],
@@ -170,7 +172,7 @@ def export_connections_file(source: Path, destination: Path) -> None:
 
 
 def load_store_data_from_json(path: Path, current: StoreData, master_password: str | None = None) -> StoreData:
-    payload = read_connections_payload(path, master_password)
+    payload, _ = migrate_connections_payload(read_connections_payload(path, master_password))
     return StoreData(
         groups=[Group(**item) for item in payload.get("groups", [])],
         servers=[Server(**item) for item in payload.get("servers", [])],

--- a/src/termia/migrations.py
+++ b/src/termia/migrations.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: 2026 Jordi Pons
+# SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import annotations
+
+from typing import Any
+
+from .constants import (
+    DEFAULT_TERMINAL_BACKGROUND,
+    DEFAULT_TERMINAL_FONT_FAMILY,
+    DEFAULT_TERMINAL_FOREGROUND,
+    LEGACY_ANSI_PALETTE,
+)
+from .models import DEFAULT_ANSI_PALETTE, TerminalSettings
+
+CURRENT_SCHEMA_VERSION = 1
+
+
+def _add_schema_version(payload: dict[str, Any], kind: str) -> tuple[dict[str, Any], bool]:
+    version = payload.get("schema_version", 0)
+    if not isinstance(version, int) or version < 0:
+        raise ValueError(f"{kind} payload has an invalid schema version.")
+    if version > CURRENT_SCHEMA_VERSION:
+        raise ValueError(f"{kind} payload uses an unsupported schema version: {version}.")
+    migrated = dict(payload)
+    changed = version != CURRENT_SCHEMA_VERSION
+    migrated["schema_version"] = CURRENT_SCHEMA_VERSION
+    return migrated, changed
+
+
+def migrate_connections_payload(payload: dict[str, Any]) -> tuple[dict[str, Any], bool]:
+    return _add_schema_version(payload, "Connections")
+
+
+def migrate_settings_payload(payload: dict[str, Any]) -> tuple[dict[str, Any], bool]:
+    return _add_schema_version(payload, "Settings")
+
+
+def migrate_statistics_payload(payload: dict[str, Any]) -> tuple[dict[str, Any], bool]:
+    return _add_schema_version(payload, "Statistics")
+
+
+def migrate_history_event_payload(payload: dict[str, Any]) -> tuple[dict[str, Any], bool]:
+    return _add_schema_version(payload, "History event")
+
+
+def migrate_embedded_settings_payload(payload: dict[str, Any]) -> tuple[dict[str, Any], bool]:
+    embedded = {key: payload[key] for key in ("app", "terminal") if key in payload}
+    if not embedded:
+        return {}, False
+    return migrate_settings_payload(embedded)
+
+
+def migrate_embedded_statistics_payload(payload: dict[str, Any]) -> tuple[dict[str, Any], bool]:
+    statistics = payload.get("statistics")
+    if not isinstance(statistics, dict):
+        return {}, False
+    return migrate_statistics_payload(statistics)
+
+
+def migrate_legacy_terminal_settings(terminal: TerminalSettings) -> tuple[TerminalSettings, bool]:
+    changed = False
+    if (
+        terminal.font_family == "Ubuntu Mono"
+        and terminal.font_size == 13
+        and terminal.foreground == "#839496"
+        and terminal.background == "#002b36"
+    ):
+        terminal.font_family = DEFAULT_TERMINAL_FONT_FAMILY
+        terminal.foreground = DEFAULT_TERMINAL_FOREGROUND
+        terminal.background = DEFAULT_TERMINAL_BACKGROUND
+        changed = True
+    if terminal.ansi_palette == LEGACY_ANSI_PALETTE:
+        terminal.ansi_palette = DEFAULT_ANSI_PALETTE.copy()
+        changed = True
+    return terminal, changed

--- a/src/termia/stores.py
+++ b/src/termia/stores.py
@@ -23,7 +23,6 @@ from .constants import (
     MAX_SPLIT_SEPARATOR_THICKNESS,
     HISTORY_FILE,
     INSTANCE_LOCK_FILE,
-    LEGACY_ANSI_PALETTE,
     SETTINGS_FILE,
     STATISTICS_FILE,
 )
@@ -39,6 +38,16 @@ from .config_io import (
     write_connections_file,
 )
 from .i18n import LANGUAGES, detect_system_language
+from .migrations import (
+    CURRENT_SCHEMA_VERSION,
+    migrate_connections_payload,
+    migrate_embedded_settings_payload,
+    migrate_embedded_statistics_payload,
+    migrate_history_event_payload,
+    migrate_legacy_terminal_settings,
+    migrate_settings_payload,
+    migrate_statistics_payload,
+)
 from .keybindings import normalize_keybindings
 from .models import (
     DEFAULT_ANSI_PALETTE,
@@ -112,6 +121,7 @@ class StatisticsStore:
             payload = json.loads(self.path.read_text(encoding="utf-8"))
             if not isinstance(payload, dict):
                 raise ValueError("Statistics file must contain a JSON object.")
+            payload, _ = migrate_statistics_payload(payload)
             fields = StatisticsSettings.__dataclass_fields__
             self.data = StatisticsSettings(**{key: value for key, value in payload.items() if key in fields})
         except (OSError, json.JSONDecodeError, TypeError, ValueError):
@@ -122,7 +132,10 @@ class StatisticsStore:
         if self.read_only:
             return
         self.path.parent.mkdir(parents=True, exist_ok=True)
-        self.path.write_text(json.dumps(asdict(self.data), indent=2), encoding="utf-8")
+        self.path.write_text(
+            json.dumps({"schema_version": CURRENT_SCHEMA_VERSION, **asdict(self.data)}, indent=2),
+            encoding="utf-8",
+        )
         self.path.chmod(0o600)
 
 
@@ -149,6 +162,7 @@ class ConnectionHistoryStore:
                     continue
                 if not isinstance(payload, dict):
                     continue
+                payload, _ = migrate_history_event_payload(payload)
                 fields = ConnectionHistoryEvent.__dataclass_fields__
                 event = ConnectionHistoryEvent(**{key: value for key, value in payload.items() if key in fields})
                 if not event.event_id:
@@ -328,6 +342,7 @@ class SettingsStore:
             payload = json.loads(self.path.read_text(encoding="utf-8"))
             if not isinstance(payload, dict):
                 raise ValueError("Settings file must contain a JSON object.")
+            payload, _ = migrate_settings_payload(payload)
             app_payload = payload.get("app", {})
             app_fields = AppSettings.__dataclass_fields__
             self.app = normalize_app_settings(AppSettings(**{key: value for key, value in app_payload.items() if key in app_fields}))
@@ -341,6 +356,7 @@ class SettingsStore:
             return
         self.path.parent.mkdir(parents=True, exist_ok=True)
         payload = {
+            "schema_version": CURRENT_SCHEMA_VERSION,
             "app": asdict(self.app),
             "terminal": asdict(self.terminal),
         }
@@ -370,17 +386,7 @@ def normalize_app_settings(app: AppSettings) -> AppSettings:
 
 
 def normalize_terminal_settings(terminal: TerminalSettings) -> TerminalSettings:
-    if (
-        terminal.font_family == "Ubuntu Mono"
-        and terminal.font_size == 13
-        and terminal.foreground == "#839496"
-        and terminal.background == "#002b36"
-    ):
-        terminal.font_family = DEFAULT_TERMINAL_FONT_FAMILY
-        terminal.foreground = DEFAULT_TERMINAL_FOREGROUND
-        terminal.background = DEFAULT_TERMINAL_BACKGROUND
-    if terminal.ansi_palette == LEGACY_ANSI_PALETTE:
-        terminal.ansi_palette = DEFAULT_ANSI_PALETTE.copy()
+    terminal, _ = migrate_legacy_terminal_settings(terminal)
     terminal.split_separator_thickness = max(
         1,
         min(
@@ -449,6 +455,7 @@ class ConnectionStore:
             raw_payload = read_raw_connections_payload(self.path)
             file_storage_mode = connection_storage_mode_from_payload(raw_payload)
             payload = decoded_connections_payload(raw_payload, self.master_password)
+            payload, connections_migrated = migrate_connections_payload(payload)
         except MissingMasterPasswordError:
             self.encryption_locked = True
             self.encryption_error = ""
@@ -483,9 +490,12 @@ class ConnectionStore:
             return
         self.encryption_locked = False
         self.encryption_error = ""
-        legacy_statistics = payload.get("statistics")
+        legacy_statistics, embedded_statistics_migrated = migrate_embedded_statistics_payload(payload)
         if legacy_statistics and not self.statistics_store.path.exists():
-            self.statistics_store.data = StatisticsSettings(**legacy_statistics)
+            fields = StatisticsSettings.__dataclass_fields__
+            self.statistics_store.data = StatisticsSettings(
+                **{key: value for key, value in legacy_statistics.items() if key in fields}
+            )
             self.statistics_store.save()
 
         app = self.settings_store.app
@@ -493,10 +503,12 @@ class ConnectionStore:
         settings_migrated = False
         if not self.settings_store.path.exists():
             if "app" in payload or "terminal" in payload:
-                app_payload = payload.get("app", {})
+                embedded_settings, embedded_settings_migrated = migrate_embedded_settings_payload(payload)
+                app_payload = embedded_settings.get("app", {})
                 app_fields = AppSettings.__dataclass_fields__
                 app = normalize_app_settings(AppSettings(**{key: value for key, value in app_payload.items() if key in app_fields}))
-                terminal = normalize_terminal_settings(TerminalSettings(**payload.get("terminal", {})))
+                terminal = normalize_terminal_settings(TerminalSettings(**embedded_settings.get("terminal", {})))
+                settings_migrated = embedded_settings_migrated
             app.connection_storage_mode = file_storage_mode
             self.settings_store.app = app
             self.settings_store.terminal = terminal
@@ -514,7 +526,9 @@ class ConnectionStore:
         split_layouts_normalized = self.normalize_split_layouts()
         repaired = self.repair_references()
         if (
-            "statistics" in payload
+            connections_migrated
+            or embedded_statistics_migrated
+            or "statistics" in payload
             or "app" in payload
             or "terminal" in payload
             or repaired

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -5,10 +5,15 @@ from pathlib import Path
 from unittest.mock import patch
 
 from termia.constants import DEFAULT_TERMINAL_BACKGROUND, DEFAULT_TERMINAL_FOREGROUND
+from termia.migrations import CURRENT_SCHEMA_VERSION, migrate_settings_payload
 from termia.stores import ConnectionStore, SettingsStore
 
 
 class MigrationTests(unittest.TestCase):
+    def test_future_schema_is_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            migrate_settings_payload({"schema_version": CURRENT_SCHEMA_VERSION + 1})
+
     def test_settings_migrate_legacy_terminal_palette_and_colors(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             path = Path(directory) / "settings.json"
@@ -36,6 +41,28 @@ class MigrationTests(unittest.TestCase):
         self.assertEqual(store.terminal.background, DEFAULT_TERMINAL_BACKGROUND)
         self.assertEqual(store.terminal.split_separator_thickness, 32)
         self.assertEqual(store.terminal.split_separator_color, "#008712")
+
+        store.save()
+        saved = json.loads(path.read_text(encoding="utf-8"))
+        self.assertEqual(saved["schema_version"], CURRENT_SCHEMA_VERSION)
+
+    def test_statistics_and_connections_get_schema_versions(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            connections_path = root / "connections.json"
+            settings_path = root / "settings.json"
+            statistics_path = root / "statistics.json"
+            lock_path = root / "instance.lock"
+            store = ConnectionStore(connections_path, settings_path, statistics_path, lock_path)
+            try:
+                store.save()
+                store.save_statistics()
+            finally:
+                store.close()
+
+            self.assertEqual(json.loads(connections_path.read_text())["schema_version"], CURRENT_SCHEMA_VERSION)
+            self.assertEqual(json.loads(settings_path.read_text())["schema_version"], CURRENT_SCHEMA_VERSION)
+            self.assertEqual(json.loads(statistics_path.read_text())["schema_version"], CURRENT_SCHEMA_VERSION)
 
     def test_connection_store_migrates_embedded_settings(self) -> None:
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
## Summary
- Add schema version 1 to connections, settings, statistics, and history payloads.
- Introduce named migrations for legacy settings, embedded settings/statistics, and unversioned files.
- Reject future schema versions through the existing recovery path.
- Document compatibility policy and add migration coverage.

## Validation
- PYTHONPATH=src python3 -m unittest discover -s tests -v (38 tests)
- Python syntax checks for all modules and tests
- scripts/compile_translations.py --check
- bash -n scripts/termia-setup.sh
- git diff --check

Closes #122