### PR TITLE
refactor: introduce terminal session registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Changes merged after `0.5.0-beta` (2026-07-21 to 2026-07-23).
 
 ### Refactored
 
+- Introduce an explicit terminal session registry instead of sharing the `open_tabs` dictionary between window mixins (`#156`).
 - Replace the connection history view mixin with an explicitly composed dialog.
 - Replace the statistics view mixin with an explicitly composed statistics dialog.
 - Pass terminal context-menu actions through an explicit callback contract composed by the application window.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ At minimum, run syntax checks for touched Python and shell files. For a broad va
 
 ```bash
 PYTHONPATH=src python3 -m unittest discover -s tests -v
-python3 -m py_compile run_termia.py scripts/compile_translations.py src/termia/app.py src/termia/asbru_import.py src/termia/config_actions.py src/termia/config_io.py src/termia/connection_dialogs.py src/termia/connection_utils.py src/termia/constants.py src/termia/i18n.py src/termia/keybindings.py src/termia/main_menu.py src/termia/models.py src/termia/preferences.py src/termia/sidebar.py src/termia/statistics_utils.py src/termia/statistics_view.py src/termia/stores.py src/termia/styles.py src/termia/tabs.py src/termia/terminal_sessions.py src/termia/terminal_config.py src/termia/ui_state.py
+python3 -m py_compile run_termia.py scripts/compile_translations.py src/termia/*.py tests/*.py
 bash -n scripts/termia-setup.sh
 scripts/compile_translations.py --check
 ```

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ POT template, both PO catalogs, and the compiled MO files are synchronized.
 
 ```bash
 PYTHONPATH=src python3 -m unittest discover -s tests -v
-python3 -m py_compile run_termia.py scripts/compile_translations.py src/termia/app.py src/termia/asbru_import.py src/termia/config_actions.py src/termia/config_io.py src/termia/connection_dialogs.py src/termia/connection_utils.py src/termia/constants.py src/termia/i18n.py src/termia/keybindings.py src/termia/main_menu.py src/termia/main_menu_actions.py src/termia/models.py src/termia/preferences.py src/termia/sidebar.py src/termia/statistics_utils.py src/termia/statistics_view.py src/termia/stores.py src/termia/styles.py src/termia/tabs.py src/termia/terminal_menu_actions.py src/termia/terminal_menus.py src/termia/terminal_sessions.py src/termia/terminal_config.py src/termia/ui_state.py
+python3 -m py_compile run_termia.py scripts/compile_translations.py src/termia/*.py tests/*.py
 bash -n scripts/termia-setup.sh
 ```
 

--- a/docs/REGRESSION_CHECKS.md
+++ b/docs/REGRESSION_CHECKS.md
@@ -175,7 +175,7 @@ Run at minimum:
 
 ```bash
 PYTHONPATH=src python3 -m unittest discover -s tests -v
-python3 -m py_compile run_termia.py scripts/compile_translations.py src/termia/app.py src/termia/asbru_import.py src/termia/config_actions.py src/termia/config_io.py src/termia/connection_dialogs.py src/termia/connection_utils.py src/termia/constants.py src/termia/i18n.py src/termia/keybindings.py src/termia/main_menu.py src/termia/main_menu_actions.py src/termia/models.py src/termia/preferences.py src/termia/sidebar.py src/termia/statistics_utils.py src/termia/statistics_view.py src/termia/stores.py src/termia/styles.py src/termia/tabs.py src/termia/terminal_menu_actions.py src/termia/terminal_menus.py src/termia/terminal_sessions.py src/termia/terminal_config.py src/termia/ui_state.py
+python3 -m py_compile run_termia.py scripts/compile_translations.py src/termia/*.py tests/*.py
 bash -n scripts/termia-setup.sh
 scripts/compile_translations.py
 scripts/compile_translations.py --check

--- a/docs/WINDOW_MIXIN_CONTRACTS.md
+++ b/docs/WINDOW_MIXIN_CONTRACTS.md
@@ -32,7 +32,7 @@ receive only the services they use.
 the mixins:
 
 - Persistence and feedback: `store`, `toast_label`.
-- Session state: `open_tabs`, `run_connections`, `stats_save_id`.
+- Session state: `session_registry`, `run_connections`, `stats_save_id`.
 - Sidebar selection: `selected`, `selected_tree_widget`,
   `group_expanded_state`, `collapse_groups_on_startup`, `tree_widgets`, and
   `active_context_popover`.
@@ -144,10 +144,10 @@ security, and keybinding dialogs have comparatively small contracts.
 
 ### `TerminalSessionsMixin`
 
-- Reads: `store`, `open_tabs`, `terminal_stack`, `toast_label`, terminal-menu
+- Reads: `store`, `session_registry`, `terminal_stack`, `toast_label`, terminal-menu
   callbacks, and terminal-font resolution.
 - Writes: `run_connections` and `stats_save_id`; it also mutates
-  `TerminalSession` objects held in `open_tabs`.
+  `TerminalSession` objects held in `session_registry`.
 - Cross-mixin dependencies: tab creation, ordering, activation, title updates,
   closing, terminal menus, and terminal preferences.
 - Architectural note: process launching, terminal views, split panes, and file
@@ -156,7 +156,7 @@ security, and keybinding dialogs have comparatively small contracts.
 
 ### `TabsMixin`
 
-- Reads: `store`, `open_tabs`, `session_tab_bar`, and `terminal_stack`.
+- Reads: `store`, `session_registry`, `session_tab_bar`, and `terminal_stack`.
 - Writes: drag state and the GTK placement of session pages and labels.
 - Cross-mixin dependencies: terminal creation/disconnection/termination,
   terminal context actions, and shared dialog helpers.
@@ -184,7 +184,8 @@ The principal cycles are:
    pattern for subsequent extractions with explicit providers and callbacks.
 3. Pass explicit action callbacks into menu builders. The main menu uses
    `MainMenuActions` and terminal context menus use `TerminalMenuActions`.
-4. Introduce a session registry that owns `open_tabs` and session lookup.
+4. `SessionRegistry` owns open terminal sessions and their lookup for tab and
+   lifecycle code.
 5. Separate tab placement from session lifecycle using the registry and
    callbacks, then replace `TabsMixin`.
 6. Replace the remaining session and sidebar mixins after their state has a

--- a/src/termia/app.py
+++ b/src/termia/app.py
@@ -30,6 +30,7 @@ from .keybindings import keybinding_matches
 from .main_menu import MainMenuMixin
 from .main_menu_actions import MainMenuActions
 from .preferences import PreferencesMixin
+from .session_registry import SessionRegistry
 from .stores import ConnectionStore
 from .sidebar import SidebarMixin
 from .statistics_presenter import StatisticsPresenter
@@ -39,7 +40,7 @@ from .tabs import TabsMixin
 from .terminal_menus import TerminalMenusMixin
 from .terminal_menu_actions import TerminalMenuActions
 from .terminal_sessions import TerminalSessionsMixin
-from .ui_state import RowObject, TerminalSession
+from .ui_state import RowObject
 
 
 class TermiaWindow(
@@ -94,7 +95,7 @@ class TermiaWindow(
         self.collapse_groups_on_startup = True
         self.tree_widgets: dict[tuple[str, str], Gtk.Widget] = {}
         self.active_context_popover: Gtk.Popover | None = None
-        self.open_tabs: dict[str, TerminalSession] = {}
+        self.session_registry = SessionRegistry()
         self.run_connections = 0
         self.statistics_presenter = StatisticsPresenter(
             lambda: self.store.data.statistics,
@@ -157,7 +158,7 @@ class TermiaWindow(
             GLib.idle_add(self.open_startup_local_terminal)
 
     def open_startup_local_terminal(self) -> bool:
-        if not self.open_tabs:
+        if not self.session_registry:
             self.on_open_local_terminal(None)
         return GLib.SOURCE_REMOVE
 

--- a/src/termia/session_registry.py
+++ b/src/termia/session_registry.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2026 Jordi Pons
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Explicit ownership and lookup for open terminal sessions."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from .ui_state import TerminalSession
+
+
+class SessionRegistry:
+    """Own the sessions whose terminal processes are managed by the window."""
+
+    def __init__(self, sessions: Iterable[TerminalSession] = ()) -> None:
+        self._sessions: dict[str, TerminalSession] = {}
+        for session in sessions:
+            self.register(session)
+
+    def register(self, session: TerminalSession) -> None:
+        if session.id in self._sessions:
+            raise ValueError(f"Session is already registered: {session.id}")
+        self._sessions[session.id] = session
+
+    def get(self, session_id: str) -> TerminalSession | None:
+        return self._sessions.get(session_id)
+
+    def contains(self, session_id: str) -> bool:
+        return session_id in self._sessions
+
+    def remove(self, session_id: str) -> TerminalSession | None:
+        return self._sessions.pop(session_id, None)
+
+    def sessions(self) -> tuple[TerminalSession, ...]:
+        return tuple(self._sessions.values())
+
+    def __bool__(self) -> bool:
+        return bool(self._sessions)

--- a/src/termia/tabs.py
+++ b/src/termia/tabs.py
@@ -25,7 +25,7 @@ class TabsMixin:
     def visible_sessions_in_tab_order(self) -> list[TerminalSession]:
         sessions_by_label = {
             session.tab_label: session
-            for session in self.open_tabs.values()
+            for session in self.session_registry.sessions()
             if session.detached_window is None
         }
         ordered: list[TerminalSession] = []
@@ -38,7 +38,7 @@ class TabsMixin:
         return ordered
 
     def set_active_session(self, session_id: str) -> None:
-        session = self.open_tabs.get(session_id)
+        session = self.session_registry.get(session_id)
         if session is None or session.detached_window is not None:
             return
         self.terminal_stack.set_visible_child(session.page)
@@ -47,7 +47,7 @@ class TabsMixin:
 
     def update_session_tab_states(self) -> None:
         visible_page = self.terminal_stack.get_visible_child()
-        for session in self.open_tabs.values():
+        for session in self.session_registry.sessions():
             session.tab_label.remove_css_class("active")
             if visible_page is session.page and session.detached_window is None:
                 session.tab_label.add_css_class("active")
@@ -65,11 +65,11 @@ class TabsMixin:
         self.update_session_tab_bar_visibility()
 
     def update_session_tab_bar_visibility(self) -> None:
-        visible_sessions = [session for session in self.open_tabs.values() if session.detached_window is None]
+        visible_sessions = [session for session in self.session_registry.sessions() if session.detached_window is None]
         self.session_tab_bar.set_visible(len(visible_sessions) > 1)
 
     def sync_window_title_with_visible_session(self) -> None:
-        visible_sessions = [session for session in self.open_tabs.values() if session.detached_window is None]
+        visible_sessions = [session for session in self.session_registry.sessions() if session.detached_window is None]
         if len(visible_sessions) == 1:
             session = visible_sessions[0]
             if session.server_id is None and session.title_locked:
@@ -93,7 +93,7 @@ class TabsMixin:
             *previous_order[closed_index + 1 :],
         ]
         for session in focus_candidates:
-            if session.id in self.open_tabs and session.detached_window is None:
+            if self.session_registry.contains(session.id) and session.detached_window is None:
                 self.set_active_session(session.id)
                 return
 
@@ -181,7 +181,7 @@ class TabsMixin:
         session_id: str,
         _tab: Gtk.Widget,
     ) -> Gdk.ContentProvider | None:
-        if session_id not in self.open_tabs:
+        if not self.session_registry.contains(session_id):
             return None
         return Gdk.ContentProvider.new_for_value(session_id)
 
@@ -204,7 +204,7 @@ class TabsMixin:
         _delete_data: bool,
         session_id: str,
     ) -> None:
-        session = self.open_tabs.get(session_id)
+        session = self.session_registry.get(session_id)
         if session is not None:
             session.tab_label.remove_css_class("dragging")
         self.tab_drag_session_id = None
@@ -215,7 +215,7 @@ class TabsMixin:
 
     def on_tab_bar_drop(self, target: Gtk.DropTarget, dragged_session_id: str, x: float, _y: float) -> bool:
         self.reorder_dragged_tab_at_bar_x(target, x, dragged_session_id)
-        dragged = self.open_tabs.get(dragged_session_id)
+        dragged = self.session_registry.get(dragged_session_id)
         if dragged is not None:
             self.set_active_session(dragged.id)
         return True
@@ -229,7 +229,7 @@ class TabsMixin:
         dragged_session_id = dragged_session_id or getattr(self, "tab_drag_session_id", None) or target.get_value()
         if not isinstance(dragged_session_id, str):
             return
-        dragged = self.open_tabs.get(dragged_session_id)
+        dragged = self.session_registry.get(dragged_session_id)
         if dragged is None or dragged.detached_window is not None:
             return
         sessions = self.visible_sessions_in_tab_order()
@@ -273,7 +273,7 @@ class TabsMixin:
         session_id: str,
         parent: Gtk.Widget,
     ) -> None:
-        session = self.open_tabs.get(session_id)
+        session = self.session_registry.get(session_id)
         if session is None:
             return
         popover = Gtk.Popover()
@@ -323,7 +323,7 @@ class TabsMixin:
     def on_detached_window_close(self, window: Gtk.Window, session: TerminalSession) -> bool:
         window.set_child(None)
         session.detached_window = None
-        if session.id in self.open_tabs:
+        if self.session_registry.contains(session.id):
             self.add_session_to_main_view(session)
         return False
 
@@ -357,7 +357,7 @@ class TabsMixin:
         self.request_close_tab(session_id, page)
 
     def request_close_tab(self, session_id: str, page: Gtk.Widget) -> None:
-        session = self.open_tabs.get(session_id)
+        session = self.session_registry.get(session_id)
         if session and session.page == page and session.connected:
             if not self.store.data.app.confirm_disconnect:
                 self.close_tab(session_id, page, disconnect=True)
@@ -374,10 +374,10 @@ class TabsMixin:
         self.close_tab(session_id, page, disconnect=False)
 
     def close_tab(self, session_id: str, page: Gtk.Widget, disconnect: bool) -> None:
-        session = self.open_tabs.get(session_id)
+        session = self.session_registry.get(session_id)
         if disconnect and session and session.page == page and session.connected:
             self.disconnect_session(session)
-            session = self.open_tabs.get(session_id)
+            session = self.session_registry.get(session_id)
         if session is None:
             return
         previous_order = self.visible_sessions_in_tab_order()
@@ -389,7 +389,7 @@ class TabsMixin:
             window.destroy()
         else:
             self.remove_session_from_main_view(session)
-        self.open_tabs.pop(session_id, None)
+        self.session_registry.remove(session_id)
         self.update_session_tab_bar_visibility()
         self.focus_available_session_after_close(session_id, previous_order)
         self.sync_window_title_with_visible_session()

--- a/src/termia/terminal_sessions.py
+++ b/src/termia/terminal_sessions.py
@@ -197,7 +197,7 @@ class TerminalSessionsMixin:
         focus_button.connect("clicked", self.on_hide_session_status_bar, session)
         session.disconnect_button.connect("clicked", self.on_request_disconnect_session, session)
         self.configure_terminal_interactions(terminal, session)
-        self.open_tabs[session.id] = session
+        self.session_registry.register(session)
         self.add_session_to_main_view(session)
         self.update_local_session_directory_title(session)
         terminal.grab_focus()
@@ -264,7 +264,7 @@ class TerminalSessionsMixin:
         focus_button.connect("clicked", self.on_hide_session_status_bar, session)
         session.disconnect_button.connect("clicked", self.on_request_disconnect_session, session)
         self.configure_terminal_interactions(session.terminal, session)
-        self.open_tabs[session.id] = session
+        self.session_registry.register(session)
         self.add_session_to_main_view(session)
 
         self.start_ssh_session(server, session, split_layout=server.split_layout)
@@ -403,7 +403,7 @@ class TerminalSessionsMixin:
                 GLib.source_remove(self.stats_save_id)
                 self.stats_save_id = None
             return
-        for session in tuple(self.open_tabs.values()):
+        for session in self.session_registry.sessions():
             self.record_session_duration(session)
         if self.stats_save_id is not None:
             GLib.source_remove(self.stats_save_id)
@@ -449,7 +449,7 @@ class TerminalSessionsMixin:
         self.schedule_statistics_save()
 
     def save_history_before_close(self) -> None:
-        for session in tuple(self.open_tabs.values()):
+        for session in self.session_registry.sessions():
             if session.history_start_recorded and not session.history_end_recorded:
                 result = "disconnected" if session.disconnect_requested else "closed"
                 self.store.record_history_end(session, result)
@@ -528,7 +528,7 @@ class TerminalSessionsMixin:
 
     def apply_session_status_bar_visibility_to_open_tabs(self) -> None:
         visible = self.should_show_session_status_bar()
-        for session in self.open_tabs.values():
+        for session in self.session_registry.sessions():
             session.status_bar.set_visible(visible)
 
     def change_terminal_font_size(self, delta: int) -> None:
@@ -927,7 +927,7 @@ class TerminalSessionsMixin:
         TerminalViewFactory(self.resolved_terminal_font_family).apply_settings(terminal, self.store.data.terminal)
 
     def apply_terminal_settings_to_open_tabs(self) -> None:
-        for session in self.open_tabs.values():
+        for session in self.session_registry.sessions():
             self.apply_terminal_settings(session.terminal)
             for terminal in session.split_terminals:
                 self.apply_terminal_settings(terminal)
@@ -960,7 +960,7 @@ class TerminalSessionsMixin:
         return GLib.SOURCE_REMOVE
 
     def terminate_open_terminal_processes(self, *, force: bool = False) -> None:
-        for session in tuple(self.open_tabs.values()):
+        for session in self.session_registry.sessions():
             if session.child_process is not None:
                 self.terminate_terminal_process(session.child_process, force=force)
             for process in tuple(session.split_processes.values()):

--- a/tests/test_session_registry.py
+++ b/tests/test_session_registry.py
@@ -16,8 +16,11 @@ class SessionRegistryTests(unittest.TestCase):
         self.assertTrue(registry)
         self.assertTrue(registry.contains("first"))
         self.assertIs(registry.get("second"), second)
-        self.assertEqual(registry.sessions(), (first, second))
+        snapshot = registry.sessions()
+        self.assertEqual(snapshot, (first, second))
         self.assertIs(registry.remove("first"), first)
+        self.assertEqual(snapshot, (first, second))
+        self.assertEqual(registry.sessions(), (second,))
         self.assertFalse(registry.contains("first"))
         self.assertIsNone(registry.remove("missing"))
 

--- a/tests/test_session_registry.py
+++ b/tests/test_session_registry.py
@@ -1,0 +1,28 @@
+import unittest
+from types import SimpleNamespace
+
+from termia.session_registry import SessionRegistry
+
+
+class SessionRegistryTests(unittest.TestCase):
+    def test_register_lookup_remove_and_snapshot(self) -> None:
+        first = SimpleNamespace(id="first")
+        second = SimpleNamespace(id="second")
+        registry = SessionRegistry()
+
+        registry.register(first)
+        registry.register(second)
+
+        self.assertTrue(registry)
+        self.assertTrue(registry.contains("first"))
+        self.assertIs(registry.get("second"), second)
+        self.assertEqual(registry.sessions(), (first, second))
+        self.assertIs(registry.remove("first"), first)
+        self.assertFalse(registry.contains("first"))
+        self.assertIsNone(registry.remove("missing"))
+
+    def test_register_rejects_duplicate_session_id(self) -> None:
+        registry = SessionRegistry([SimpleNamespace(id="duplicate")])
+
+        with self.assertRaisesRegex(ValueError, "already registered"):
+            registry.register(SimpleNamespace(id="duplicate"))

--- a/tests/test_tabs.py
+++ b/tests/test_tabs.py
@@ -82,6 +82,53 @@ class DetachTabTests(unittest.TestCase):
         self.assertTrue(session.detached_window.presented)
 
 
+class CloseTabTests(unittest.TestCase):
+    def test_close_tab_removes_only_the_closed_session_from_registry(self) -> None:
+        page = object()
+        session = SimpleNamespace(
+            id="closed",
+            page=page,
+            connected=False,
+            detached_window=None,
+        )
+        remaining_session = SimpleNamespace(
+            id="remaining",
+            detached_window=None,
+        )
+
+        class Host(TabsMixin):
+            def __init__(self) -> None:
+                self.session_registry = SessionRegistry([session, remaining_session])
+                self.removed = None
+                self.focused = None
+
+            def visible_sessions_in_tab_order(self):
+                return [session, remaining_session]
+
+            def terminate_split_processes(self, current_session) -> None:
+                pass
+
+            def remove_session_from_main_view(self, current_session) -> None:
+                self.removed = current_session
+
+            def update_session_tab_bar_visibility(self) -> None:
+                pass
+
+            def focus_available_session_after_close(self, closed_id, previous_order) -> None:
+                self.focused = (closed_id, previous_order)
+
+            def sync_window_title_with_visible_session(self) -> None:
+                pass
+
+        host = Host()
+        host.close_tab(session.id, page, disconnect=False)
+
+        self.assertIs(host.removed, session)
+        self.assertIsNone(host.session_registry.get(session.id))
+        self.assertIs(host.session_registry.get(remaining_session.id), remaining_session)
+        self.assertEqual(host.focused, (session.id, [session, remaining_session]))
+
+
 class MiddleClickTabTests(unittest.TestCase):
     def test_middle_click_requests_tab_close(self) -> None:
         page = object()

--- a/tests/test_tabs.py
+++ b/tests/test_tabs.py
@@ -2,6 +2,7 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import patch
 
+from termia.session_registry import SessionRegistry
 from termia.tabs import TabsMixin
 
 
@@ -49,7 +50,7 @@ class DetachTabTests(unittest.TestCase):
 
         class Host(TabsMixin):
             def __init__(self) -> None:
-                self.open_tabs = {session.id: session, previous_session.id: previous_session}
+                self.session_registry = SessionRegistry([session, previous_session])
                 self.focused = None
                 self.removed = None
                 self.visible_sessions = [previous_session, session]

--- a/tests/test_terminal_processes.py
+++ b/tests/test_terminal_processes.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 from termia.terminal_processes import TerminalProcess, signal_terminal_process, spawn_terminal_process
 from termia.terminal_sessions import TerminalSessionsMixin
+from termia.session_registry import SessionRegistry
 
 
 class FakeTerminal:
@@ -64,12 +65,15 @@ class TerminalProcessTests(unittest.TestCase):
 
         class Host(TerminalSessionsMixin):
             def __init__(self) -> None:
-                self.open_tabs = {
-                    "session": SimpleNamespace(
+                self.session_registry = SessionRegistry(
+                    [
+                        SimpleNamespace(
+                            id="session",
                         child_process=main_process,
                         split_processes={"split": split_process},
-                    )
-                }
+                        )
+                    ]
+                )
                 self.terminated = []
 
             def terminate_terminal_process(self, process, *, force=False) -> bool:


### PR DESCRIPTION
## Summary
- Add SessionRegistry as the explicit owner of open terminal sessions.
- Migrate tab and terminal-session lifecycle code away from the shared open_tabs dictionary.
- Add focused registry coverage and update the mixin contract documentation.

Closes #156

## Validation
- PYTHONPATH=src python3 -m unittest discover -s tests -v (67 tests)
- python3 -m py_compile src/termia/app.py src/termia/session_registry.py src/termia/tabs.py src/termia/terminal_sessions.py
- git diff --check

## Manual verification
1. Open a local terminal and multiple SSH sessions; tabs should open, select, reorder, detach, and restore normally.
2. Split a local and an SSH terminal, then close tabs and Termia; all main and split child processes must be cleaned up.
3. Confirm reconnect and local-terminal retry still replace the failed tab with a new session.