### PR TITLE
refactor: extract connection history presenter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Changes merged after `0.5.0-beta` (2026-07-21 to 2026-07-23).
 
 ### Refactored
 
+- Extract connection-history filtering and display formatting into an explicitly injected, GTK-independent presenter.
 - Document the state, services, cross-mixin calls, and dependency hotspots that make up the current `TermiaWindow` mixin contracts.
 - Introduce explicit schema versioning and named migrations for connections, settings, statistics, and history files.
 - Establish an automated unit-test and GTK smoke-test baseline (`#104`).

--- a/docs/REGRESSION_CHECKS.md
+++ b/docs/REGRESSION_CHECKS.md
@@ -120,6 +120,13 @@ Protected behavior does not mean the code cannot change. It means regressions sh
 - LS color customization must continue to reduce overly bright directory/file colors.
 - Tab labels should show short and medium names without unnecessary truncation, and provide a tooltip with the full title.
 
+### Connection History
+
+- Searching connection history must remain case-insensitive and match server names, hosts, users, results, details, timestamps, and formatted durations.
+- Hiding local terminals must preserve SSH entries and the current search filter.
+- History rows must keep translated connection kinds and results, server or local-terminal names, endpoints, details, and durations.
+- Clearing history must refresh the open dialog without retaining stale entries.
+
 ### Statistics
 
 - Statistics collection must remain lightweight and should not continuously write to disk on every keypress.
@@ -145,6 +152,7 @@ Before merging changes that touch UI, terminals, tabs, or configuration, verify:
 - Edit a server and confirm collapsed groups stay collapsed.
 - Search for a group, subgroup, and server in the sidebar filter.
 - Confirm the Recent section appears above Favorites, shows the 10 most recently connected servers without duplicates, and updates after new SSH connections.
+- Open connection history, search for an SSH server, toggle local-terminal entries, and confirm row contents remain unchanged.
 - Open Preferences from Configuration and confirm the app does not hang.
 - Start a second Termia process and confirm it opens as a separate window with the read-only badge visible.
 - In the read-only instance, confirm add/edit/delete/import/clear/preferences actions are disabled or rejected, while connecting and exporting still work.

--- a/docs/WINDOW_MIXIN_CONTRACTS.md
+++ b/docs/WINDOW_MIXIN_CONTRACTS.md
@@ -113,12 +113,14 @@ security, and keybinding dialogs have comparatively small contracts.
 
 ### `ConnectionHistoryViewMixin`
 
-- Reads: `store`, `toast_label`.
+- Reads: `store`, `toast_label`, and the explicitly composed
+  `history_presenter`.
 - Window services: translation, dialog buttons, and writable-action
   configuration.
 - Cross-mixin dependencies: none beyond those common services.
-- Architectural note: filtering and display formatting can be extracted
-  independently from GTK dialog construction.
+- Extracted component: `ConnectionHistoryPresenter` owns filtering and display
+  formatting. It receives only an entries provider and translation callback;
+  the mixin retains GTK dialog and row construction.
 
 ### `StatisticsViewMixin`
 
@@ -176,8 +178,8 @@ The principal cycles are:
 
 1. Define a small host interface for translation, feedback, writability, and
    dialog parenting.
-2. Extract history filtering/formatting or statistics presentation first; both
-   have narrow contracts and focused tests can cover them.
+2. Continue the pattern established by the extracted history presenter with
+   statistics presentation, which has a similarly narrow contract.
 3. Pass explicit action callbacks into main and terminal menu builders.
 4. Introduce a session registry that owns `open_tabs` and session lookup.
 5. Separate tab placement from session lifecycle using the registry and

--- a/src/termia/app.py
+++ b/src/termia/app.py
@@ -11,6 +11,7 @@ gi.require_version("Gdk", "4.0")
 from gi.repository import Gdk, Gio, GLib, Gtk
 
 from .config_actions import ConfigActionsMixin
+from .connection_history_presenter import ConnectionHistoryPresenter
 from .connection_history_view import ConnectionHistoryViewMixin
 from .connection_dialogs import ConnectionDialogsMixin
 from .constants import (
@@ -57,6 +58,10 @@ class TermiaWindow(
             self.set_handle_menubar_accel(False)
 
         self.store = ConnectionStore(DATA_FILE)
+        self.history_presenter = ConnectionHistoryPresenter(
+            lambda: self.store.history_store.entries,
+            self.t,
+        )
         if self.store.data.app.debug_enabled:
             configure_debug_logging(True)
         log_startup_context(

--- a/src/termia/connection_history_presenter.py
+++ b/src/termia/connection_history_presenter.py
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: 2026 Jordi Pons
+# SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from datetime import datetime
+
+from .models import ConnectionHistoryEntry
+from .statistics_utils import format_duration
+
+HistoryEntriesProvider = Callable[[], Sequence[ConnectionHistoryEntry]]
+Translator = Callable[[str], str]
+
+
+class ConnectionHistoryPresenter:
+    """Prepare connection-history data without depending on GTK or the window."""
+
+    def __init__(self, entries: HistoryEntriesProvider, translate: Translator) -> None:
+        self._entries = entries
+        self._translate = translate
+
+    def filter_entries(
+        self,
+        query: str,
+        show_local_terminals: bool = True,
+    ) -> list[ConnectionHistoryEntry]:
+        normalized_query = query.strip().casefold()
+        entries = [
+            entry
+            for entry in self._entries()
+            if show_local_terminals or entry.kind != "local"
+        ]
+        if not normalized_query:
+            return entries
+        return [
+            entry
+            for entry in entries
+            if self.entry_matches(entry, normalized_query)
+        ]
+
+    def entry_matches(self, entry: ConnectionHistoryEntry, query: str) -> bool:
+        haystack = " ".join(
+            str(value)
+            for value in (
+                entry.kind,
+                entry.title,
+                entry.server_name,
+                entry.host,
+                entry.user,
+                entry.result,
+                entry.detail,
+                entry.started_at,
+                entry.ended_at,
+                format_duration(entry.duration_seconds),
+            )
+            if value
+        ).casefold()
+        return query in haystack
+
+    def build_line(self, entry: ConnectionHistoryEntry) -> str:
+        return " · ".join(
+            part
+            for part in (self.build_heading(entry), self.build_subtitle(entry))
+            if part
+        )
+
+    def build_heading(self, entry: ConnectionHistoryEntry) -> str:
+        timestamp = self.format_timestamp(entry.ended_at or entry.started_at)
+        result = self.format_result(entry.result, entry.ended_at)
+        duration = format_duration(entry.duration_seconds)
+        return " · ".join(part for part in (timestamp, result, duration) if part)
+
+    def build_subtitle(self, entry: ConnectionHistoryEntry) -> str:
+        kind = self.format_kind(entry.kind)
+        target = entry.server_name or entry.title or self._translate("local_terminal")
+        details = [part for part in (kind, target) if part]
+        endpoint = self.format_endpoint(entry.user, entry.host, entry.port)
+        if endpoint:
+            details.append(endpoint)
+        if entry.detail:
+            details.append(entry.detail)
+        return " · ".join(details)
+
+    def format_timestamp(self, value: str) -> str:
+        if not value:
+            return ""
+        try:
+            timestamp = datetime.fromisoformat(value)
+        except ValueError:
+            return value
+        return timestamp.astimezone().strftime("%Y-%m-%d %H:%M:%S")
+
+    def format_result(self, result: str, ended_at: str) -> str:
+        if not ended_at:
+            return self._translate("history_result_running")
+        if result == "failed":
+            return self._translate("history_result_failed")
+        if result == "disconnected":
+            return self._translate("history_result_disconnected")
+        return self._translate("history_result_closed")
+
+    def format_kind(self, kind: str) -> str:
+        if kind == "ssh":
+            return self._translate("history_kind_ssh")
+        if kind == "local":
+            return self._translate("history_kind_local")
+        return kind
+
+    def format_endpoint(self, user: str, host: str, port: int) -> str:
+        if not host:
+            return ""
+        endpoint = f"{host}:{port}" if port else host
+        return f"{user}@{endpoint}" if user else endpoint

--- a/src/termia/connection_history_view.py
+++ b/src/termia/connection_history_view.py
@@ -2,16 +2,13 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
-from datetime import datetime
-from typing import Any
-
 import gi
 
 gi.require_version("Gtk", "4.0")
 gi.require_version("Pango", "1.0")
 from gi.repository import Gio, Gtk, Pango
 
-from .statistics_utils import format_duration
+from .models import ConnectionHistoryEntry
 
 
 class ConnectionHistoryViewMixin:
@@ -132,12 +129,16 @@ class ConnectionHistoryViewMixin:
             list_box.remove(child)
             child = next_child
 
-        query = search_entry.get_text().strip().casefold()
+        query = search_entry.get_text()
         show_local_terminals = state.get("show_local_terminals", True)
-        entries = self.filter_connection_history_entries(query, show_local_terminals)
+        entries = self.history_presenter.filter_entries(query, show_local_terminals)
         if not entries:
             row = Gtk.ListBoxRow()
-            label_key = "no_matching_history" if query or not show_local_terminals else "no_connection_history"
+            label_key = (
+                "no_matching_history"
+                if query.strip() or not show_local_terminals
+                else "no_connection_history"
+            )
             label = Gtk.Label(label=self.t(label_key))
             label.set_xalign(0)
             label.set_margin_top(8)
@@ -151,34 +152,7 @@ class ConnectionHistoryViewMixin:
         for entry in entries:
             list_box.append(self.build_history_row(entry))
 
-    def filter_connection_history_entries(self, query: str, show_local_terminals: bool = True) -> list[Any]:
-        entries = self.store.history_store.entries
-        if not show_local_terminals:
-            entries = [entry for entry in entries if entry.kind != "local"]
-        if not query:
-            return entries
-        return [entry for entry in entries if self.connection_history_entry_matches(entry, query)]
-
-    def connection_history_entry_matches(self, entry: Any, query: str) -> bool:
-        haystack = " ".join(
-            str(value)
-            for value in (
-                entry.kind,
-                entry.title,
-                entry.server_name,
-                entry.host,
-                entry.user,
-                entry.result,
-                entry.detail,
-                entry.started_at,
-                entry.ended_at,
-                format_duration(entry.duration_seconds),
-            )
-            if value
-        ).casefold()
-        return query in haystack
-
-    def build_history_row(self, entry: Any) -> Gtk.ListBoxRow:
+    def build_history_row(self, entry: ConnectionHistoryEntry) -> Gtk.ListBoxRow:
         row = Gtk.ListBoxRow()
         box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
         box.set_margin_top(0)
@@ -186,69 +160,10 @@ class ConnectionHistoryViewMixin:
         box.set_margin_start(12)
         box.set_margin_end(12)
 
-        label = Gtk.Label(label=self.build_history_line(entry))
+        label = Gtk.Label(label=self.history_presenter.build_line(entry))
         label.set_xalign(0)
         label.set_wrap(False)
         label.set_ellipsize(Pango.EllipsizeMode.END)
         box.append(label)
         row.set_child(box)
         return row
-
-    def build_history_line(self, entry: Any) -> str:
-        heading = self.build_history_heading(entry)
-        subtitle = self.build_history_subtitle(entry)
-        parts = [part for part in (heading, subtitle) if part]
-        return " · ".join(parts)
-
-    def build_history_heading(self, entry) -> str:
-        timestamp = self.format_history_timestamp(entry.ended_at or entry.started_at)
-        result = self.format_history_result(entry.result, entry.ended_at)
-        duration = format_duration(entry.duration_seconds)
-        parts = [part for part in (timestamp, result, duration) if part]
-        return " · ".join(parts)
-
-    def build_history_subtitle(self, entry) -> str:
-        kind = self.format_history_kind(entry.kind)
-        target = entry.server_name or entry.title or self.t("local_terminal")
-        details = [part for part in (kind, target) if part]
-        endpoint = self.format_history_endpoint(entry.user, entry.host, entry.port)
-        if endpoint:
-            details.append(endpoint)
-        if entry.detail:
-            details.append(entry.detail)
-        return " · ".join(details)
-
-    def format_history_timestamp(self, value: str) -> str:
-        if not value:
-            return ""
-        try:
-            dt = datetime.fromisoformat(value)
-        except ValueError:
-            return value
-        return dt.astimezone().strftime("%Y-%m-%d %H:%M:%S")
-
-    def format_history_result(self, result: str, ended_at: str) -> str:
-        if not ended_at:
-            return self.t("history_result_running")
-        if result == "failed":
-            return self.t("history_result_failed")
-        if result == "disconnected":
-            return self.t("history_result_disconnected")
-        return self.t("history_result_closed")
-
-    def format_history_kind(self, kind: str) -> str:
-        if kind == "ssh":
-            return self.t("history_kind_ssh")
-        if kind == "local":
-            return self.t("history_kind_local")
-        return kind
-
-    def format_history_endpoint(self, user: str, host: str, port: int) -> str:
-        if not host:
-            return ""
-        endpoint = host
-        if port:
-            endpoint = f"{endpoint}:{port}"
-        if user:
-            endpoint = f"{user}@{endpoint}"
-        return endpoint

--- a/tests/test_connection_history_presenter.py
+++ b/tests/test_connection_history_presenter.py
@@ -1,0 +1,69 @@
+import unittest
+
+from termia.connection_history_presenter import ConnectionHistoryPresenter
+from termia.models import ConnectionHistoryEntry
+
+
+class ConnectionHistoryPresenterTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.entries = [
+            ConnectionHistoryEntry(
+                session_id="ssh-1",
+                kind="ssh",
+                server_name="Production",
+                host="example.test",
+                port=2222,
+                user="admin",
+                started_at="2026-07-22T10:00:00+02:00",
+                ended_at="2026-07-22T10:01:05+02:00",
+                result="failed",
+                duration_seconds=65,
+                detail="Connection refused",
+            ),
+            ConnectionHistoryEntry(
+                session_id="local-1",
+                kind="local",
+                title="Local shell",
+                started_at="2026-07-22T11:00:00+02:00",
+                duration_seconds=None,
+            ),
+        ]
+        self.presenter = ConnectionHistoryPresenter(
+            lambda: self.entries,
+            lambda key: f"<{key}>",
+        )
+
+    def test_filter_normalizes_query_and_can_hide_local_entries(self) -> None:
+        self.assertEqual(
+            [entry.session_id for entry in self.presenter.filter_entries("  PRODUCTION  ")],
+            ["ssh-1"],
+        )
+        self.assertEqual(
+            [entry.session_id for entry in self.presenter.filter_entries("", False)],
+            ["ssh-1"],
+        )
+        self.assertEqual(
+            [entry.session_id for entry in self.presenter.filter_entries("00:01:05")],
+            ["ssh-1"],
+        )
+
+    def test_build_line_combines_translated_status_target_and_endpoint(self) -> None:
+        line = self.presenter.build_line(self.entries[0])
+
+        self.assertIn("<history_result_failed>", line)
+        self.assertIn("<history_kind_ssh>", line)
+        self.assertIn("Production", line)
+        self.assertIn("admin@example.test:2222", line)
+        self.assertIn("Connection refused", line)
+
+    def test_running_local_entry_uses_running_and_local_labels(self) -> None:
+        line = self.presenter.build_line(self.entries[1])
+
+        self.assertIn("<history_result_running>", line)
+        self.assertIn("<history_kind_local>", line)
+        self.assertIn("Local shell", line)
+
+    def test_format_helpers_preserve_invalid_timestamp_and_unknown_kind(self) -> None:
+        self.assertEqual(self.presenter.format_timestamp("invalid"), "invalid")
+        self.assertEqual(self.presenter.format_kind("other"), "other")
+        self.assertEqual(self.presenter.format_endpoint("", "", 0), "")


### PR DESCRIPTION
## Summary
- extract history filtering and display formatting into a GTK-independent presenter
- inject the history entries provider and translator at the TermiaWindow composition boundary
- keep GTK dialog and row construction in ConnectionHistoryViewMixin
- document the new explicit dependency and regression checks

## Tests
- `PYTHONPATH=src python3 -m unittest discover -s tests -v` (46 passed)
- `python3 -m py_compile run_termia.py scripts/compile_translations.py src/termia/*.py tests/*.py`
- `python3 scripts/compile_translations.py --check`
- `bash -n scripts/termia-setup.sh`
- `git diff --check`