### PR TITLE
fix: terminate terminal process groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Changes merged after `0.5.0-beta` (2026-07-21 to 2026-07-23).
 
 ### Fixed
 
+- Terminate isolated VTE process groups when disconnecting sessions or closing Termia to avoid orphaned terminal and SSH children (`#148`).
 - Keep Debug output in Termia's state log instead of forwarding it to stderr/syslog, and show its path in the Debug preference tooltip.
 - Fix moving a tab to a new window by preserving the previous tab order when selecting the next focused session.
 - Reset the main menu to its top-level view after closing the Import/Export submenu.

--- a/docs/REGRESSION_CHECKS.md
+++ b/docs/REGRESSION_CHECKS.md
@@ -52,6 +52,7 @@ Protected behavior does not mean the code cannot change. It means regressions sh
 - Exiting a local shell must follow the configured local terminal close behavior.
 - Exiting a split shell with `exit` must remove only that split pane and keep sibling panes usable.
 - When close-on-exit is enabled, a split tab must close after the last pane exits regardless of whether the original terminal or a split exits last.
+- Closing Termia must terminate every process group in the isolated VTE session for active SSH, local-terminal, and split-pane sessions without signalling unrelated processes.
 
 ### Focus and Keyboard
 
@@ -151,6 +152,7 @@ Before merging changes that touch UI, terminals, tabs, or configuration, verify:
 - Confirm terminal context-menu actions still work: disconnect, show status bar, copy, paste, terminal preferences, session statistics, file transfer, all split directions, and all Tab submenu actions.
 - Create split panes in all four directions and confirm each new pane opens a working shell.
 - Run `exit` inside a split pane and confirm only that pane disappears while the sibling pane keeps focus and remains usable.
+- Open an SSH session, a local terminal, and a split pane; close Termia and confirm their local child processes do not remain after a brief grace period.
 - Right-click a server/group in the tree and open the context menu.
 - Edit a server and confirm collapsed groups stay collapsed.
 - Search for a group, subgroup, and server in the sidebar filter.

--- a/src/termia/app.py
+++ b/src/termia/app.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 import argparse
 import logging
+import signal
 
 import gi
 
@@ -125,8 +126,11 @@ class TermiaWindow(
         )
         self.stats_save_id: int | None = None
         self.close_confirmation_pending = False
+        self.shutdown_in_progress = False
         self.connect("close-request", self.on_main_window_close_request)
         self.connect("destroy", lambda *_args: self.store.close())
+        if hasattr(GLib, "unix_signal_add"):
+            GLib.unix_signal_add(GLib.PRIORITY_DEFAULT, signal.SIGTERM, self.on_unix_termination_signal)
 
         self.toast_label = Gtk.Label()
         self.toast_label.add_css_class("dim-label")
@@ -239,10 +243,11 @@ class TermiaWindow(
         password_entry.grab_focus()
 
     def on_main_window_close_request(self, _window: Gtk.Window) -> bool:
-        if not self.store.data.app.confirm_close_app:
-            self.save_history_before_close()
-            self.save_statistics_before_close()
+        if self.shutdown_in_progress:
             return False
+        if not self.store.data.app.confirm_close_app:
+            self.begin_main_window_shutdown()
+            return True
         if self.close_confirmation_pending:
             return True
         self.close_confirmation_pending = True
@@ -262,11 +267,27 @@ class TermiaWindow(
         except GLib.Error:
             return
         if response == 1:
-            self.save_history_before_close()
-            self.save_statistics_before_close()
-            application = self.get_application()
-            if application is not None:
-                application.quit()
+            self.begin_main_window_shutdown()
+
+    def on_unix_termination_signal(self) -> bool:
+        self.begin_main_window_shutdown()
+        return GLib.SOURCE_REMOVE
+
+    def begin_main_window_shutdown(self) -> None:
+        if self.shutdown_in_progress:
+            return
+        self.shutdown_in_progress = True
+        self.save_history_before_close()
+        self.save_statistics_before_close()
+        self.terminate_open_terminal_processes()
+        GLib.timeout_add(500, self.finish_main_window_shutdown)
+
+    def finish_main_window_shutdown(self) -> bool:
+        self.terminate_open_terminal_processes(force=True)
+        application = self.get_application()
+        if application is not None:
+            application.quit()
+        return GLib.SOURCE_REMOVE
 
     def apply_app_theme(self) -> None:
         settings = Gtk.Settings.get_default()

--- a/src/termia/terminal_processes.py
+++ b/src/termia/terminal_processes.py
@@ -3,10 +3,112 @@
 # This file is distributed under the terms of the GNU General Public License.
 from __future__ import annotations
 
+import os
+import signal
+from dataclasses import dataclass
+from pathlib import Path
+
 import gi
 
 gi.require_version("Vte", "3.91")
 from gi.repository import GLib, Vte
+
+
+@dataclass(frozen=True)
+class TerminalProcess:
+    """Identity captured for a VTE child and its isolated process group."""
+
+    pid: int
+    process_group_id: int | None
+    session_id: int | None
+    start_time: str | None
+
+
+def process_start_time(pid: int) -> str | None:
+    """Return the Linux process start time, used to reject a reused PID."""
+    try:
+        stat = Path(f"/proc/{pid}/stat").read_text(encoding="utf-8")
+    except OSError:
+        return None
+    _prefix, separator, fields = stat.rpartition(")")
+    if not separator:
+        return None
+    values = fields.split()
+    return values[19] if len(values) > 19 else None
+
+
+def process_group_and_session(pid: int) -> tuple[int, int] | None:
+    try:
+        stat = Path(f"/proc/{pid}/stat").read_text(encoding="utf-8")
+    except OSError:
+        return None
+    _prefix, separator, fields = stat.rpartition(")")
+    if not separator:
+        return None
+    values = fields.split()
+    if len(values) < 4:
+        return None
+    return int(values[2]), int(values[3])
+
+
+def process_groups_in_session(session_id: int) -> set[int]:
+    groups: set[int] = set()
+    try:
+        candidates = Path("/proc").iterdir()
+    except OSError:
+        return groups
+    for candidate in candidates:
+        if not candidate.name.isdigit():
+            continue
+        identity = process_group_and_session(int(candidate.name))
+        if identity is not None and identity[1] == session_id:
+            groups.add(identity[0])
+    return groups
+
+
+def capture_terminal_process(pid: int) -> TerminalProcess:
+    try:
+        process_group_id = os.getpgid(pid)
+    except OSError:
+        process_group_id = None
+    if process_group_id == os.getpgrp():
+        process_group_id = None
+    try:
+        session_id = os.getsid(pid)
+    except OSError:
+        session_id = None
+    if session_id == os.getsid(0):
+        session_id = None
+    return TerminalProcess(pid, process_group_id, session_id, process_start_time(pid))
+
+
+def signal_terminal_process(process: TerminalProcess, signum: int) -> bool:
+    """Signal every process group in an isolated VTE session when available."""
+    if process.session_id is not None:
+        groups = process_groups_in_session(process.session_id)
+        if groups:
+            signalled = False
+            for process_group_id in groups:
+                if process_group_id == os.getpgrp():
+                    continue
+                try:
+                    os.killpg(process_group_id, signum)
+                except (ProcessLookupError, PermissionError, OSError):
+                    continue
+                signalled = True
+            if signalled:
+                return True
+    current_start_time = process_start_time(process.pid)
+    if process.start_time is not None and current_start_time != process.start_time:
+        return False
+    try:
+        if process.process_group_id is not None and os.getpgid(process.pid) == process.process_group_id:
+            os.killpg(process.process_group_id, signum)
+        else:
+            os.kill(process.pid, signum)
+    except (ProcessLookupError, PermissionError, OSError):
+        return False
+    return True
 
 
 def spawn_terminal_process(
@@ -14,7 +116,7 @@ def spawn_terminal_process(
     working_directory: str | None,
     command: list[str],
     environment: list[str],
-) -> int:
+) -> TerminalProcess:
     _ok, child_pid = terminal.spawn_sync(
         Vte.PtyFlags.DEFAULT,
         working_directory,
@@ -25,4 +127,4 @@ def spawn_terminal_process(
         None,
         None,
     )
-    return child_pid
+    return capture_terminal_process(child_pid)

--- a/src/termia/terminal_sessions.py
+++ b/src/termia/terminal_sessions.py
@@ -31,7 +31,7 @@ from .terminal_config import (
     build_terminal_environment,
     split_layout_plan,
 )
-from .terminal_processes import spawn_terminal_process
+from .terminal_processes import TerminalProcess, signal_terminal_process, spawn_terminal_process
 from .terminal_view import TerminalViewFactory
 from .ui_state import TerminalSession
 
@@ -203,7 +203,7 @@ class TerminalSessionsMixin:
         terminal.grab_focus()
         self.store.record_history_start(session, "local")
         try:
-            child_pid = spawn_terminal_process(
+            child_process = spawn_terminal_process(
                 terminal,
                 working_directory,
                 command,
@@ -222,11 +222,12 @@ class TerminalSessionsMixin:
             self.update_session_tab_title(session, self.t("tab_error_title").format(title=session.title))
             self.toast_label.set_label(message)
             return
-        session.child_pid = child_pid
+        session.child_process = child_process
+        session.child_pid = child_process.pid
         self.update_local_session_directory_title(session)
         session.timeout_id = GLib.timeout_add_seconds(1, self.update_session_timer, session)
         terminal.connect("child-exited", self.on_process_terminal_exited, session)
-        session.status_label.set_label(f"{title} · PID {child_pid}")
+        session.status_label.set_label(f"{title} · PID {child_process.pid}")
         self.apply_split_layout(session, split_layout, fallback_working_directory=working_directory)
         if initial_command.strip():
             GLib.timeout_add(INITIAL_LOCAL_COMMAND_DELAY_MS, self.feed_initial_local_command, terminal, initial_command.strip())
@@ -275,6 +276,7 @@ class TerminalSessionsMixin:
         session.disconnect_requested = False
         session.pending_reconnect = False
         session.child_pid = None
+        session.child_process = None
         session.connected = True
         session.disconnect_button.set_sensitive(True)
         session.status_label.set_label(self.t("connecting"))
@@ -311,7 +313,7 @@ class TerminalSessionsMixin:
         terminal.feed(f"{self.t('ssh_connecting_command').format(command=' '.join(command))}\r\n\r\n".encode())
         terminal.grab_focus()
         try:
-            child_pid = spawn_terminal_process(terminal, None, command, envv)
+            child_process = spawn_terminal_process(terminal, None, command, envv)
         except GLib.Error as exc:
             message = self.t("ssh_start_failed").format(error=exc.message)
             terminal.feed(f"{message}\r\n".encode())
@@ -320,11 +322,12 @@ class TerminalSessionsMixin:
             self.mark_session_for_reconnect(session, server, self.t("ssh_start_failed_toast").format(name=server.name))
             return
 
-        session.child_pid = child_pid
+        session.child_process = child_process
+        session.child_pid = child_process.pid
         session.timeout_id = GLib.timeout_add_seconds(1, self.update_session_timer, session)
         terminal.connect("child-exited", self.on_terminal_exited, server, session)
         self.record_connection(server.id)
-        session.status_label.set_label(f"{server.name} · PID {child_pid}")
+        session.status_label.set_label(f"{server.name} · PID {child_process.pid}")
         self.apply_split_layout(session, split_layout, server=server)
         self.toast_label.set_label(self.t("session_opened").format(title=session.title))
 
@@ -674,7 +677,7 @@ class TerminalSessionsMixin:
                 command = build_local_prompt_shell_command(self.store.data.terminal, bash_path)
         working_directory = self.local_terminal_working_directory(source_terminal, fallback_working_directory)
         try:
-            child_pid = spawn_terminal_process(
+            child_process = spawn_terminal_process(
                 terminal,
                 working_directory,
                 command,
@@ -685,7 +688,8 @@ class TerminalSessionsMixin:
             terminal.feed(f"{message}\r\n".encode())
             self.toast_label.set_label(message)
             return
-        session.split_child_pids[id(terminal)] = child_pid
+        session.split_child_pids[id(terminal)] = child_process.pid
+        session.split_processes[id(terminal)] = child_process
         terminal.connect("child-exited", self.on_split_terminal_exited, session)
 
     def start_ssh_split_terminal(
@@ -722,13 +726,14 @@ class TerminalSessionsMixin:
             command = build_ssh_command(server, ssh_path)
         terminal.feed(f"{self.t('ssh_connecting_command').format(command=' '.join(command))}\r\n\r\n".encode())
         try:
-            child_pid = spawn_terminal_process(terminal, None, command, envv)
+            child_process = spawn_terminal_process(terminal, None, command, envv)
         except GLib.Error as exc:
             message = self.t("ssh_start_failed").format(error=exc.message)
             terminal.feed(f"{message}\r\n".encode())
             self.toast_label.set_label(self.t("ssh_start_failed_toast").format(name=server.name))
             return
-        session.split_child_pids[id(terminal)] = child_pid
+        session.split_child_pids[id(terminal)] = child_process.pid
+        session.split_processes[id(terminal)] = child_process
         terminal.connect("child-exited", self.on_split_terminal_exited, session)
         self.record_connection(server.id)
         if announce:
@@ -750,6 +755,7 @@ class TerminalSessionsMixin:
 
     def on_split_terminal_exited(self, terminal: Vte.Terminal, _status: int, session: TerminalSession) -> None:
         session.split_child_pids.pop(id(terminal), None)
+        session.split_processes.pop(id(terminal), None)
         self.mark_terminal_inactive(terminal, session)
         if terminal in session.split_terminals:
             session.split_terminals.remove(terminal)
@@ -937,14 +943,28 @@ class TerminalSessionsMixin:
         return GLib.SOURCE_CONTINUE
 
     def terminate_split_processes(self, session: TerminalSession) -> None:
-        for child_pid in tuple(session.split_child_pids.values()):
-            try:
-                os.kill(child_pid, signal.SIGTERM)
-            except ProcessLookupError:
-                pass
-            except PermissionError:
-                pass
+        for process in tuple(session.split_processes.values()):
+            self.terminate_terminal_process(process)
         session.split_child_pids.clear()
+        session.split_processes.clear()
+
+    def terminate_terminal_process(self, process: TerminalProcess, *, force: bool = False) -> bool:
+        signum = signal.SIGKILL if force else signal.SIGTERM
+        terminated = signal_terminal_process(process, signum)
+        if terminated and not force:
+            GLib.timeout_add(500, self.force_terminate_terminal_process, process)
+        return terminated
+
+    def force_terminate_terminal_process(self, process: TerminalProcess) -> bool:
+        self.terminate_terminal_process(process, force=True)
+        return GLib.SOURCE_REMOVE
+
+    def terminate_open_terminal_processes(self, *, force: bool = False) -> None:
+        for session in tuple(self.open_tabs.values()):
+            if session.child_process is not None:
+                self.terminate_terminal_process(session.child_process, force=force)
+            for process in tuple(session.split_processes.values()):
+                self.terminate_terminal_process(process, force=force)
 
     def on_request_disconnect_session(self, _button: Gtk.Button, session: TerminalSession) -> None:
         if not session.connected:
@@ -964,16 +984,11 @@ class TerminalSessionsMixin:
         if not session.connected:
             return
         session.disconnect_requested = True
-        if session.child_pid is not None:
-            try:
-                os.kill(session.child_pid, signal.SIGTERM)
-            except ProcessLookupError:
-                pass
-            except PermissionError:
-                message = self.t("sigterm_failed")
-                session.terminal.feed(f"{message}\r\n".encode())
-                self.toast_label.set_label(message)
-                return
+        if session.child_process is not None and not self.terminate_terminal_process(session.child_process):
+            message = self.t("sigterm_failed")
+            session.terminal.feed(f"{message}\r\n".encode())
+            self.toast_label.set_label(message)
+            return
         self.terminate_split_processes(session)
         self.record_session_duration(session)
         self.save_statistics_now()

--- a/src/termia/ui_state.py
+++ b/src/termia/ui_state.py
@@ -11,6 +11,7 @@ gi.require_version("Vte", "3.91")
 from gi.repository import Gtk, Vte
 
 from .sidebar_projection import SidebarRow as RowObject
+from .terminal_processes import TerminalProcess
 
 
 @dataclass
@@ -32,6 +33,7 @@ class TerminalSession:
     detached_window: Gtk.Window | None = None
     timeout_id: int | None = None
     child_pid: int | None = None
+    child_process: TerminalProcess | None = None
     connected: bool = True
     disconnect_requested: bool = False
     pending_reconnect: bool = False
@@ -47,4 +49,5 @@ class TerminalSession:
     history_port: int = 0
     split_terminals: list[Vte.Terminal] = field(default_factory=list)
     split_child_pids: dict[int, int] = field(default_factory=dict)
+    split_processes: dict[int, TerminalProcess] = field(default_factory=dict)
     active_terminal_ids: set[int] = field(default_factory=set)

--- a/tests/test_terminal_processes.py
+++ b/tests/test_terminal_processes.py
@@ -1,6 +1,10 @@
+import signal
 import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
 
-from termia.terminal_processes import spawn_terminal_process
+from termia.terminal_processes import TerminalProcess, signal_terminal_process, spawn_terminal_process
+from termia.terminal_sessions import TerminalSessionsMixin
 
 
 class FakeTerminal:
@@ -14,8 +18,74 @@ class TerminalProcessTests(unittest.TestCase):
         terminal = FakeTerminal()
         environment = ["TERM=xterm-256color"]
 
-        child_pid = spawn_terminal_process(terminal, "/tmp", ["/bin/bash", "-l"], environment)
+        process = spawn_terminal_process(terminal, "/tmp", ["/bin/bash", "-l"], environment)
 
-        self.assertEqual(child_pid, 4242)
+        self.assertEqual(process.pid, 4242)
         self.assertEqual(terminal.args[1:5], ("/tmp", ["/bin/bash", "-l"], environment, 0))
         self.assertEqual(terminal.args[5:], (None, None, None))
+
+    @patch("termia.terminal_processes.process_start_time", return_value="42")
+    @patch("termia.terminal_processes.os.killpg")
+    @patch("termia.terminal_processes.os.getpgrp", return_value=1)
+    @patch("termia.terminal_processes.os.getpgid", return_value=99)
+    def test_signals_the_captured_process_group(self, getpgid, getpgrp, killpg, start_time) -> None:
+        process = TerminalProcess(pid=42, process_group_id=99, session_id=None, start_time="42")
+
+        self.assertTrue(signal_terminal_process(process, signal.SIGTERM))
+        killpg.assert_called_once_with(99, signal.SIGTERM)
+        getpgid.assert_called_once_with(42)
+
+    @patch("termia.terminal_processes.os.kill")
+    @patch("termia.terminal_processes.process_start_time", return_value="new")
+    def test_reused_pid_is_never_signalled(self, start_time, kill) -> None:
+        process = TerminalProcess(pid=42, process_group_id=99, session_id=None, start_time="old")
+
+        self.assertFalse(signal_terminal_process(process, signal.SIGTERM))
+        kill.assert_not_called()
+
+    @patch("termia.terminal_processes.os.killpg")
+    @patch("termia.terminal_processes.os.getpgrp", return_value=1)
+    @patch("termia.terminal_processes.process_groups_in_session", return_value={99, 100})
+    def test_signals_every_group_in_the_captured_terminal_session(self, groups, getpgrp, killpg) -> None:
+        process = TerminalProcess(pid=42, process_group_id=99, session_id=500, start_time="42")
+
+        self.assertTrue(signal_terminal_process(process, signal.SIGTERM))
+        self.assertCountEqual(
+            killpg.call_args_list,
+            [
+                ((99, signal.SIGTERM),),
+                ((100, signal.SIGTERM),),
+            ],
+        )
+
+    def test_terminates_main_and_split_processes_for_every_open_session(self) -> None:
+        main_process = TerminalProcess(pid=1, process_group_id=10, session_id=100, start_time="1")
+        split_process = TerminalProcess(pid=2, process_group_id=20, session_id=200, start_time="2")
+
+        class Host(TerminalSessionsMixin):
+            def __init__(self) -> None:
+                self.open_tabs = {
+                    "session": SimpleNamespace(
+                        child_process=main_process,
+                        split_processes={"split": split_process},
+                    )
+                }
+                self.terminated = []
+
+            def terminate_terminal_process(self, process, *, force=False) -> bool:
+                self.terminated.append((process, force))
+                return True
+
+        host = Host()
+        host.terminate_open_terminal_processes()
+        host.terminate_open_terminal_processes(force=True)
+
+        self.assertEqual(
+            host.terminated,
+            [
+                (main_process, False),
+                (split_process, False),
+                (main_process, True),
+                (split_process, True),
+            ],
+        )


### PR DESCRIPTION
## Summary
- capture VTE child identity using PID, process group, isolated session, and Linux start time
- send SIGTERM to every process group in an isolated terminal session, including background jobs
- use a 500 ms fallback SIGKILL only after validating the same process identity
- terminate active terminal processes during normal window shutdown and system SIGTERM handling
- preserve the direct-child fallback when VTE does not isolate a session

Refs #148

## Safety
- a reused PID is never signalled
- Termia's own process group and session are never targeted
- SIGKILL cannot be intercepted after Termia itself is forcibly killed; this PR covers normal shutdown and SIGTERM-driven service shutdown

## Validation
- full test suite: 60 tests passed
- full Python syntax compilation
- bash syntax check for scripts/termia-setup.sh
- translation catalog consistency check

## Manual verification
- run a background sleep process in a local terminal, close Termia, then confirm its PID is gone
- repeat with split panes and SSH sessions
- repeat with a process that ignores SIGTERM to verify the fallback cleanup