### PR TITLE
refactor: extract statistics presenter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Changes merged after `0.5.0-beta` (2026-07-21 to 2026-07-23).
 
 ### Refactored
 
+- Extract statistics dashboard metrics and ranking into an explicitly injected, GTK-independent presenter.
 - Extract connection-history filtering and display formatting into an explicitly injected, GTK-independent presenter.
 - Document the state, services, cross-mixin calls, and dependency hotspots that make up the current `TermiaWindow` mixin contracts.
 - Introduce explicit schema versioning and named migrations for connections, settings, statistics, and history files.

--- a/docs/REGRESSION_CHECKS.md
+++ b/docs/REGRESSION_CHECKS.md
@@ -153,6 +153,7 @@ Before merging changes that touch UI, terminals, tabs, or configuration, verify:
 - Search for a group, subgroup, and server in the sidebar filter.
 - Confirm the Recent section appears above Favorites, shows the 10 most recently connected servers without duplicates, and updates after new SSH connections.
 - Open connection history, search for an SSH server, toggle local-terminal entries, and confirm row contents remain unchanged.
+- Open statistics and confirm the four metric cards, current-run count, duration values, ranked servers, counts, and progress bars remain correct.
 - Open Preferences from Configuration and confirm the app does not hang.
 - Start a second Termia process and confirm it opens as a separate window with the read-only badge visible.
 - In the read-only instance, confirm add/edit/delete/import/clear/preferences actions are disabled or rejected, while connecting and exporting still work.

--- a/docs/WINDOW_MIXIN_CONTRACTS.md
+++ b/docs/WINDOW_MIXIN_CONTRACTS.md
@@ -124,11 +124,13 @@ security, and keybinding dialogs have comparatively small contracts.
 
 ### `StatisticsViewMixin`
 
-- Reads: `store`, `run_connections`.
+- Reads: the explicitly composed `statistics_presenter`.
 - Window services: translation and dialog buttons.
 - Cross-mixin dependencies: none beyond those common services.
-- Architectural note: this is the smallest direct `TermiaWindow` mixin
-  contract.
+- Extracted component: `StatisticsPresenter` owns card metrics, duration
+  formatting, current-run values, and server ranking. It receives statistics,
+  servers, current-run, and translation providers; the mixin retains GTK
+  widget construction.
 
 ### `TerminalMenusMixin`
 
@@ -178,8 +180,8 @@ The principal cycles are:
 
 1. Define a small host interface for translation, feedback, writability, and
    dialog parenting.
-2. Continue the pattern established by the extracted history presenter with
-   statistics presentation, which has a similarly narrow contract.
+2. Use the history and statistics presenters as the pattern for subsequent
+   extractions with explicit providers and callbacks.
 3. Pass explicit action callbacks into main and terminal menu builders.
 4. Introduce a session registry that owns `open_tabs` and session lookup.
 5. Separate tab placement from session lifecycle using the registry and

--- a/src/termia/app.py
+++ b/src/termia/app.py
@@ -30,6 +30,7 @@ from .main_menu import MainMenuMixin
 from .preferences import PreferencesMixin
 from .stores import ConnectionStore
 from .sidebar import SidebarMixin
+from .statistics_presenter import StatisticsPresenter
 from .statistics_view import StatisticsViewMixin
 from .styles import build_application_css
 from .tabs import TabsMixin
@@ -84,6 +85,12 @@ class TermiaWindow(
         self.active_context_popover: Gtk.Popover | None = None
         self.open_tabs: dict[str, TerminalSession] = {}
         self.run_connections = 0
+        self.statistics_presenter = StatisticsPresenter(
+            lambda: self.store.data.statistics,
+            lambda: self.store.data.servers,
+            lambda: self.run_connections,
+            self.t,
+        )
         self.stats_save_id: int | None = None
         self.close_confirmation_pending = False
         self.connect("close-request", self.on_main_window_close_request)

--- a/src/termia/statistics_presenter.py
+++ b/src/termia/statistics_presenter.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: 2026 Jordi Pons
+# SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+
+from .models import Server, StatisticsSettings
+from .statistics_utils import (
+    TopServerStat,
+    average_session_duration,
+    format_duration,
+    top_server_statistics,
+)
+
+StatisticsProvider = Callable[[], StatisticsSettings]
+ServersProvider = Callable[[], Sequence[Server]]
+RunConnectionsProvider = Callable[[], int]
+Translator = Callable[[str], str]
+
+
+@dataclass(frozen=True)
+class StatisticCard:
+    title: str
+    value: str
+    subtitle: str
+
+
+@dataclass(frozen=True)
+class StatisticsDashboard:
+    cards: tuple[StatisticCard, ...]
+    top_servers: tuple[TopServerStat, ...]
+    max_server_count: int
+
+
+class StatisticsPresenter:
+    """Prepare statistics dashboard content without depending on GTK."""
+
+    def __init__(
+        self,
+        statistics: StatisticsProvider,
+        servers: ServersProvider,
+        run_connections: RunConnectionsProvider,
+        translate: Translator,
+    ) -> None:
+        self._statistics = statistics
+        self._servers = servers
+        self._run_connections = run_connections
+        self._translate = translate
+
+    def dashboard(self) -> StatisticsDashboard:
+        stats = self._statistics()
+        average_duration = average_session_duration(stats)
+        cards = (
+            StatisticCard(
+                self._translate("connections"),
+                str(stats.connections),
+                f"{self._translate('current_run')} {self._run_connections()}",
+            ),
+            StatisticCard(
+                self._translate("sessions"),
+                str(stats.completed_sessions),
+                self._translate("global"),
+            ),
+            StatisticCard(
+                self._translate("average_duration"),
+                format_duration(average_duration),
+                self._translate("duration"),
+            ),
+            StatisticCard(
+                self._translate("longest_duration"),
+                format_duration(stats.duration_max if stats.completed_sessions else None),
+                f"{self._translate('shortest_duration')}: {format_duration(stats.duration_min)}",
+            ),
+        )
+        top_servers = tuple(
+            top_server_statistics(stats, list(self._servers()))
+        )
+        return StatisticsDashboard(
+            cards=cards,
+            top_servers=top_servers,
+            max_server_count=max(
+                (item.count for item in top_servers),
+                default=1,
+            ),
+        )

--- a/src/termia/statistics_view.py
+++ b/src/termia/statistics_view.py
@@ -7,7 +7,7 @@ import gi
 gi.require_version("Gtk", "4.0")
 from gi.repository import Gtk
 
-from .statistics_utils import average_session_duration, format_duration, top_server_statistics
+from .statistics_presenter import StatisticCard, StatisticsDashboard
 
 
 class StatisticsViewMixin:
@@ -31,33 +31,18 @@ class StatisticsViewMixin:
         scroller.set_child(dashboard)
         content.append(scroller)
 
-        stats = self.store.data.statistics
-        average_duration = average_session_duration(stats)
+        presentation = self.statistics_presenter.dashboard()
         cards = Gtk.Grid()
         cards.set_column_spacing(10)
         cards.set_row_spacing(10)
-        cards.attach(
-            self.build_stat_card(
-                self.t("connections"), str(stats.connections), f"{self.t('current_run')} {self.run_connections}"
-            ),
-            0, 0, 1, 1
-        )
-        cards.attach(
-            self.build_stat_card(self.t("sessions"), str(stats.completed_sessions), self.t("global")),
-            1, 0, 1, 1
-        )
-        cards.attach(
-            self.build_stat_card(self.t("average_duration"), format_duration(average_duration), self.t("duration")),
-            2, 0, 1, 1
-        )
-        cards.attach(
-            self.build_stat_card(
-                self.t("longest_duration"),
-                format_duration(stats.duration_max if stats.completed_sessions else None),
-                f"{self.t('shortest_duration')}: {format_duration(stats.duration_min)}",
-            ),
-            0, 1, 1, 1
-        )
+        for index, card in enumerate(presentation.cards):
+            cards.attach(
+                self.build_stat_card(card),
+                index % 3,
+                index // 3,
+                1,
+                1,
+            )
         for card in self.iter_grid_children(cards):
             card.set_hexpand(True)
         dashboard.append(cards)
@@ -66,22 +51,22 @@ class StatisticsViewMixin:
         title.set_xalign(0)
         title.add_css_class("heading")
         dashboard.append(title)
-        dashboard.append(self.build_top_servers_list())
+        dashboard.append(self.build_top_servers_list(presentation))
 
         dialog.connect("response", lambda current, _response: current.destroy())
         dialog.present()
 
-    def build_stat_card(self, title: str, value: str, subtitle: str = "") -> Gtk.Widget:
+    def build_stat_card(self, presentation: StatisticCard) -> Gtk.Widget:
         card = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=3)
         card.add_css_class("stat-card")
-        title_label = Gtk.Label(label=title)
+        title_label = Gtk.Label(label=presentation.title)
         title_label.set_xalign(0)
         title_label.add_css_class("stat-card-title")
         title_label.add_css_class("dim-label")
-        value_label = Gtk.Label(label=value)
+        value_label = Gtk.Label(label=presentation.value)
         value_label.set_xalign(0)
         value_label.add_css_class("stat-card-value")
-        subtitle_label = Gtk.Label(label=subtitle)
+        subtitle_label = Gtk.Label(label=presentation.subtitle)
         subtitle_label.set_xalign(0)
         subtitle_label.add_css_class("stat-card-subtitle")
         subtitle_label.add_css_class("dim-label")
@@ -98,11 +83,10 @@ class StatisticsViewMixin:
             child = child.get_next_sibling()
         return children
 
-    def build_top_servers_list(self) -> Gtk.Widget:
-        stats = self.store.data.statistics
+    def build_top_servers_list(self, presentation: StatisticsDashboard) -> Gtk.Widget:
         list_box = Gtk.ListBox()
         list_box.set_selection_mode(Gtk.SelectionMode.NONE)
-        if not stats.server_connections:
+        if not presentation.top_servers:
             row = Gtk.ListBoxRow()
             label = Gtk.Label(label=self.t("no_statistics"))
             label.set_xalign(0)
@@ -114,9 +98,7 @@ class StatisticsViewMixin:
             list_box.append(row)
             return list_box
 
-        ranked = top_server_statistics(stats, self.store.data.servers)
-        max_count = max((item.count for item in ranked), default=1)
-        for item in ranked:
+        for item in presentation.top_servers:
             row = Gtk.ListBoxRow()
             row_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=4)
             row_box.add_css_class("stat-row")
@@ -135,7 +117,7 @@ class StatisticsViewMixin:
                 subtitle_label.set_xalign(0)
                 subtitle_label.add_css_class("dim-label")
                 row_box.append(subtitle_label)
-            progress = Gtk.LevelBar.new_for_interval(0, max_count)
+            progress = Gtk.LevelBar.new_for_interval(0, presentation.max_server_count)
             progress.set_value(item.count)
             progress.set_hexpand(True)
             row_box.append(progress)

--- a/tests/test_statistics_presenter.py
+++ b/tests/test_statistics_presenter.py
@@ -1,0 +1,61 @@
+import unittest
+
+from termia.models import Server, StatisticsSettings
+from termia.statistics_presenter import StatisticsPresenter
+
+
+class StatisticsPresenterTests(unittest.TestCase):
+    def test_dashboard_prepares_cards_and_ranked_servers(self) -> None:
+        stats = StatisticsSettings(
+            connections=7,
+            completed_sessions=2,
+            duration_total=130,
+            duration_min=30,
+            duration_max=100,
+            server_connections={"web": 4, "db": 2},
+        )
+        servers = [
+            Server(id="web", name="Web", host="web.test", user="admin", port=22),
+            Server(id="db", name="Database", host="db.test", user="dba", port=2200),
+        ]
+        presenter = StatisticsPresenter(
+            lambda: stats,
+            lambda: servers,
+            lambda: 3,
+            lambda key: f"<{key}>",
+        )
+
+        dashboard = presenter.dashboard()
+
+        self.assertEqual(
+            [(card.title, card.value, card.subtitle) for card in dashboard.cards],
+            [
+                ("<connections>", "7", "<current_run> 3"),
+                ("<sessions>", "2", "<global>"),
+                ("<average_duration>", "00:01:05", "<duration>"),
+                ("<longest_duration>", "00:01:40", "<shortest_duration>: 00:00:30"),
+            ],
+        )
+        self.assertEqual(
+            [(row.name, row.subtitle, row.count) for row in dashboard.top_servers],
+            [
+                ("Web", "admin@web.test:22", 4),
+                ("Database", "dba@db.test:2200", 2),
+            ],
+        )
+        self.assertEqual(dashboard.max_server_count, 4)
+
+    def test_empty_dashboard_uses_duration_placeholders(self) -> None:
+        presenter = StatisticsPresenter(
+            StatisticsSettings,
+            list,
+            lambda: 0,
+            lambda key: key,
+        )
+
+        dashboard = presenter.dashboard()
+
+        self.assertEqual(dashboard.cards[2].value, "--:--:--")
+        self.assertEqual(dashboard.cards[3].value, "--:--:--")
+        self.assertEqual(dashboard.top_servers, ())
+        self.assertEqual(dashboard.max_server_count, 1)


### PR DESCRIPTION
## Summary
- extract dashboard metrics, durations, current-run values, and server ranking into a GTK-independent presenter
- inject statistics, server, current-run, and translation providers at the window composition boundary
- keep GTK widget construction in StatisticsViewMixin
- document the explicit dependency and manual regression check

## Tests
- `PYTHONPATH=src python3 -m unittest discover -s tests -v` (48 passed)
- `python3 -m py_compile run_termia.py scripts/compile_translations.py src/termia/*.py tests/*.py`
- `python3 scripts/compile_translations.py --check`
- `bash -n scripts/termia-setup.sh`
- `git diff --check`