### PR TITLE
Refactor: inject main menu actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Changes merged after `0.5.0-beta` (2026-07-21 to 2026-07-23).
 
 ### Fixed
 
+- Reset the main menu to its top-level view after closing the Import/Export submenu.
 - Re-enable write-capable sidebar actions after encrypted connections are successfully unlocked.
 - Keep the Debug mode checkbox enabled in General preferences when password shortcut options are present.
 - Refresh write actions after encrypted connections are unlocked so preferences and configuration actions are not left disabled.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Changes merged after `0.5.0-beta` (2026-07-21 to 2026-07-23).
 
 ### Refactored
 
+- Pass main-menu feature actions through an explicit callback contract composed by the application window.
 - Extract statistics dashboard metrics and ranking into an explicitly injected, GTK-independent presenter.
 - Extract connection-history filtering and display formatting into an explicitly injected, GTK-independent presenter.
 - Document the state, services, cross-mixin calls, and dependency hotspots that make up the current `TermiaWindow` mixin contracts.

--- a/docs/REGRESSION_CHECKS.md
+++ b/docs/REGRESSION_CHECKS.md
@@ -154,6 +154,7 @@ Before merging changes that touch UI, terminals, tabs, or configuration, verify:
 - Confirm the Recent section appears above Favorites, shows the 10 most recently connected servers without duplicates, and updates after new SSH connections.
 - Open connection history, search for an SSH server, toggle local-terminal entries, and confirm row contents remain unchanged.
 - Open statistics and confirm the four metric cards, current-run count, duration values, ranked servers, counts, and progress bars remain correct.
+- Open every main-menu action and every Connections File submenu action, confirming each still opens or runs the intended feature after the popover closes.
 - Open Preferences from Configuration and confirm the app does not hang.
 - Start a second Termia process and confirm it opens as a separate window with the read-only badge visible.
 - In the read-only instance, confirm add/edit/delete/import/clear/preferences actions are disabled or rejected, while connecting and exporting still work.
@@ -167,7 +168,7 @@ Run at minimum:
 
 ```bash
 PYTHONPATH=src python3 -m unittest discover -s tests -v
-python3 -m py_compile run_termia.py scripts/compile_translations.py src/termia/app.py src/termia/asbru_import.py src/termia/config_actions.py src/termia/config_io.py src/termia/connection_dialogs.py src/termia/connection_utils.py src/termia/constants.py src/termia/i18n.py src/termia/keybindings.py src/termia/main_menu.py src/termia/models.py src/termia/preferences.py src/termia/sidebar.py src/termia/statistics_utils.py src/termia/statistics_view.py src/termia/stores.py src/termia/styles.py src/termia/tabs.py src/termia/terminal_sessions.py src/termia/terminal_config.py src/termia/ui_state.py
+python3 -m py_compile run_termia.py scripts/compile_translations.py src/termia/app.py src/termia/asbru_import.py src/termia/config_actions.py src/termia/config_io.py src/termia/connection_dialogs.py src/termia/connection_utils.py src/termia/constants.py src/termia/i18n.py src/termia/keybindings.py src/termia/main_menu.py src/termia/main_menu_actions.py src/termia/models.py src/termia/preferences.py src/termia/sidebar.py src/termia/statistics_utils.py src/termia/statistics_view.py src/termia/stores.py src/termia/styles.py src/termia/tabs.py src/termia/terminal_sessions.py src/termia/terminal_config.py src/termia/ui_state.py
 bash -n scripts/termia-setup.sh
 scripts/compile_translations.py
 scripts/compile_translations.py --check

--- a/docs/REGRESSION_CHECKS.md
+++ b/docs/REGRESSION_CHECKS.md
@@ -155,6 +155,7 @@ Before merging changes that touch UI, terminals, tabs, or configuration, verify:
 - Open connection history, search for an SSH server, toggle local-terminal entries, and confirm row contents remain unchanged.
 - Open statistics and confirm the four metric cards, current-run count, duration values, ranked servers, counts, and progress bars remain correct.
 - Open every main-menu action and every Connections File submenu action, confirming each still opens or runs the intended feature after the popover closes.
+- Open Import/Export, close the menu with `Esc` or its menu button, and confirm reopening starts at the top-level menu.
 - Open Preferences from Configuration and confirm the app does not hang.
 - Start a second Termia process and confirm it opens as a separate window with the read-only badge visible.
 - In the read-only instance, confirm add/edit/delete/import/clear/preferences actions are disabled or rejected, while connecting and exporting still work.

--- a/docs/WINDOW_MIXIN_CONTRACTS.md
+++ b/docs/WINDOW_MIXIN_CONTRACTS.md
@@ -71,13 +71,14 @@ Some mixins add transient state after construction:
 
 ### `MainMenuMixin`
 
-- Reads: no data widgets beyond the window services; it wires callbacks from
-  nearly every feature area.
+- Reads: the explicitly composed `MainMenuActions` callback set.
 - Window services: translation and writable-action configuration.
-- Cross-mixin dependencies: configuration actions, all preference dialogs,
-  history, statistics, and the shared dialog-button helpers it defines.
-- Architectural note: it is a composition boundary and should receive action
-  callbacks explicitly instead of discovering methods on the window.
+- Cross-mixin dependencies: none for menu dispatch; the shared dialog-button
+  helpers and built-in Help and About dialog implementations remain on the
+  mixin.
+- Extracted component: `MainMenuActions` defines the actions supplied by the
+  application composition root. The menu builder no longer discovers
+  configuration, preference, history, or statistics callbacks on the window.
 
 ### Preference mixins
 
@@ -182,7 +183,8 @@ The principal cycles are:
    dialog parenting.
 2. Use the history and statistics presenters as the pattern for subsequent
    extractions with explicit providers and callbacks.
-3. Pass explicit action callbacks into main and terminal menu builders.
+3. Pass explicit action callbacks into menu builders. The main menu now uses
+   `MainMenuActions`; terminal menus remain to be converted.
 4. Introduce a session registry that owns `open_tabs` and session lookup.
 5. Separate tab placement from session lifecycle using the registry and
    callbacks, then replace `TabsMixin`.

--- a/src/termia/app.py
+++ b/src/termia/app.py
@@ -27,6 +27,7 @@ from .debug import configure_debug_logging, log_startup_context, log_store_state
 from .i18n import translate_key
 from .keybindings import keybinding_matches
 from .main_menu import MainMenuMixin
+from .main_menu_actions import MainMenuActions
 from .preferences import PreferencesMixin
 from .stores import ConnectionStore
 from .sidebar import SidebarMixin
@@ -90,6 +91,22 @@ class TermiaWindow(
             lambda: self.store.data.servers,
             lambda: self.run_connections,
             self.t,
+        )
+        self.main_menu_actions = MainMenuActions(
+            general_preferences=lambda: self.on_app_preferences(None),
+            terminal_settings=lambda: self.on_terminal_settings(None),
+            prompt_settings=lambda: self.on_prompt_settings(None),
+            keybinding_settings=lambda: self.on_keybindings_settings(None),
+            security_settings=lambda: self.on_security_settings(None),
+            statistics=lambda: self.on_statistics_dashboard(None),
+            connection_history=lambda: self.on_connection_history(None),
+            data_locations=self.on_data_locations,
+            export_config=self.on_export_config,
+            import_config=self.on_import_config,
+            import_asbru_config=self.on_import_asbru_config,
+            clear_config=self.on_request_clear_config,
+            help=lambda: self.on_help(None),
+            about=lambda: self.on_about(None),
         )
         self.stats_save_id: int | None = None
         self.close_confirmation_pending = False
@@ -292,7 +309,7 @@ class TermiaWindow(
         menu_button = Gtk.MenuButton()
         self.main_menu_button = menu_button
         menu_button.set_tooltip_text(self.t("main_menu"))
-        menu_button.set_popover(self.build_main_menu())
+        menu_button.set_popover(self.build_main_menu(self.main_menu_actions))
         menu_button.set_child(Gtk.Image.new_from_icon_name("open-menu-symbolic"))
         header.pack_start(menu_button)
 
@@ -493,7 +510,9 @@ class TermiaWindow(
         self.toggle_sidebar_button.set_tooltip_text(self.t("servers"))
         self.new_tab_button.set_tooltip_text(self.t("new_tab"))
         self.main_menu_button.set_tooltip_text(self.t("main_menu"))
-        self.main_menu_button.set_popover(self.build_main_menu())
+        self.main_menu_button.set_popover(
+            self.build_main_menu(self.main_menu_actions)
+        )
         self.read_only_badge.set_label(self.t("read_only_badge"))
         if self.store.read_only:
             self.set_title(f"Termia ({self.t('read_only_badge')})")

--- a/src/termia/main_menu.py
+++ b/src/termia/main_menu.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
-from typing import Any
+from collections.abc import Callable
 
 import gi
 
@@ -12,19 +12,24 @@ from gi.repository import Gdk, GLib, Gtk
 
 from .constants import ABOUT_IMAGE, ISSUES_URL
 from . import __version__
+from .main_menu_actions import MainMenuActions
 
 
 class MainMenuMixin:
     POPOVER_CALLBACK_DELAY_MS = 100
 
-    def build_main_menu(self) -> Gtk.Popover:
+    def build_main_menu(self, actions: MainMenuActions) -> Gtk.Popover:
         popover = Gtk.Popover()
         popover.add_css_class("termia-menu-popover")
         popover.set_has_arrow(False)
-        popover.set_child(self.build_main_menu_content(popover))
+        popover.set_child(self.build_main_menu_content(popover, actions))
         return popover
 
-    def build_main_menu_content(self, popover: Gtk.Popover) -> Gtk.Widget:
+    def build_main_menu_content(
+        self,
+        popover: Gtk.Popover,
+        actions: MainMenuActions,
+    ) -> Gtk.Widget:
         menu = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=4)
         menu.add_css_class("termia-menu-panel")
         menu.set_margin_top(6)
@@ -34,66 +39,87 @@ class MainMenuMixin:
 
         general = Gtk.Button(label=self.t("general"))
         general.set_halign(Gtk.Align.FILL)
-        general.connect("clicked", lambda _button: self.run_after_popover_closed(popover, self.on_app_preferences))
+        self.connect_main_menu_action(
+            general, popover, actions.general_preferences
+        )
         self.configure_write_action(general)
         menu.append(general)
 
         terminal = Gtk.Button(label=self.t("terminal"))
         terminal.set_halign(Gtk.Align.FILL)
-        terminal.connect("clicked", lambda _button: self.run_after_popover_closed(popover, self.on_terminal_settings))
+        self.connect_main_menu_action(
+            terminal, popover, actions.terminal_settings
+        )
         self.configure_write_action(terminal)
         menu.append(terminal)
 
         prompt = Gtk.Button(label=self.t("prompt"))
         prompt.set_halign(Gtk.Align.FILL)
-        prompt.connect("clicked", lambda _button: self.run_after_popover_closed(popover, self.on_prompt_settings))
+        self.connect_main_menu_action(prompt, popover, actions.prompt_settings)
         self.configure_write_action(prompt)
         menu.append(prompt)
 
         keybindings = Gtk.Button(label=self.t("keybindings"))
         keybindings.set_halign(Gtk.Align.FILL)
-        keybindings.connect("clicked", lambda _button: self.run_after_popover_closed(popover, self.on_keybindings_settings))
+        self.connect_main_menu_action(
+            keybindings, popover, actions.keybinding_settings
+        )
         self.configure_write_action(keybindings)
         menu.append(keybindings)
 
         security = Gtk.Button(label=self.t("security"))
         security.set_halign(Gtk.Align.FILL)
-        security.connect("clicked", lambda _button: self.run_after_popover_closed(popover, self.on_security_settings))
+        self.connect_main_menu_action(
+            security, popover, actions.security_settings
+        )
         self.configure_write_action(security)
         menu.append(security)
 
         statistics = Gtk.Button(label=self.t("statistics"))
         statistics.set_halign(Gtk.Align.FILL)
-        statistics.connect("clicked", lambda _button: self.run_after_popover_closed(popover, self.on_statistics_dashboard))
+        self.connect_main_menu_action(statistics, popover, actions.statistics)
         menu.append(statistics)
 
         history = Gtk.Button(label=self.t("connection_history"))
         history.set_halign(Gtk.Align.FILL)
-        history.connect("clicked", lambda _button: self.run_after_popover_closed(popover, self.on_connection_history))
+        self.connect_main_menu_action(
+            history, popover, actions.connection_history
+        )
         menu.append(history)
 
         data_locations = Gtk.Button(label=self.t("data_locations"))
         data_locations.set_halign(Gtk.Align.FILL)
-        data_locations.connect("clicked", lambda _button: self.run_action_after_popover_closed(popover, self.on_data_locations))
+        self.connect_main_menu_action(
+            data_locations, popover, actions.data_locations
+        )
         menu.append(data_locations)
 
         connections_file = Gtk.Button(label=self.t("connections_file"))
         connections_file.set_halign(Gtk.Align.FILL)
-        connections_file.connect("clicked", lambda _button: popover.set_child(self.build_main_connections_menu(popover)))
+        connections_file.connect(
+            "clicked",
+            lambda _button: popover.set_child(
+                self.build_main_connections_menu(popover, actions)
+            ),
+        )
         menu.append(connections_file)
 
         help_btn = Gtk.Button(label=self.t("help"))
         help_btn.set_halign(Gtk.Align.FILL)
-        help_btn.connect("clicked", lambda _button: self.run_after_popover_closed(popover, self.on_help))
+        self.connect_main_menu_action(help_btn, popover, actions.help)
         menu.append(help_btn)
 
         about_btn = Gtk.Button(label=self.t("about"))
         about_btn.set_halign(Gtk.Align.FILL)
-        about_btn.connect("clicked", lambda _button: self.run_after_popover_closed(popover, self.on_about))
+        self.connect_main_menu_action(about_btn, popover, actions.about)
         menu.append(about_btn)
         return menu
 
-    def build_main_connections_menu(self, popover: Gtk.Popover) -> Gtk.Widget:
+    def build_main_connections_menu(
+        self,
+        popover: Gtk.Popover,
+        actions: MainMenuActions,
+    ) -> Gtk.Widget:
         menu = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=4)
         menu.add_css_class("termia-menu-panel")
         menu.set_margin_top(6)
@@ -103,44 +129,65 @@ class MainMenuMixin:
 
         back = Gtk.Button(label=self.t("main_menu"))
         back.set_halign(Gtk.Align.FILL)
-        back.connect("clicked", lambda _button: popover.set_child(self.build_main_menu_content(popover)))
+        back.connect(
+            "clicked",
+            lambda _button: popover.set_child(
+                self.build_main_menu_content(popover, actions)
+            ),
+        )
         menu.append(back)
 
         export_config = Gtk.Button(label=self.t("export_config"))
         export_config.set_halign(Gtk.Align.FILL)
-        export_config.connect("clicked", lambda _button: self.run_action_after_popover_closed(popover, self.on_export_config))
+        self.connect_main_menu_action(
+            export_config, popover, actions.export_config
+        )
         menu.append(export_config)
 
         import_config = Gtk.Button(label=self.t("import_config"))
         import_config.set_halign(Gtk.Align.FILL)
-        import_config.connect("clicked", lambda _button: self.run_action_after_popover_closed(popover, self.on_import_config))
+        self.connect_main_menu_action(
+            import_config, popover, actions.import_config
+        )
         self.configure_write_action(import_config)
         menu.append(import_config)
 
         import_asbru = Gtk.Button(label=self.t("import_asbru"))
         import_asbru.set_halign(Gtk.Align.FILL)
-        import_asbru.connect("clicked", lambda _button: self.run_action_after_popover_closed(popover, self.on_import_asbru_config))
+        self.connect_main_menu_action(
+            import_asbru, popover, actions.import_asbru_config
+        )
         self.configure_write_action(import_asbru)
         menu.append(import_asbru)
 
         clear_config = Gtk.Button(label=self.t("clear_config"))
         clear_config.set_halign(Gtk.Align.FILL)
         clear_config.add_css_class("destructive-action")
-        clear_config.connect("clicked", lambda _button: self.run_action_after_popover_closed(popover, self.on_request_clear_config))
+        self.connect_main_menu_action(
+            clear_config, popover, actions.clear_config
+        )
         self.configure_write_action(clear_config)
         menu.append(clear_config)
         return menu
 
-    def run_after_popover_closed(self, popover: Gtk.Popover, callback: Any) -> None:
-        popover.popdown()
+    def connect_main_menu_action(
+        self,
+        button: Gtk.Button,
+        popover: Gtk.Popover,
+        callback: Callable[[], None],
+    ) -> None:
+        button.connect(
+            "clicked",
+            lambda _button: self.run_action_after_popover_closed(
+                popover, callback
+            ),
+        )
 
-        def run_callback() -> bool:
-            callback(None)
-            return GLib.SOURCE_REMOVE
-
-        GLib.timeout_add(self.POPOVER_CALLBACK_DELAY_MS, run_callback)
-
-    def run_action_after_popover_closed(self, popover: Gtk.Popover, callback: Any) -> None:
+    def run_action_after_popover_closed(
+        self,
+        popover: Gtk.Popover,
+        callback: Callable[[], None],
+    ) -> None:
         popover.popdown()
 
         def run_callback() -> bool:

--- a/src/termia/main_menu.py
+++ b/src/termia/main_menu.py
@@ -23,6 +23,7 @@ class MainMenuMixin:
         popover.add_css_class("termia-menu-popover")
         popover.set_has_arrow(False)
         popover.set_child(self.build_main_menu_content(popover, actions))
+        popover.connect("closed", lambda *_args: self.reset_main_menu(popover, actions))
         return popover
 
     def build_main_menu_content(
@@ -182,6 +183,13 @@ class MainMenuMixin:
                 popover, callback
             ),
         )
+
+    def reset_main_menu(
+        self,
+        popover: Gtk.Popover,
+        actions: MainMenuActions,
+    ) -> None:
+        popover.set_child(self.build_main_menu_content(popover, actions))
 
     def run_action_after_popover_closed(
         self,

--- a/src/termia/main_menu_actions.py
+++ b/src/termia/main_menu_actions.py
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: 2026 Jordi Pons
+# SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+MenuAction = Callable[[], None]
+
+
+@dataclass(frozen=True)
+class MainMenuActions:
+    """Callbacks exposed to the main menu by the application composition root."""
+
+    general_preferences: MenuAction
+    terminal_settings: MenuAction
+    prompt_settings: MenuAction
+    keybinding_settings: MenuAction
+    security_settings: MenuAction
+    statistics: MenuAction
+    connection_history: MenuAction
+    data_locations: MenuAction
+    export_config: MenuAction
+    import_config: MenuAction
+    import_asbru_config: MenuAction
+    clear_config: MenuAction
+    help: MenuAction
+    about: MenuAction

--- a/tests/test_main_menu.py
+++ b/tests/test_main_menu.py
@@ -1,0 +1,26 @@
+import unittest
+from types import SimpleNamespace
+
+from termia.main_menu import MainMenuMixin
+
+
+class FakePopover:
+    def __init__(self) -> None:
+        self.child = None
+
+    def set_child(self, child) -> None:
+        self.child = child
+
+
+class MainMenuResetTests(unittest.TestCase):
+    def test_reset_main_menu_replaces_submenu_with_top_level_content(self) -> None:
+        actions = SimpleNamespace()
+        popover = FakePopover()
+
+        class Host(MainMenuMixin):
+            def build_main_menu_content(self, current_popover, current_actions):
+                return (current_popover, current_actions)
+
+        MainMenuMixin.reset_main_menu(Host(), popover, actions)
+
+        self.assertEqual(popover.child, (popover, actions))

--- a/tests/test_main_menu_actions.py
+++ b/tests/test_main_menu_actions.py
@@ -1,0 +1,35 @@
+import unittest
+from dataclasses import fields
+
+from termia.main_menu_actions import MainMenuActions
+
+
+class MainMenuActionsTests(unittest.TestCase):
+    def test_each_explicit_action_dispatches_to_its_callback(self) -> None:
+        calls = []
+
+        def action(name):
+            return lambda: calls.append(name)
+
+        actions = MainMenuActions(
+            general_preferences=action("general_preferences"),
+            terminal_settings=action("terminal_settings"),
+            prompt_settings=action("prompt_settings"),
+            keybinding_settings=action("keybinding_settings"),
+            security_settings=action("security_settings"),
+            statistics=action("statistics"),
+            connection_history=action("connection_history"),
+            data_locations=action("data_locations"),
+            export_config=action("export_config"),
+            import_config=action("import_config"),
+            import_asbru_config=action("import_asbru_config"),
+            clear_config=action("clear_config"),
+            help=action("help"),
+            about=action("about"),
+        )
+
+        action_names = [field.name for field in fields(actions)]
+        for name in action_names:
+            getattr(actions, name)()
+
+        self.assertEqual(calls, action_names)


### PR DESCRIPTION
## Summary
- Introduce an explicit MainMenuActions callback contract.
- Compose all main-menu feature callbacks in TermiaWindow.
- Reset the main menu to its top-level view whenever the popover closes.
- Add contract and regression tests and update architecture/regression documentation.

## Tests
- `PYTHONPATH=src python3 -m unittest discover -s tests -v` (50 passed)
- `python3 -m py_compile src/termia/app.py src/termia/main_menu.py src/termia/main_menu_actions.py tests/test_main_menu.py tests/test_main_menu_actions.py`
- `scripts/compile_translations.py --check`
- `git diff --check`

The GTK visual smoke launch could not run in the execution environment because no usable display was available.

Closes #132
Closes #134