### PR TITLE
fix: re-enable write actions after unlocking connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Changes merged after `0.5.0-beta` (2026-07-21 to 2026-07-23).
 
 ### Fixed
 
+- Re-enable write-capable sidebar actions after encrypted connections are successfully unlocked.
 - Keep the Debug mode checkbox enabled in General preferences when password shortcut options are present.
 - Refresh write actions after encrypted connections are unlocked so preferences and configuration actions are not left disabled.
 

--- a/src/termia/app.py
+++ b/src/termia/app.py
@@ -121,13 +121,17 @@ class TermiaWindow(
         return False
 
     def configure_write_action(self, widget: Gtk.Widget) -> Gtk.Widget:
-        if self.store.read_only or self.store.encryption_locked:
-            widget.set_sensitive(False)
-            widget.set_tooltip_text(
+        write_blocked = self.store.read_only or self.store.encryption_locked
+        widget.set_sensitive(not write_blocked)
+        widget.set_tooltip_text(
+            (
                 self.t("connections_locked_tooltip")
                 if self.store.encryption_locked
                 else self.t("read_only_mode_tooltip")
             )
+            if write_blocked
+            else None
+        )
         return widget
 
     def request_unlock_connections(self) -> bool:

--- a/tests/test_write_actions.py
+++ b/tests/test_write_actions.py
@@ -1,0 +1,60 @@
+import importlib.util
+import unittest
+from types import SimpleNamespace
+
+
+@unittest.skipUnless(importlib.util.find_spec("gi"), "GTK bindings are unavailable")
+class WriteActionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        from termia.app import TermiaWindow
+
+        self.configure_write_action = TermiaWindow.configure_write_action
+
+    def window(self, *, read_only: bool, encryption_locked: bool):
+        return SimpleNamespace(
+            store=SimpleNamespace(
+                read_only=read_only,
+                encryption_locked=encryption_locked,
+            ),
+            t=lambda key: key,
+        )
+
+    def widget(self):
+        state = SimpleNamespace(sensitive=None, tooltip="stale")
+        state.set_sensitive = lambda value: setattr(state, "sensitive", value)
+        state.set_tooltip_text = lambda value: setattr(state, "tooltip", value)
+        return state
+
+    def test_write_action_is_reenabled_and_stale_tooltip_is_cleared(self) -> None:
+        widget = self.widget()
+
+        result = self.configure_write_action(
+            self.window(read_only=False, encryption_locked=False),
+            widget,
+        )
+
+        self.assertIs(result, widget)
+        self.assertTrue(widget.sensitive)
+        self.assertIsNone(widget.tooltip)
+
+    def test_encrypted_store_keeps_write_action_disabled(self) -> None:
+        widget = self.widget()
+
+        self.configure_write_action(
+            self.window(read_only=False, encryption_locked=True),
+            widget,
+        )
+
+        self.assertFalse(widget.sensitive)
+        self.assertEqual(widget.tooltip, "connections_locked_tooltip")
+
+    def test_read_only_store_keeps_write_action_disabled(self) -> None:
+        widget = self.widget()
+
+        self.configure_write_action(
+            self.window(read_only=True, encryption_locked=False),
+            widget,
+        )
+
+        self.assertFalse(widget.sensitive)
+        self.assertEqual(widget.tooltip, "read_only_mode_tooltip")


### PR DESCRIPTION
## Summary
- explicitly restore sensitivity for write-capable actions after encrypted connections are unlocked
- clear stale lock tooltips when writes become available
- keep actions disabled in read-only and encryption-locked states

## Tests
- `PYTHONPATH=src python3 -m unittest discover -s tests` (42 passed)
- `python3 -m py_compile src/termia/app.py tests/test_write_actions.py`
- `python3 scripts/compile_translations.py --check`
- `git diff --check`