### PR TITLE
refactor: decouple tab lifecycle actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Changes merged after `0.5.0-beta` (2026-07-21 to 2026-07-23).
 
 ### Refactored
 
+- Pass tab-triggered terminal lifecycle operations through an explicit callback contract (`#158`).
 - Introduce an explicit terminal session registry instead of sharing the `open_tabs` dictionary between window mixins (`#156`).
 - Replace the connection history view mixin with an explicitly composed dialog.
 - Replace the statistics view mixin with an explicitly composed statistics dialog.

--- a/docs/WINDOW_MIXIN_CONTRACTS.md
+++ b/docs/WINDOW_MIXIN_CONTRACTS.md
@@ -33,6 +33,8 @@ the mixins:
 
 - Persistence and feedback: `store`, `toast_label`.
 - Session state: `session_registry`, `run_connections`, `stats_save_id`.
+- Explicit actions: `main_menu_actions`, `terminal_menu_actions`, and
+  `tab_lifecycle_actions`.
 - Sidebar selection: `selected`, `selected_tree_widget`,
   `group_expanded_state`, `collapse_groups_on_startup`, `tree_widgets`, and
   `active_context_popover`.
@@ -149,28 +151,32 @@ security, and keybinding dialogs have comparatively small contracts.
 - Writes: `run_connections` and `stats_save_id`; it also mutates
   `TerminalSession` objects held in `session_registry`.
 - Cross-mixin dependencies: tab creation, ordering, activation, title updates,
-  closing, terminal menus, and terminal preferences.
+  closing, terminal menus, and terminal preferences. Tab-triggered duplication,
+  disconnection, confirmation, and split cleanup are exposed through the
+  explicitly composed `TabLifecycleActions` contract.
 - Architectural note: process launching, terminal views, split panes, and file
   transfer are already delegated to focused modules, but lifecycle
   orchestration still depends directly on tab and window state.
 
 ### `TabsMixin`
 
-- Reads: `store`, `session_registry`, `session_tab_bar`, and `terminal_stack`.
+- Reads: `store`, `session_registry`, `tab_lifecycle_actions`,
+  `session_tab_bar`, and `terminal_stack`.
 - Writes: drag state and the GTK placement of session pages and labels.
-- Cross-mixin dependencies: terminal creation/disconnection/termination,
-  terminal context actions, and shared dialog helpers.
-- Architectural note: the circular dependency between tabs and terminal
-  sessions is the most important contract to break before either mixin can be
-  replaced.
+- Cross-mixin dependencies: terminal context actions and shared dialog helpers.
+  Terminal creation, confirmation, disconnection, and split-process cleanup
+  are supplied explicitly through `TabLifecycleActions`.
+- Architectural note: terminal sessions still create and close tabs through
+  `TabsMixin`, but tab management no longer discovers terminal lifecycle
+  methods implicitly on the composed window.
 
 ## Dependency hotspots
 
-The principal cycles are:
+The principal dependency hotspots are:
 
-1. `TerminalSessionsMixin` creates and closes tabs through `TabsMixin`, while
-   `TabsMixin` starts, disconnects, and terminates sessions through
-   `TerminalSessionsMixin`.
+1. `TerminalSessionsMixin` still creates and closes tabs through `TabsMixin`;
+   the former reverse dependency now uses the explicit `TabLifecycleActions`
+   callback contract.
 2. `TerminalMenusMixin` dispatches actions to both tabs and terminal sessions,
    while terminal sessions install the menu callback on each VTE widget.
 3. `SidebarMixin` opens sessions and dialogs, while configuration and
@@ -186,8 +192,9 @@ The principal cycles are:
    `MainMenuActions` and terminal context menus use `TerminalMenuActions`.
 4. `SessionRegistry` owns open terminal sessions and their lookup for tab and
    lifecycle code.
-5. Separate tab placement from session lifecycle using the registry and
-   callbacks, then replace `TabsMixin`.
+5. `TabLifecycleActions` separates tab placement from terminal lifecycle
+   operations. The next step is to replace `TabsMixin` with an explicitly
+   composed tab controller.
 6. Replace the remaining session and sidebar mixins after their state has a
    single explicit owner.
 

--- a/src/termia/app.py
+++ b/src/termia/app.py
@@ -36,6 +36,7 @@ from .sidebar import SidebarMixin
 from .statistics_presenter import StatisticsPresenter
 from .statistics_view import StatisticsDialog
 from .styles import build_application_css
+from .tab_lifecycle_actions import TabLifecycleActions
 from .tabs import TabsMixin
 from .terminal_menus import TerminalMenusMixin
 from .terminal_menu_actions import TerminalMenuActions
@@ -104,6 +105,12 @@ class TermiaWindow(
             self.t,
         )
         self.statistics_dialog = StatisticsDialog(self, self.statistics_presenter, self.t)
+        self.tab_lifecycle_actions = TabLifecycleActions(
+            duplicate_session=self.duplicate_session,
+            disconnect_session=self.disconnect_session,
+            terminate_split_processes=self.terminate_split_processes,
+            confirm_session_action=self.confirm_session_action,
+        )
         self.main_menu_actions = MainMenuActions(
             general_preferences=lambda: self.on_app_preferences(None),
             terminal_settings=lambda: self.on_terminal_settings(None),

--- a/src/termia/tab_lifecycle_actions.py
+++ b/src/termia/tab_lifecycle_actions.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2026 Jordi Pons
+# SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from .ui_state import TerminalSession
+
+SessionAction = Callable[[TerminalSession], None]
+ConfirmedAction = Callable[[], None]
+ConfirmationAction = Callable[
+    [TerminalSession, str, str, str, ConfirmedAction],
+    None,
+]
+
+
+@dataclass(frozen=True)
+class TabLifecycleActions:
+    """Terminal lifecycle callbacks exposed to tab management."""
+
+    duplicate_session: SessionAction
+    disconnect_session: SessionAction
+    terminate_split_processes: SessionAction
+    confirm_session_action: ConfirmationAction

--- a/src/termia/tabs.py
+++ b/src/termia/tabs.py
@@ -10,7 +10,6 @@ gi.require_version("Gtk", "4.0")
 gi.require_version("Pango", "1.0")
 from gi.repository import Gdk, Graphene, Gtk, Pango
 
-from .connection_utils import find_server
 from .ui_state import TerminalSession
 
 
@@ -295,12 +294,7 @@ class TabsMixin:
 
     def duplicate_tab(self, popover: Gtk.Popover, session: TerminalSession) -> None:
         popover.popdown()
-        if session.server_id is not None:
-            server = find_server(self.store.data.servers, session.server_id)
-            if server is not None:
-                self.open_terminal_tab(server)
-            return
-        self.on_open_local_terminal(None)
+        self.tab_lifecycle_actions.duplicate_session(session)
 
     def detach_tab(self, popover: Gtk.Popover, session: TerminalSession) -> None:
         popover.popdown()
@@ -363,7 +357,7 @@ class TabsMixin:
                 self.close_tab(session_id, page, disconnect=True)
                 return
             detail = self.t("close_ssh_session_confirm") if session.server_id is not None else self.t("close_local_session_confirm")
-            self.confirm_session_action(
+            self.tab_lifecycle_actions.confirm_session_action(
                 session,
                 self.t("close_session_title"),
                 detail,
@@ -376,12 +370,12 @@ class TabsMixin:
     def close_tab(self, session_id: str, page: Gtk.Widget, disconnect: bool) -> None:
         session = self.session_registry.get(session_id)
         if disconnect and session and session.page == page and session.connected:
-            self.disconnect_session(session)
+            self.tab_lifecycle_actions.disconnect_session(session)
             session = self.session_registry.get(session_id)
         if session is None:
             return
         previous_order = self.visible_sessions_in_tab_order()
-        self.terminate_split_processes(session)
+        self.tab_lifecycle_actions.terminate_split_processes(session)
         if session.detached_window is not None:
             window = session.detached_window
             session.detached_window = None

--- a/src/termia/terminal_sessions.py
+++ b/src/termia/terminal_sessions.py
@@ -269,6 +269,14 @@ class TerminalSessionsMixin:
 
         self.start_ssh_session(server, session, split_layout=server.split_layout)
 
+    def duplicate_session(self, session: TerminalSession) -> None:
+        if session.server_id is not None:
+            server = find_server(self.store.data.servers, session.server_id)
+            if server is not None:
+                self.open_terminal_tab(server)
+            return
+        self.on_open_local_terminal(None)
+
     def start_ssh_session(self, server: Server, session: TerminalSession, *, split_layout: str = "none") -> None:
         terminal = session.terminal
         session.started_at = time.monotonic()

--- a/tests/test_tab_lifecycle_actions.py
+++ b/tests/test_tab_lifecycle_actions.py
@@ -1,0 +1,71 @@
+import unittest
+from types import SimpleNamespace
+
+from termia.tab_lifecycle_actions import TabLifecycleActions
+from termia.terminal_sessions import TerminalSessionsMixin
+
+
+class TabLifecycleActionsTests(unittest.TestCase):
+    def test_each_explicit_action_dispatches_to_its_callback(self) -> None:
+        calls = []
+
+        def action(name):
+            return lambda *args: calls.append((name, args))
+
+        actions = TabLifecycleActions(
+            duplicate_session=action("duplicate_session"),
+            disconnect_session=action("disconnect_session"),
+            terminate_split_processes=action("terminate_split_processes"),
+            confirm_session_action=action("confirm_session_action"),
+        )
+        session = object()
+        confirmed_action = lambda: None
+
+        actions.duplicate_session(session)
+        actions.disconnect_session(session)
+        actions.terminate_split_processes(session)
+        actions.confirm_session_action(session, "title", "detail", "confirm", confirmed_action)
+
+        self.assertEqual(
+            calls,
+            [
+                ("duplicate_session", (session,)),
+                ("disconnect_session", (session,)),
+                ("terminate_split_processes", (session,)),
+                (
+                    "confirm_session_action",
+                    (session, "title", "detail", "confirm", confirmed_action),
+                ),
+            ],
+        )
+
+
+class DuplicateSessionTests(unittest.TestCase):
+    def test_duplicate_session_preserves_ssh_and_local_startup_paths(self) -> None:
+        server = SimpleNamespace(id="server")
+
+        class Host(TerminalSessionsMixin):
+            def __init__(self) -> None:
+                self.store = SimpleNamespace(data=SimpleNamespace(servers=[server]))
+                self.opened_server = None
+                self.opened_local = False
+
+            def open_terminal_tab(self, selected_server) -> None:
+                self.opened_server = selected_server
+
+            def on_open_local_terminal(self, _button) -> None:
+                self.opened_local = True
+
+        host = Host()
+
+        host.duplicate_session(SimpleNamespace(server_id=server.id))
+        self.assertIs(host.opened_server, server)
+
+        host.duplicate_session(SimpleNamespace(server_id=None))
+        self.assertTrue(host.opened_local)
+
+        host.opened_server = None
+        host.opened_local = False
+        host.duplicate_session(SimpleNamespace(server_id="missing"))
+        self.assertIsNone(host.opened_server)
+        self.assertFalse(host.opened_local)

--- a/tests/test_tabs.py
+++ b/tests/test_tabs.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 from termia.session_registry import SessionRegistry
+from termia.tab_lifecycle_actions import TabLifecycleActions
 from termia.tabs import TabsMixin
 
 
@@ -82,13 +83,35 @@ class DetachTabTests(unittest.TestCase):
         self.assertTrue(session.detached_window.presented)
 
 
+class DuplicateTabTests(unittest.TestCase):
+    def test_duplicate_tab_closes_popover_and_dispatches_lifecycle_action(self) -> None:
+        session = SimpleNamespace(id="duplicate")
+        duplicated = []
+
+        class Host(TabsMixin):
+            def __init__(self) -> None:
+                self.tab_lifecycle_actions = TabLifecycleActions(
+                    duplicate_session=duplicated.append,
+                    disconnect_session=lambda _session: None,
+                    terminate_split_processes=lambda _session: None,
+                    confirm_session_action=lambda *_args: None,
+                )
+
+        host = Host()
+        popover = FakePopover()
+        host.duplicate_tab(popover, session)
+
+        self.assertTrue(popover.closed)
+        self.assertEqual(duplicated, [session])
+
+
 class CloseTabTests(unittest.TestCase):
     def test_close_tab_removes_only_the_closed_session_from_registry(self) -> None:
         page = object()
         session = SimpleNamespace(
             id="closed",
             page=page,
-            connected=False,
+            connected=True,
             detached_window=None,
         )
         remaining_session = SimpleNamespace(
@@ -101,12 +124,24 @@ class CloseTabTests(unittest.TestCase):
                 self.session_registry = SessionRegistry([session, remaining_session])
                 self.removed = None
                 self.focused = None
+                self.terminated = None
+                self.disconnected = None
+                self.tab_lifecycle_actions = TabLifecycleActions(
+                    duplicate_session=lambda _session: None,
+                    disconnect_session=self.disconnect_session,
+                    terminate_split_processes=self.terminate_split_processes,
+                    confirm_session_action=lambda *_args: None,
+                )
 
             def visible_sessions_in_tab_order(self):
                 return [session, remaining_session]
 
             def terminate_split_processes(self, current_session) -> None:
-                pass
+                self.terminated = current_session
+
+            def disconnect_session(self, current_session) -> None:
+                self.disconnected = current_session
+                current_session.connected = False
 
             def remove_session_from_main_view(self, current_session) -> None:
                 self.removed = current_session
@@ -121,9 +156,11 @@ class CloseTabTests(unittest.TestCase):
                 pass
 
         host = Host()
-        host.close_tab(session.id, page, disconnect=False)
+        host.close_tab(session.id, page, disconnect=True)
 
+        self.assertIs(host.disconnected, session)
         self.assertIs(host.removed, session)
+        self.assertIs(host.terminated, session)
         self.assertIsNone(host.session_registry.get(session.id))
         self.assertIs(host.session_registry.get(remaining_session.id), remaining_session)
         self.assertEqual(host.focused, (session.id, [session, remaining_session]))


### PR DESCRIPTION
## Summary

- introduce an explicit TabLifecycleActions callback contract composed by TermiaWindow
- move local and SSH session duplication into terminal lifecycle orchestration
- remove implicit terminal creation, confirmation, disconnection, and split-cleanup calls from TabsMixin
- document the reduced mixin coupling and next tab-controller extraction step
- add focused dispatch, duplication, close, registry, and process-cleanup coverage

## Tests

- PYTHONPATH=src python3 -m unittest discover -s tests -v (71 tests)
- python3 -m py_compile run_termia.py scripts/compile_translations.py src/termia/*.py tests/*.py
- bash -n scripts/run_test_instance.sh
- bash -n scripts/termia-setup.sh
- scripts/compile_translations.py --check
- git diff --check

## Manual checks

- duplicate local and SSH tabs
- close connected tabs with and without confirmation
- close split tabs and verify sibling/process cleanup
- detach and restore tabs, preserving focus and order

Closes #158