### PR TITLE
Fix: move tabs to new windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Changes merged after `0.5.0-beta` (2026-07-21 to 2026-07-23).
 
 ### Fixed
 
+- Fix moving a tab to a new window by preserving the previous tab order when selecting the next focused session.
 - Reset the main menu to its top-level view after closing the Import/Export submenu.
 - Re-enable write-capable sidebar actions after encrypted connections are successfully unlocked.
 - Keep the Debug mode checkbox enabled in General preferences when password shortcut options are present.

--- a/docs/REGRESSION_CHECKS.md
+++ b/docs/REGRESSION_CHECKS.md
@@ -141,6 +141,7 @@ Before merging changes that touch UI, terminals, tabs, or configuration, verify:
 
 - Open Termia and confirm a local terminal opens if the preference is enabled.
 - Open two local terminals and reorder their tabs with the mouse.
+- Right-click a tab, move it to a new window, repeat with another tab, and restore both detached windows to the main window.
 - Duplicate a local terminal and confirm the custom prompt is applied.
 - Open two SSH sessions and duplicate one of them.
 - Close a tab and confirm focus moves to the next terminal.

--- a/src/termia/tabs.py
+++ b/src/termia/tabs.py
@@ -291,8 +291,9 @@ class TabsMixin:
         popover.popdown()
         if session.detached_window is not None:
             return
+        previous_order = self.visible_sessions_in_tab_order()
         self.remove_session_from_main_view(session)
-        self.focus_available_session_after_close(session.id)
+        self.focus_available_session_after_close(session.id, previous_order)
         window = Gtk.Window(title=session.title, transient_for=self)
         if hasattr(window, "set_handle_menubar_accel"):
             window.set_handle_menubar_accel(False)

--- a/tests/test_tabs.py
+++ b/tests/test_tabs.py
@@ -1,0 +1,81 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from termia.tabs import TabsMixin
+
+
+class FakePopover:
+    def __init__(self) -> None:
+        self.closed = False
+
+    def popdown(self) -> None:
+        self.closed = True
+
+
+class FakeWindow:
+    def __init__(self, **_kwargs) -> None:
+        self.child = None
+        self.presented = False
+
+    def set_handle_menubar_accel(self, _enabled: bool) -> None:
+        pass
+
+    def set_default_size(self, _width: int, _height: int) -> None:
+        pass
+
+    def set_child(self, child) -> None:
+        self.child = child
+
+    def connect(self, *_args) -> None:
+        pass
+
+    def present(self) -> None:
+        self.presented = True
+
+
+class DetachTabTests(unittest.TestCase):
+    def test_detach_tab_keeps_previous_order_for_focus_selection(self) -> None:
+        session = SimpleNamespace(
+            id="detached",
+            title="Detached",
+            page=object(),
+            detached_window=None,
+        )
+        previous_session = SimpleNamespace(
+            id="previous",
+            detached_window=None,
+        )
+
+        class Host(TabsMixin):
+            def __init__(self) -> None:
+                self.open_tabs = {session.id: session, previous_session.id: previous_session}
+                self.focused = None
+                self.removed = None
+                self.visible_sessions = [previous_session, session]
+
+            def visible_sessions_in_tab_order(self):
+                return self.visible_sessions
+
+            def remove_session_from_main_view(self, current_session) -> None:
+                self.removed = current_session
+
+            def focus_available_session_after_close(self, closed_id, previous_order) -> None:
+                self.focused = (closed_id, previous_order)
+
+            def update_session_tab_bar_visibility(self) -> None:
+                pass
+
+            def sync_window_title_with_visible_session(self) -> None:
+                pass
+
+        host = Host()
+        popover = FakePopover()
+        with patch("termia.tabs.Gtk.Window", FakeWindow):
+            host.detach_tab(popover, session)
+
+        self.assertTrue(popover.closed)
+        self.assertIs(host.removed, session)
+        self.assertEqual(host.focused, (session.id, [previous_session, session]))
+        self.assertIsInstance(session.detached_window, FakeWindow)
+        self.assertTrue(session.detached_window.presented)


### PR DESCRIPTION
## Summary
- Capture the visible tab order before detaching a tab.
- Pass that order to focus selection so the remaining tab can receive focus.
- Add a regression test covering the detach flow and update the manual checklist.

## Root cause
`detach_tab()` called `focus_available_session_after_close()` without its required `previous_order` argument, raising a `TypeError` before the new window was created.

## Tests
- `PYTHONPATH=src python3 -m unittest discover -s tests -v` (51 passed)
- `python3 -m py_compile src/termia/tabs.py tests/test_tabs.py`
- `git diff --check`

Closes #137