### PR TITLE
Refactor: inject terminal context-menu actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Changes merged after `0.5.0-beta` (2026-07-21 to 2026-07-23).
 
 ### Refactored
 
+- Pass terminal context-menu actions through an explicit callback contract composed by the application window.
 - Pass main-menu feature actions through an explicit callback contract composed by the application window.
 - Extract statistics dashboard metrics and ranking into an explicitly injected, GTK-independent presenter.
 - Extract connection-history filtering and display formatting into an explicitly injected, GTK-independent presenter.

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ POT template, both PO catalogs, and the compiled MO files are synchronized.
 
 ```bash
 PYTHONPATH=src python3 -m unittest discover -s tests -v
-python3 -m py_compile run_termia.py scripts/compile_translations.py src/termia/app.py src/termia/asbru_import.py src/termia/config_actions.py src/termia/config_io.py src/termia/connection_dialogs.py src/termia/connection_utils.py src/termia/constants.py src/termia/i18n.py src/termia/keybindings.py src/termia/main_menu.py src/termia/models.py src/termia/preferences.py src/termia/sidebar.py src/termia/statistics_utils.py src/termia/statistics_view.py src/termia/stores.py src/termia/styles.py src/termia/tabs.py src/termia/terminal_sessions.py src/termia/terminal_config.py src/termia/ui_state.py
+python3 -m py_compile run_termia.py scripts/compile_translations.py src/termia/app.py src/termia/asbru_import.py src/termia/config_actions.py src/termia/config_io.py src/termia/connection_dialogs.py src/termia/connection_utils.py src/termia/constants.py src/termia/i18n.py src/termia/keybindings.py src/termia/main_menu.py src/termia/main_menu_actions.py src/termia/models.py src/termia/preferences.py src/termia/sidebar.py src/termia/statistics_utils.py src/termia/statistics_view.py src/termia/stores.py src/termia/styles.py src/termia/tabs.py src/termia/terminal_menu_actions.py src/termia/terminal_menus.py src/termia/terminal_sessions.py src/termia/terminal_config.py src/termia/ui_state.py
 bash -n scripts/termia-setup.sh
 ```
 

--- a/docs/REGRESSION_CHECKS.md
+++ b/docs/REGRESSION_CHECKS.md
@@ -147,6 +147,7 @@ Before merging changes that touch UI, terminals, tabs, or configuration, verify:
 - Close a tab and confirm focus moves to the next terminal.
 - Right-click a terminal and open the context menu.
 - From the terminal context menu, confirm the translated `Split` submenu appears above `Tab` and is separated by a thin divider.
+- Confirm terminal context-menu actions still work: disconnect, show status bar, copy, paste, terminal preferences, session statistics, file transfer, all split directions, and all Tab submenu actions.
 - Create split panes in all four directions and confirm each new pane opens a working shell.
 - Run `exit` inside a split pane and confirm only that pane disappears while the sibling pane keeps focus and remains usable.
 - Right-click a server/group in the tree and open the context menu.
@@ -170,7 +171,7 @@ Run at minimum:
 
 ```bash
 PYTHONPATH=src python3 -m unittest discover -s tests -v
-python3 -m py_compile run_termia.py scripts/compile_translations.py src/termia/app.py src/termia/asbru_import.py src/termia/config_actions.py src/termia/config_io.py src/termia/connection_dialogs.py src/termia/connection_utils.py src/termia/constants.py src/termia/i18n.py src/termia/keybindings.py src/termia/main_menu.py src/termia/main_menu_actions.py src/termia/models.py src/termia/preferences.py src/termia/sidebar.py src/termia/statistics_utils.py src/termia/statistics_view.py src/termia/stores.py src/termia/styles.py src/termia/tabs.py src/termia/terminal_sessions.py src/termia/terminal_config.py src/termia/ui_state.py
+python3 -m py_compile run_termia.py scripts/compile_translations.py src/termia/app.py src/termia/asbru_import.py src/termia/config_actions.py src/termia/config_io.py src/termia/connection_dialogs.py src/termia/connection_utils.py src/termia/constants.py src/termia/i18n.py src/termia/keybindings.py src/termia/main_menu.py src/termia/main_menu_actions.py src/termia/models.py src/termia/preferences.py src/termia/sidebar.py src/termia/statistics_utils.py src/termia/statistics_view.py src/termia/stores.py src/termia/styles.py src/termia/tabs.py src/termia/terminal_menu_actions.py src/termia/terminal_menus.py src/termia/terminal_sessions.py src/termia/terminal_config.py src/termia/ui_state.py
 bash -n scripts/termia-setup.sh
 scripts/compile_translations.py
 scripts/compile_translations.py --check

--- a/docs/WINDOW_MIXIN_CONTRACTS.md
+++ b/docs/WINDOW_MIXIN_CONTRACTS.md
@@ -135,13 +135,15 @@ security, and keybinding dialogs have comparatively small contracts.
 
 ### `TerminalMenusMixin`
 
-- Reads: `store`.
+- Reads: `store` and the explicitly composed `TerminalMenuActions` callback
+  set.
 - Window services: translation and context-menu construction.
-- Cross-mixin dependencies: session splitting and disconnection, file
-  transfer, tab duplication/renaming/closing, terminal copy/paste, preferences,
-  status visibility, and statistics.
-- Architectural note: like the main menu, it should eventually receive an
-  explicit set of actions.
+- Cross-mixin dependencies: none for action dispatch; session splitting and
+  disconnection, file transfer, tab operations, terminal copy/paste,
+  preferences, status visibility, and statistics are supplied as callbacks.
+- Extracted component: `TerminalMenuActions` defines the actions supplied by
+  the application composition root. The menu builder no longer discovers these
+  feature callbacks on the window.
 
 ### `TerminalSessionsMixin`
 
@@ -183,8 +185,8 @@ The principal cycles are:
    dialog parenting.
 2. Use the history and statistics presenters as the pattern for subsequent
    extractions with explicit providers and callbacks.
-3. Pass explicit action callbacks into menu builders. The main menu now uses
-   `MainMenuActions`; terminal menus remain to be converted.
+3. Pass explicit action callbacks into menu builders. The main menu uses
+   `MainMenuActions` and terminal context menus use `TerminalMenuActions`.
 4. Introduce a session registry that owns `open_tabs` and session lookup.
 5. Separate tab placement from session lifecycle using the registry and
    callbacks, then replace `TabsMixin`.

--- a/src/termia/app.py
+++ b/src/termia/app.py
@@ -36,6 +36,7 @@ from .statistics_view import StatisticsViewMixin
 from .styles import build_application_css
 from .tabs import TabsMixin
 from .terminal_menus import TerminalMenusMixin
+from .terminal_menu_actions import TerminalMenuActions
 from .terminal_sessions import TerminalSessionsMixin
 from .ui_state import RowObject, TerminalSession
 
@@ -107,6 +108,20 @@ class TermiaWindow(
             clear_config=self.on_request_clear_config,
             help=lambda: self.on_help(None),
             about=lambda: self.on_about(None),
+        )
+        self.terminal_menu_actions = TerminalMenuActions(
+            disconnect=self.disconnect_from_terminal_menu,
+            show_status_bar=self.show_session_status_bar_from_menu,
+            copy=self.copy_terminal_selection,
+            paste=self.paste_terminal_clipboard,
+            send_files=self.on_send_files_to_server,
+            configure=self.configure_terminal_from_menu,
+            session_statistics=self.show_session_statistics,
+            split=self.split_terminal_from_menu,
+            rename_tab=self.show_rename_tab_dialog,
+            duplicate_tab=self.duplicate_tab,
+            new_tab=self.new_tab_from_terminal_menu,
+            close_tab=self.close_tab_from_terminal_menu,
         )
         self.stats_save_id: int | None = None
         self.close_confirmation_pending = False

--- a/src/termia/terminal_menu_actions.py
+++ b/src/termia/terminal_menu_actions.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2026 Jordi Pons
+# SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from .models import Server
+from .ui_state import TerminalSession
+
+MenuPopover = object
+TerminalWidget = object
+
+
+@dataclass(frozen=True)
+class TerminalMenuActions:
+    """Callbacks exposed to terminal context menus by the composition root."""
+
+    disconnect: Callable[[MenuPopover, TerminalSession], None]
+    show_status_bar: Callable[[MenuPopover, TerminalSession], None]
+    copy: Callable[[MenuPopover, TerminalWidget], None]
+    paste: Callable[[MenuPopover, TerminalWidget], None]
+    send_files: Callable[[MenuPopover, Server], None]
+    configure: Callable[[MenuPopover], None]
+    session_statistics: Callable[[MenuPopover, TerminalSession], None]
+    split: Callable[[MenuPopover, TerminalSession, TerminalWidget, str], None]
+    rename_tab: Callable[[MenuPopover, TerminalSession], None]
+    duplicate_tab: Callable[[MenuPopover, TerminalSession], None]
+    new_tab: Callable[[MenuPopover], None]
+    close_tab: Callable[[MenuPopover, TerminalSession], None]

--- a/src/termia/terminal_menus.py
+++ b/src/termia/terminal_menus.py
@@ -13,6 +13,7 @@ from gi.repository import Gdk, GLib, Gtk, Vte
 
 from .connection_utils import find_server
 from .keybindings import keybinding_label
+from .terminal_menu_actions import TerminalMenuActions
 from .ui_state import TerminalSession
 
 
@@ -26,6 +27,7 @@ class TerminalMenusMixin:
         session: TerminalSession,
         terminal: Vte.Terminal,
     ) -> None:
+        actions: TerminalMenuActions = self.terminal_menu_actions
         popover = Gtk.Popover()
         popover.add_css_class("termia-menu-popover")
         popover.set_has_arrow(False)
@@ -46,22 +48,22 @@ class TerminalMenusMixin:
         menu.set_margin_end(6)
         active_submenu: dict[str, Gtk.Popover | None] = {"popover": None}
         popover.connect("closed", lambda *_args: self.close_active_terminal_submenu(active_submenu))
-        self.add_context_menu_item(menu, self.t("disconnect"), lambda: self.disconnect_from_terminal_menu(popover, session))
+        self.add_context_menu_item(menu, self.t("disconnect"), lambda: actions.disconnect(popover, session))
         if not session.status_bar.get_visible():
             self.add_context_menu_item(
-                menu, self.t("show_session_status_bar"), lambda: self.show_session_status_bar_from_menu(popover, session)
+                menu, self.t("show_session_status_bar"), lambda: actions.show_status_bar(popover, session)
             )
         self.add_terminal_shortcut_menu_item(
             menu,
             self.t("copy"),
             self.store.data.app.keybindings.get("copy", ""),
-            lambda: self.copy_terminal_selection(popover, terminal),
+            lambda: actions.copy(popover, terminal),
         )
         self.add_terminal_shortcut_menu_item(
             menu,
             self.t("paste"),
             self.store.data.app.keybindings.get("paste", ""),
-            lambda: self.paste_terminal_clipboard(popover, terminal),
+            lambda: actions.paste(popover, terminal),
         )
         if session.server_id is not None:
             server = find_server(self.store.data.servers, session.server_id)
@@ -69,13 +71,13 @@ class TerminalMenusMixin:
                 self.add_context_menu_item(
                     menu,
                     self.t("send_files_to_server"),
-                    lambda: self.on_send_files_to_server(popover, server),
+                    lambda: actions.send_files(popover, server),
                 )
-        self.add_context_menu_item(menu, self.t("configure_terminal"), lambda: self.configure_terminal_from_menu(popover))
-        self.add_context_menu_item(menu, self.t("session_statistics"), lambda: self.show_session_statistics(popover, session))
+        self.add_context_menu_item(menu, self.t("configure_terminal"), lambda: actions.configure(popover))
+        self.add_context_menu_item(menu, self.t("session_statistics"), lambda: actions.session_statistics(popover, session))
         self.add_context_menu_separator(menu)
-        self.add_terminal_split_menu(menu, popover, session, terminal, active_submenu)
-        self.add_terminal_tab_menu(menu, popover, session, active_submenu)
+        self.add_terminal_split_menu(menu, popover, session, terminal, active_submenu, actions)
+        self.add_terminal_tab_menu(menu, popover, session, active_submenu, actions)
         popover.set_child(menu)
         popover.popup()
 
@@ -116,12 +118,13 @@ class TerminalMenusMixin:
         session: TerminalSession,
         terminal: Vte.Terminal,
         active_submenu: dict[str, Gtk.Popover | None],
+        actions: TerminalMenuActions,
     ) -> None:
         submenu_items = [
-            (self.t("split_up"), lambda: self.split_terminal_from_menu(parent_popover, session, terminal, "up")),
-            (self.t("split_down"), lambda: self.split_terminal_from_menu(parent_popover, session, terminal, "down")),
-            (self.t("split_right"), lambda: self.split_terminal_from_menu(parent_popover, session, terminal, "right")),
-            (self.t("split_left"), lambda: self.split_terminal_from_menu(parent_popover, session, terminal, "left")),
+            (self.t("split_up"), lambda: actions.split(parent_popover, session, terminal, "up")),
+            (self.t("split_down"), lambda: actions.split(parent_popover, session, terminal, "down")),
+            (self.t("split_right"), lambda: actions.split(parent_popover, session, terminal, "right")),
+            (self.t("split_left"), lambda: actions.split(parent_popover, session, terminal, "left")),
         ]
         self.add_terminal_nested_menu(menu, self.t("split"), submenu_items, active_submenu)
 
@@ -131,12 +134,13 @@ class TerminalMenusMixin:
         parent_popover: Gtk.Popover,
         session: TerminalSession,
         active_submenu: dict[str, Gtk.Popover | None],
+        actions: TerminalMenuActions,
     ) -> None:
         submenu_items = [
-            (self.t("rename_tab"), lambda: self.show_rename_tab_dialog(parent_popover, session)),
-            (self.t("duplicate_tab"), lambda: self.duplicate_tab(parent_popover, session)),
-            (self.t("new_tab"), lambda: self.new_tab_from_terminal_menu(parent_popover)),
-            (self.t("close_tab"), lambda: self.close_tab_from_terminal_menu(parent_popover, session)),
+            (self.t("rename_tab"), lambda: actions.rename_tab(parent_popover, session)),
+            (self.t("duplicate_tab"), lambda: actions.duplicate_tab(parent_popover, session)),
+            (self.t("new_tab"), lambda: actions.new_tab(parent_popover)),
+            (self.t("close_tab"), lambda: actions.close_tab(parent_popover, session)),
         ]
         self.add_terminal_nested_menu(menu, self.t("tab"), submenu_items, active_submenu)
 

--- a/tests/test_terminal_menu_actions.py
+++ b/tests/test_terminal_menu_actions.py
@@ -1,0 +1,61 @@
+import unittest
+
+from termia.terminal_menu_actions import TerminalMenuActions
+
+
+class TerminalMenuActionsTests(unittest.TestCase):
+    def test_each_explicit_action_dispatches_to_its_callback(self) -> None:
+        calls = []
+
+        def action(name):
+            return lambda *args: calls.append((name, args))
+
+        actions = TerminalMenuActions(
+            disconnect=action("disconnect"),
+            show_status_bar=action("show_status_bar"),
+            copy=action("copy"),
+            paste=action("paste"),
+            send_files=action("send_files"),
+            configure=action("configure"),
+            session_statistics=action("session_statistics"),
+            split=action("split"),
+            rename_tab=action("rename_tab"),
+            duplicate_tab=action("duplicate_tab"),
+            new_tab=action("new_tab"),
+            close_tab=action("close_tab"),
+        )
+        popover = object()
+        session = object()
+        terminal = object()
+        server = object()
+
+        actions.disconnect(popover, session)
+        actions.show_status_bar(popover, session)
+        actions.copy(popover, terminal)
+        actions.paste(popover, terminal)
+        actions.send_files(popover, server)
+        actions.configure(popover)
+        actions.session_statistics(popover, session)
+        actions.split(popover, session, terminal, "left")
+        actions.rename_tab(popover, session)
+        actions.duplicate_tab(popover, session)
+        actions.new_tab(popover)
+        actions.close_tab(popover, session)
+
+        self.assertEqual(
+            [name for name, _args in calls],
+            [
+                "disconnect",
+                "show_status_bar",
+                "copy",
+                "paste",
+                "send_files",
+                "configure",
+                "session_statistics",
+                "split",
+                "rename_tab",
+                "duplicate_tab",
+                "new_tab",
+                "close_tab",
+            ],
+        )


### PR DESCRIPTION
## Summary
- Introduce an explicit TerminalMenuActions callback contract.
- Compose terminal context-menu actions in TermiaWindow.
- Preserve the current menu labels, shortcuts, Split and Tab submenu ordering, hover behavior, and action targets.
- Add contract coverage and update architecture, regression, and validation documentation.

## Tests
- `PYTHONPATH=src python3 -m unittest discover -s tests -v` (54 passed)
- Python syntax checks for the touched modules pass.
- `scripts/compile_translations.py --check`
- `git diff --check`

## Manual verification
Test terminal context-menu actions, the Split submenu in all directions, and Tab submenu actions for local and SSH sessions where available.

Closes #139