### PR TITLE
fix: stop GSK frame stats in Debug mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Changes merged after `0.5.0-beta` (released 2026-07-20).
 
 ### Fixed
 
-- Stop Debug mode from enabling GSK renderer frame statistics that flood the system log (`#162`).
+- Stop Debug mode from enabling GSK renderer frame statistics that flood the system log, and format structured GLib diagnostics as readable text (`#162`).
 - Finalize stale connection-history entries from an earlier Termia process as interrupted instead of leaving them in progress (`#151`).
 - Terminate isolated VTE process groups when disconnecting sessions or closing Termia to avoid orphaned terminal and SSH children (`#148`).
 - Keep Debug output in Termia's state log instead of forwarding it to stderr/syslog, and show its path in the Debug preference tooltip (`#135`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Changes merged after `0.5.0-beta` (released 2026-07-20).
 
 ### Fixed
 
+- Stop Debug mode from enabling GSK renderer frame statistics that flood the system log (`#162`).
 - Finalize stale connection-history entries from an earlier Termia process as interrupted instead of leaving them in progress (`#151`).
 - Terminate isolated VTE process groups when disconnecting sessions or closing Termia to avoid orphaned terminal and SSH children (`#148`).
 - Keep Debug output in Termia's state log instead of forwarding it to stderr/syslog, and show its path in the Debug preference tooltip (`#135`).

--- a/src/termia/debug.py
+++ b/src/termia/debug.py
@@ -17,17 +17,6 @@ LOGGER = logging.getLogger("termia")
 _GLIB_WRITER_CONFIGURED = False
 
 
-def _glib_field(fields: object, key: str) -> str | None:
-    if isinstance(fields, dict):
-        value = fields.get(key)
-        return str(value) if value is not None else None
-    for field in fields:  # type: ignore[union-attr]
-        if field.key == key:
-            value = field.value
-            return value.decode() if isinstance(value, bytes) else str(value)
-    return None
-
-
 def _write_glib_log(
     log_level: GLib.LogLevelFlags,
     fields: object,
@@ -35,9 +24,6 @@ def _write_glib_log(
     _user_data: object,
 ) -> GLib.LogWriterOutput:
     if LOGGER.disabled:
-        return GLib.LogWriterOutput.UNHANDLED
-    message = _glib_field(fields, "MESSAGE")
-    if not message:
         return GLib.LogWriterOutput.UNHANDLED
     if log_level & (GLib.LogLevelFlags.LEVEL_ERROR | GLib.LogLevelFlags.LEVEL_CRITICAL):
         level = logging.ERROR
@@ -47,8 +33,13 @@ def _write_glib_log(
         level = logging.DEBUG
     else:
         level = logging.INFO
-    domain = _glib_field(fields, "GLIB_DOMAIN") or "GLib"
-    LOGGER.log(level, "[%s] %s", domain, message)
+    try:
+        message = GLib.log_writer_format_fields(log_level, fields, False).strip()
+    except (TypeError, ValueError, UnicodeError) as exc:
+        LOGGER.warning("Could not format GLib diagnostic: %s", exc)
+        return GLib.LogWriterOutput.HANDLED
+    if message:
+        LOGGER.log(level, "%s", message)
     return GLib.LogWriterOutput.HANDLED
 
 

--- a/src/termia/debug.py
+++ b/src/termia/debug.py
@@ -64,7 +64,6 @@ def configure_debug_logging(enabled: bool) -> None:
     if LOGGER.handlers:
         return
     os.environ.setdefault("G_MESSAGES_DEBUG", "all")
-    os.environ.setdefault("GSK_DEBUG", "renderer")
     os.environ.setdefault("PYTHONFAULTHANDLER", "1")
     LOGGER.setLevel(logging.DEBUG)
     LOGGER.propagate = False

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -1,6 +1,7 @@
 import tempfile
 import unittest
 import logging
+import os
 from pathlib import Path
 from unittest.mock import patch
 
@@ -47,3 +48,25 @@ class DebugLoggingTests(unittest.TestCase):
 
             self.assertEqual(result, GLib.LogWriterOutput.HANDLED)
             self.assertIn("[Gtk] GTK diagnostic", log_path.read_text(encoding="utf-8"))
+
+    def test_debug_logging_does_not_enable_gsk_renderer_output(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            log_path = Path(directory) / "debug.log"
+            with (
+                patch.object(debug, "DEBUG_LOG_FILE", log_path),
+                patch.dict(os.environ, {}, clear=True),
+            ):
+                debug.configure_debug_logging(True)
+
+                self.assertNotIn("GSK_DEBUG", os.environ)
+
+    def test_debug_logging_preserves_external_gsk_debug_value(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            log_path = Path(directory) / "debug.log"
+            with (
+                patch.object(debug, "DEBUG_LOG_FILE", log_path),
+                patch.dict(os.environ, {"GSK_DEBUG": "shaders"}, clear=True),
+            ):
+                debug.configure_debug_logging(True)
+
+                self.assertEqual(os.environ["GSK_DEBUG"], "shaders")

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -39,15 +39,19 @@ class DebugLoggingTests(unittest.TestCase):
             log_path = Path(directory) / "debug.log"
             with patch.object(debug, "DEBUG_LOG_FILE", log_path):
                 debug.configure_debug_logging(True)
-                result = debug._write_glib_log(
+                GLib.log_variant(
+                    "GtkTest",
                     GLib.LogLevelFlags.LEVEL_DEBUG,
-                    {"MESSAGE": "GTK diagnostic", "GLIB_DOMAIN": "Gtk"},
-                    2,
-                    None,
+                    GLib.Variant(
+                        "a{sv}",
+                        {"MESSAGE": GLib.Variant("s", "GTK diagnostic")},
+                    ),
                 )
 
-            self.assertEqual(result, GLib.LogWriterOutput.HANDLED)
-            self.assertIn("[Gtk] GTK diagnostic", log_path.read_text(encoding="utf-8"))
+            contents = log_path.read_text(encoding="utf-8")
+            self.assertIn("GtkTest", contents)
+            self.assertIn("GTK diagnostic", contents)
+            self.assertNotRegex(contents, r"DEBUG \[\d+\] \d+")
 
     def test_debug_logging_does_not_enable_gsk_renderer_output(self) -> None:
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
## Summary

- stop normal Debug mode from setting `GSK_DEBUG=renderer`
- prevent GTK from printing per-frame renderer statistics to the desktop process output and system log
- format real `GLib.LogField` records with the GLib structured-log formatter instead of exposing pointer values
- preserve externally supplied `GSK_DEBUG` values for explicit renderer diagnostics
- keep Python and structured GLib diagnostics routed to Termia's state debug log
- add regression tests based on a real `GLib.log_variant()` record and document the fix

## Validation

- `PYTHONPATH=src python3 -m unittest discover -s tests -v` (73 tests)
- `python3 -m py_compile run_termia.py scripts/compile_translations.py src/termia/*.py tests/*.py`
- `bash -n scripts/run_test_instance.sh`
- `bash -n scripts/termia-setup.sh`
- `scripts/compile_translations.py --check`
- `git diff --check`
- reviewed the full diff for personal or sensitive data

## Manual check

Enable Debug mode, restart Termia, and use the interface for several seconds. Verify that new `Frame stats` records do not appear in `/var/log/syslog`, while the active profile's `debug.log` receives readable diagnostics rather than numeric pointer values.

Closes #162
