### PR TITLE
refactor: compose statistics dialog explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Changes merged after `0.5.0-beta` (2026-07-21 to 2026-07-23).
 
 ### Refactored
 
+- Replace the statistics view mixin with an explicitly composed statistics dialog.
 - Pass terminal context-menu actions through an explicit callback contract composed by the application window.
 - Pass main-menu feature actions through an explicit callback contract composed by the application window.
 - Extract statistics dashboard metrics and ranking into an explicitly injected, GTK-independent presenter.

--- a/docs/WINDOW_MIXIN_CONTRACTS.md
+++ b/docs/WINDOW_MIXIN_CONTRACTS.md
@@ -123,14 +123,13 @@ security, and keybinding dialogs have comparatively small contracts.
   formatting. It receives only an entries provider and translation callback;
   the mixin retains GTK dialog and row construction.
 
-### `StatisticsViewMixin`
+### `StatisticsDialog`
 
-- Reads: the explicitly composed `statistics_presenter`.
-- Window services: translation and dialog buttons.
-- Cross-mixin dependencies: none beyond those common services.
-- Extracted component: `StatisticsPresenter` owns card metrics, duration
-  formatting, current-run values, and server ranking. It receives statistics,
-  servers, current-run, and translation providers; the mixin retains GTK
+- Composed explicitly with a GTK parent, `StatisticsPresenter`, and
+  translation callback; it does not receive `TermiaWindow`.
+- Cross-mixin dependencies: none.
+- `StatisticsPresenter` owns card metrics, duration formatting, current-run
+  values, and server ranking. `StatisticsDialog` owns only GTK dialog and
   widget construction.
 
 ### `TerminalMenusMixin`
@@ -183,8 +182,8 @@ The principal cycles are:
 
 1. Define a small host interface for translation, feedback, writability, and
    dialog parenting.
-2. Use the history and statistics presenters as the pattern for subsequent
-   extractions with explicit providers and callbacks.
+2. Use the extracted `StatisticsDialog` and the history presenter as the
+   pattern for subsequent extractions with explicit providers and callbacks.
 3. Pass explicit action callbacks into menu builders. The main menu uses
    `MainMenuActions` and terminal context menus use `TerminalMenuActions`.
 4. Introduce a session registry that owns `open_tabs` and session lookup.

--- a/src/termia/app.py
+++ b/src/termia/app.py
@@ -32,7 +32,7 @@ from .preferences import PreferencesMixin
 from .stores import ConnectionStore
 from .sidebar import SidebarMixin
 from .statistics_presenter import StatisticsPresenter
-from .statistics_view import StatisticsViewMixin
+from .statistics_view import StatisticsDialog
 from .styles import build_application_css
 from .tabs import TabsMixin
 from .terminal_menus import TerminalMenusMixin
@@ -48,7 +48,6 @@ class TermiaWindow(
     PreferencesMixin,
     SidebarMixin,
     ConnectionHistoryViewMixin,
-    StatisticsViewMixin,
     TerminalMenusMixin,
     TerminalSessionsMixin,
     TabsMixin,
@@ -93,13 +92,14 @@ class TermiaWindow(
             lambda: self.run_connections,
             self.t,
         )
+        self.statistics_dialog = StatisticsDialog(self, self.statistics_presenter, self.t)
         self.main_menu_actions = MainMenuActions(
             general_preferences=lambda: self.on_app_preferences(None),
             terminal_settings=lambda: self.on_terminal_settings(None),
             prompt_settings=lambda: self.on_prompt_settings(None),
             keybinding_settings=lambda: self.on_keybindings_settings(None),
             security_settings=lambda: self.on_security_settings(None),
-            statistics=lambda: self.on_statistics_dashboard(None),
+            statistics=self.statistics_dialog.show,
             connection_history=lambda: self.on_connection_history(None),
             data_locations=self.on_data_locations,
             export_config=self.on_export_config,

--- a/src/termia/statistics_view.py
+++ b/src/termia/statistics_view.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
+from collections.abc import Callable
+
 import gi
 
 gi.require_version("Gtk", "4.0")
@@ -10,12 +12,26 @@ from gi.repository import Gtk
 from .statistics_presenter import StatisticCard, StatisticsDashboard
 
 
-class StatisticsViewMixin:
-    def on_statistics_dashboard(self, _button: Gtk.Button) -> None:
-        dialog = Gtk.Dialog(title=self.t("statistics_title"), transient_for=self, modal=True)
+class StatisticsDialog:
+    """Builds the statistics dialog from explicit GTK and presentation dependencies."""
+
+    def __init__(
+        self,
+        parent: Gtk.Window,
+        presenter: StatisticsPresenter,
+        translate: Callable[[str], str],
+    ) -> None:
+        self.parent = parent
+        self.presenter = presenter
+        self.translate = translate
+
+    def show(self) -> None:
+        dialog = Gtk.Dialog(title=self.translate("statistics_title"), transient_for=self.parent, modal=True)
         dialog.set_resizable(True)
         dialog.set_default_size(620, 520)
-        self.add_dialog_action_button(dialog, self.t("close"), Gtk.ResponseType.CLOSE, last=True)
+        close_button = dialog.add_button(self.translate("close"), Gtk.ResponseType.CLOSE)
+        close_button.set_margin_end(12)
+        close_button.set_margin_bottom(12)
 
         content = dialog.get_content_area()
         content.set_margin_top(16)
@@ -31,7 +47,7 @@ class StatisticsViewMixin:
         scroller.set_child(dashboard)
         content.append(scroller)
 
-        presentation = self.statistics_presenter.dashboard()
+        presentation = self.presenter.dashboard()
         cards = Gtk.Grid()
         cards.set_column_spacing(10)
         cards.set_row_spacing(10)
@@ -47,7 +63,7 @@ class StatisticsViewMixin:
             card.set_hexpand(True)
         dashboard.append(cards)
 
-        title = Gtk.Label(label=self.t("top_servers"))
+        title = Gtk.Label(label=self.translate("top_servers"))
         title.set_xalign(0)
         title.add_css_class("heading")
         dashboard.append(title)
@@ -88,7 +104,7 @@ class StatisticsViewMixin:
         list_box.set_selection_mode(Gtk.SelectionMode.NONE)
         if not presentation.top_servers:
             row = Gtk.ListBoxRow()
-            label = Gtk.Label(label=self.t("no_statistics"))
+            label = Gtk.Label(label=self.translate("no_statistics"))
             label.set_xalign(0)
             label.set_margin_top(8)
             label.set_margin_bottom(8)

--- a/tests/test_statistics_view.py
+++ b/tests/test_statistics_view.py
@@ -1,0 +1,16 @@
+import unittest
+
+from termia.statistics_view import StatisticsDialog
+
+
+class StatisticsDialogTests(unittest.TestCase):
+    def test_accepts_only_explicit_view_dependencies(self) -> None:
+        parent = object()
+        presenter = object()
+        translate = lambda key: key
+
+        dialog = StatisticsDialog(parent, presenter, translate)
+
+        self.assertIs(dialog.parent, parent)
+        self.assertIs(dialog.presenter, presenter)
+        self.assertIs(dialog.translate, translate)


### PR DESCRIPTION
## Summary
- replace StatisticsViewMixin with an explicitly composed StatisticsDialog
- inject only the GTK parent, statistics presenter, and translation callback
- document the reduced window contract and add a focused dependency test

## Validation
- full test suite: 56 tests passed
- full Python syntax compilation
- bash syntax check for scripts/termia-setup.sh
- translation catalog consistency check

## Manual verification
- open Statistics from the main menu and confirm the dashboard cards, rankings, scroll behavior, and Close action are unchanged.