### PR TITLE
feat: close tabs with middle click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changes merged after `0.5.0-beta` (2026-07-21 to 2026-07-23).
 
 ### Added
 
+- Close tabs with a middle mouse click (`#141`).
 - Add an opt-in Debug mode in General preferences and a `--debug` launcher option for GTK/VTE rendering, storage-lock, encryption, and read-only diagnostics.
 - Add a keyboard shortcut to focus the server filter (`#96`).
 - Add keyboard navigation shortcuts for the sidebar and tabs (`#98`, `#100`).

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Roadmap: [ROADMAP.md](ROADMAP.md)
 - Filter servers with `Ctrl+F` and open multiple tabbed sessions to the same host.
 - Reopen the 10 most recently connected servers from a Recent section above Favorites, without duplicates.
 - Mark servers as favorites and jump to them from a dedicated section in the sidebar.
-- Use embedded, width-sharing tabs and move a tab to a separate window.
+- Use embedded, width-sharing tabs, close tabs with a middle mouse click, and move a tab to a separate window.
 - Create and open configurable local terminal profiles from the sidebar.
 - Split a terminal tab into multiple panes from the terminal context menu.
 - Configure basic split layouts per SSH server or local terminal profile.

--- a/docs/README.ca.md
+++ b/docs/README.ca.md
@@ -13,7 +13,7 @@ Documentació en castellà: [README.es.md](README.es.md)
   privada.
 - Filtrar servidors amb `Ctrl+F` i obrir diverses sessions al mateix host en pestanyes.
 - Reobrir els 10 servidors connectats més recentment des d'una secció Recent a sobre de Favorites, sense duplicats.
-- Usar pestanyes incrustades que reparteixen l'amplada disponible i moure una pestanya a una finestra independent.
+- Usar pestanyes incrustades que reparteixen l'amplada disponible, tancar-les amb el clic central i moure una pestanya a una finestra independent.
 - Crear i obrir perfils configurables de terminal local des de la barra lateral.
 - Dividir una pestanya de terminal en diversos panells des del menú contextual del terminal.
 - Configurar dissenys bàsics de divisió per a cada servidor SSH o perfil de terminal local.

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -13,7 +13,7 @@ Documentación en catalán: [README.ca.md](README.ca.md)
   clave privada.
 - Filtrar servidores con `Ctrl+F` y abrir varias sesiones al mismo host en pestañas.
 - Reabrir los 10 servidores conectados más recientemente desde una sección Recent encima de Favorites, sin duplicados.
-- Usar pestañas embebidas que reparten el ancho disponible y mover una pestaña a una ventana independiente.
+- Usar pestañas embebidas que reparten el ancho disponible, cerrarlas con clic central y mover una pestaña a una ventana independiente.
 - Crear y abrir perfiles configurables de terminal local desde la barra lateral.
 - Dividir una pestaña de terminal en varios paneles desde el menú contextual del terminal.
 - Configurar diseños básicos de división por cada servidor SSH o perfil de terminal local.

--- a/docs/REGRESSION_CHECKS.md
+++ b/docs/REGRESSION_CHECKS.md
@@ -145,6 +145,7 @@ Before merging changes that touch UI, terminals, tabs, or configuration, verify:
 - Duplicate a local terminal and confirm the custom prompt is applied.
 - Open two SSH sessions and duplicate one of them.
 - Close a tab and confirm focus moves to the next terminal.
+- Middle-click a tab and confirm it follows the configured close confirmation and moves focus to the next terminal.
 - Right-click a terminal and open the context menu.
 - From the terminal context menu, confirm the translated `Split` submenu appears above `Tab` and is separated by a thin divider.
 - Confirm terminal context-menu actions still work: disconnect, show status bar, copy, paste, terminal preferences, session statistics, file transfer, all split directions, and all Tab submenu actions.

--- a/src/termia/tabs.py
+++ b/src/termia/tabs.py
@@ -134,6 +134,10 @@ class TabsMixin:
         left_click.set_button(1)
         left_click.connect("pressed", self.on_tab_left_press, session_id)
         box.add_controller(left_click)
+        middle_click = Gtk.GestureClick.new()
+        middle_click.set_button(2)
+        middle_click.connect("pressed", self.on_tab_middle_press, session_id, page)
+        box.add_controller(middle_click)
         drag_source = Gtk.DragSource.new()
         drag_source.set_actions(Gdk.DragAction.MOVE)
         drag_source.connect("prepare", self.on_tab_drag_prepare, session_id, box)
@@ -157,6 +161,17 @@ class TabsMixin:
         session_id: str,
     ) -> None:
         self.set_active_session(session_id)
+
+    def on_tab_middle_press(
+        self,
+        _gesture: Gtk.GestureClick,
+        _n_press: int,
+        _x: float,
+        _y: float,
+        session_id: str,
+        page: Gtk.Widget,
+    ) -> None:
+        self.request_close_tab(session_id, page)
 
     def on_tab_drag_prepare(
         self,
@@ -339,6 +354,9 @@ class TabsMixin:
         dialog.destroy()
 
     def on_request_close_tab(self, _button: Gtk.Button, session_id: str, page: Gtk.Widget) -> None:
+        self.request_close_tab(session_id, page)
+
+    def request_close_tab(self, session_id: str, page: Gtk.Widget) -> None:
         session = self.open_tabs.get(session_id)
         if session and session.page == page and session.connected:
             if not self.store.data.app.confirm_disconnect:

--- a/tests/test_tabs.py
+++ b/tests/test_tabs.py
@@ -79,3 +79,20 @@ class DetachTabTests(unittest.TestCase):
         self.assertEqual(host.focused, (session.id, [previous_session, session]))
         self.assertIsInstance(session.detached_window, FakeWindow)
         self.assertTrue(session.detached_window.presented)
+
+
+class MiddleClickTabTests(unittest.TestCase):
+    def test_middle_click_requests_tab_close(self) -> None:
+        page = object()
+
+        class Host(TabsMixin):
+            def __init__(self) -> None:
+                self.closed = None
+
+            def request_close_tab(self, session_id, clicked_page) -> None:
+                self.closed = (session_id, clicked_page)
+
+        host = Host()
+        host.on_tab_middle_press(None, 1, 0.0, 0.0, "session", page)
+
+        self.assertEqual(host.closed, ("session", page))


### PR DESCRIPTION
## Summary
- close a tab by middle-clicking its tab label
- reuse the existing close flow so configured disconnect confirmations remain effective
- document the gesture and add regression coverage

Closes #141

## Validation
-  (55 tests)
- full Python syntax compilation
- 
- translation catalogs are synchronized (280 messages)

## Manual verification
- pending GTK interaction check: middle-click an SSH and a local terminal tab, including the confirmation-enabled case.