### PR TITLE
docs: define supported GTK runtime baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Changes merged after `0.5.0-beta` (2026-07-21 to 2026-07-23).
 
 ### Changed
 
+- Document the supported Python, GTK, GDK, and VTE runtime baseline and retained compatibility guards.
 - Rename the saved-password shortcut settings to avoid implying that Termia executes `sudo`.
 - Unify the setup commands and dependency checks (`#94`).
 - Synchronize translation catalogs and add automated catalog consistency validation (`#102`).

--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ Each session can show a status bar with its state, PID, elapsed time, a compact 
 Termia has been tested on Ubuntu 24.04.4 LTS with Linux kernel
 6.8.0-117-generic, GNOME 46.0, and Wayland.
 
+## Supported runtime baseline
+
+Termia requires Python 3.10 or newer, GTK 4.0/GDK 4.0, and the GTK 4 VTE
+introspection namespace `Vte 3.91`. The current validation environment provides
+GTK 4.14.5 and VTE 0.76.0. Compatibility guards for optional GTK methods such as
+`set_handle_menubar_accel` and `set_show_separators` remain intentional so the
+same source can run across distributions that expose different GTK API levels.
+
 ## Project layout
 
 ```text

--- a/docs/README.ca.md
+++ b/docs/README.ca.md
@@ -53,6 +53,15 @@ Cada sessió pot mostrar una barra d'estat amb estat, PID, temps transcorregut, 
 Termia s'ha provat en Ubuntu 24.04.4 LTS amb kernel Linux
 6.8.0-117-generic, GNOME 46.0 i Wayland.
 
+## Base d'execució compatible
+
+Termia requereix Python 3.10 o posterior, GTK 4.0/GDK 4.0 i l'espai
+d'introspecció de VTE per a GTK 4, `Vte 3.91`. L'entorn actual de validació
+proporciona GTK 4.14.5 i VTE 0.76.0. Les comprovacions de compatibilitat per a
+mètodes GTK opcionals com `set_handle_menubar_accel` i
+`set_show_separators` són intencionades, perquè les distribucions poden
+exposar diferents nivells de l'API de GTK.
+
 ## Descarregar i instal·lar
 
 Clona el repositori complet:

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -53,6 +53,15 @@ Cada sesión puede mostrar una barra de estado con estado, PID, tiempo transcurr
 Termia se ha probado en Ubuntu 24.04.4 LTS con kernel Linux
 6.8.0-117-generic, GNOME 46.0 y Wayland.
 
+## Base de ejecución compatible
+
+Termia requiere Python 3.10 o posterior, GTK 4.0/GDK 4.0 y el espacio de
+introspección de VTE para GTK 4, `Vte 3.91`. El entorno actual de validación
+proporciona GTK 4.14.5 y VTE 0.76.0. Las comprobaciones de compatibilidad para
+métodos GTK opcionales como `set_handle_menubar_accel` y
+`set_show_separators` son intencionadas, porque las distribuciones pueden
+exponer distintos niveles de API de GTK.
+
 ## Descargar e instalar
 
 Clona el repositorio completo:


### PR DESCRIPTION
## Summary
- document Python, GTK/GDK, and VTE runtime requirements
- record the validated GTK 4.14.5 and VTE 0.76.0 environment
- explain why optional GTK compatibility guards remain

## Tests
- `PYTHONPATH=src python3 -m unittest discover -s tests` (39 passed)
- `python3 scripts/compile_translations.py --check`
- `git diff --check