### PR TITLE
release: prepare Termia 0.5.0-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Changes merged after `0.5.0-beta.2` (released 2026-07-29).
+
+## 0.5.0-beta.2 - 2026-07-29
+
 Changes merged after `0.5.0-beta` (released 2026-07-20).
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ Roadmap: [ROADMAP.md](ROADMAP.md)
 
 ## Download and install (Ubuntu 24.04+)
 
-Download [termia_0.5.0.beta-4_all.deb](https://github.com/buuuki/termia/releases/download/v0.5.0-beta/termia_0.5.0.beta-4_all.deb)
+Download [termia_0.5.0.beta.2-1_all.deb](https://github.com/buuuki/termia/releases/download/v0.5.0-beta.2/termia_0.5.0.beta.2-1_all.deb)
 and install it with APT, which resolves the required dependencies:
 
 ```bash
-sudo apt install ./termia_0.5.0.beta-4_all.deb
+sudo apt install ./termia_0.5.0.beta.2-1_all.deb
 ```
 
 ## Download from source
@@ -120,11 +120,11 @@ sudo apt build-dep .
 dpkg-buildpackage -us -uc -b
 ```
 
-The resulting `termia_0.5.0~beta-4_all.deb` is created in the parent directory.
+The resulting `termia_0.5.0~beta.2-1_all.deb` is created in the parent directory.
 Install it with:
 
 ```bash
-sudo apt install ../termia_0.5.0~beta-4_all.deb
+sudo apt install ../termia_0.5.0~beta.2-1_all.deb
 ```
 
 The Debian package installs the `termia` command, desktop launcher, and icon;

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+termia (0.5.0~beta.2-1) unstable; urgency=medium
+
+  * Release Termia 0.5.0-beta.2 with the fixes and refactors accumulated since
+    the initial 0.5.0 beta.
+  * Synchronize application, Debian package, changelog, and download versions.
+
+ -- Jordi Pons <jpons.git@proton.me>  Wed, 29 Jul 2026 16:40:31 +0200
+
 termia (0.5.0~beta-4) unstable; urgency=medium
 
   * Fix the installed desktop launcher's icon name.

--- a/docs/README.ca.md
+++ b/docs/README.ca.md
@@ -21,11 +21,11 @@ Documentació en castellà: [README.es.md](README.es.md)
 
 ## Descarregar i instal·lar (Ubuntu 24.04+)
 
-Descarrega [termia_0.5.0.beta-4_all.deb](https://github.com/buuuki/termia/releases/download/v0.5.0-beta/termia_0.5.0.beta-4_all.deb)
+Descarrega [termia_0.5.0.beta.2-1_all.deb](https://github.com/buuuki/termia/releases/download/v0.5.0-beta.2/termia_0.5.0.beta.2-1_all.deb)
 i instal·la'l amb APT, que resoldrà les dependències necessàries:
 
 ```bash
-sudo apt install ./termia_0.5.0.beta-4_all.deb
+sudo apt install ./termia_0.5.0.beta.2-1_all.deb
 ```
 
 ## Descarregar i instal·lar des del codi font
@@ -83,8 +83,8 @@ debug` a les preferències Generals. També pots activar-lo per a una execució 
 python3 run_termia.py --debug
 ```
 
-La informació es desa a `~/.local/state/termia/debug.log` i també es mostra
-per stderr. No registra contrasenyes ni el contingut de les connexions.
+La informació es desa a `~/.local/state/termia/debug.log`. No registra
+contrasenyes ni el contingut de les connexions.
 
 Elimina únicament el llançador d'escriptori, sense esborrar ajustos, connexions,
 estadístiques ni paquets del sistema:
@@ -104,11 +104,11 @@ sudo apt build-dep .
 dpkg-buildpackage -us -uc -b
 ```
 
-El fitxer `termia_0.5.0~beta-4_all.deb` es crea al directori pare. Instal·la'l
+El fitxer `termia_0.5.0~beta.2-1_all.deb` es crea al directori pare. Instal·la'l
 amb:
 
 ```bash
-sudo apt install ../termia_0.5.0~beta-4_all.deb
+sudo apt install ../termia_0.5.0~beta.2-1_all.deb
 ```
 
 El paquet Debian instal·la l'ordre `termia`, el llançador d'escriptori i la

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -21,11 +21,11 @@ Documentación en catalán: [README.ca.md](README.ca.md)
 
 ## Descargar e instalar (Ubuntu 24.04+)
 
-Descarga [termia_0.5.0.beta-4_all.deb](https://github.com/buuuki/termia/releases/download/v0.5.0-beta/termia_0.5.0.beta-4_all.deb)
+Descarga [termia_0.5.0.beta.2-1_all.deb](https://github.com/buuuki/termia/releases/download/v0.5.0-beta.2/termia_0.5.0.beta.2-1_all.deb)
 e instálalo con APT, que resolverá las dependencias necesarias:
 
 ```bash
-sudo apt install ./termia_0.5.0.beta-4_all.deb
+sudo apt install ./termia_0.5.0.beta.2-1_all.deb
 ```
 
 ## Descargar e instalar desde el código fuente
@@ -104,11 +104,11 @@ sudo apt build-dep .
 dpkg-buildpackage -us -uc -b
 ```
 
-El fichero `termia_0.5.0~beta-4_all.deb` se crea en el directorio padre.
+El fichero `termia_0.5.0~beta.2-1_all.deb` se crea en el directorio padre.
 Instálalo con:
 
 ```bash
-sudo apt install ../termia_0.5.0~beta-4_all.deb
+sudo apt install ../termia_0.5.0~beta.2-1_all.deb
 ```
 
 El paquete Debian instala el comando `termia`, el lanzador de escritorio y el

--- a/src/termia/__init__.py
+++ b/src/termia/__init__.py
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 """Termia SSH connection manager."""
 
-__version__ = "0.5.0-beta"
+__version__ = "0.5.0-beta.2"


### PR DESCRIPTION
## Summary
- bump the Termia application version to 0.5.0-beta.2
- map the Debian package to 0.5.0~beta.2-1
- finalize the accumulated changelog and create a fresh Unreleased section
- update English, Spanish, and Catalan download/build instructions
- correct the stale Catalan Debug stderr statement

## Validation
- 73 unit tests passed before packaging and during dpkg-buildpackage
- Python compilation, shell syntax, and translation catalog checks passed
- dpkg-buildpackage -us -uc -b completed successfully
- package metadata reports Termia 0.5.0-beta.2 / Debian 0.5.0~beta.2-1
- verified upgrade ordering from 0.5.0~beta-4
- extracted package modules compile successfully
- audited package contents for private paths, credentials, keys, user configuration, histories, logs, tests, and caches
- package SHA-256: a086006638e9e235aa5c78fda6cf95f3f851236551223112fbc8f5a0d0076e4e
- lintian was unavailable locally

## Post-merge
After explicit merge confirmation, create annotated tag v0.5.0-beta.2, publish the GitHub prerelease, and upload the validated Debian package.

Closes #168
