### PR TITLE
fix: preserve sidebar action tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 Changes merged after `0.5.0-beta.2` (released 2026-07-29).
 
+### Fixed
+
+- Preserve translated action tooltips for writable sidebar icon buttons while
+  retaining read-only and locked-connection explanations when disabled
+  (`#170`).
+
 ## 0.5.0-beta.2 - 2026-07-29
 
 Changes merged after `0.5.0-beta` (released 2026-07-20).

--- a/docs/REGRESSION_CHECKS.md
+++ b/docs/REGRESSION_CHECKS.md
@@ -80,6 +80,11 @@ Protected behavior does not mean the code cannot change. It means regressions sh
 
 ### Server Tree
 
+- The icon-only sidebar actions for creating a group, server, or local terminal
+  and for expanding or collapsing all groups must expose their translated
+  action tooltips. Write actions must show the read-only or locked-connections
+  explanation only while disabled and restore their action tooltip when
+  enabled again.
 - Groups and subgroups must preserve expanded/collapsed state when editing servers or refreshing the list.
 - The server tree must not jump to the top when selecting or right-clicking entries.
 - Filtering must include matching servers, groups, and subgroups.

--- a/src/termia/app.py
+++ b/src/termia/app.py
@@ -182,7 +182,12 @@ class TermiaWindow(
         self.toast_label.set_label(self.t("read_only_mode_enabled"))
         return False
 
-    def configure_write_action(self, widget: Gtk.Widget) -> Gtk.Widget:
+    def configure_write_action(
+        self,
+        widget: Gtk.Widget,
+        *,
+        enabled_tooltip: str | None = None,
+    ) -> Gtk.Widget:
         write_blocked = self.store.read_only or self.store.encryption_locked
         widget.set_sensitive(not write_blocked)
         widget.set_tooltip_text(
@@ -192,7 +197,7 @@ class TermiaWindow(
                 else self.t("read_only_mode_tooltip")
             )
             if write_blocked
-            else None
+            else enabled_tooltip
         )
         return widget
 
@@ -393,19 +398,19 @@ class TermiaWindow(
         sidebar_actions = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
         add_group = Gtk.Button(icon_name="folder-new-symbolic")
         self.add_group_button = add_group
-        add_group.set_tooltip_text(self.t("new_group"))
         add_group.connect("clicked", self.on_add_group)
-        self.configure_write_action(add_group)
+        self.configure_write_action(add_group, enabled_tooltip=self.t("new_group"))
         add_server = Gtk.Button(icon_name="list-add-symbolic")
         self.add_server_button = add_server
-        add_server.set_tooltip_text(self.t("new_server"))
         add_server.connect("clicked", self.on_add_server)
-        self.configure_write_action(add_server)
+        self.configure_write_action(add_server, enabled_tooltip=self.t("new_server"))
         add_local_terminal = Gtk.Button(icon_name="utilities-terminal-symbolic")
         self.add_local_terminal_button = add_local_terminal
-        add_local_terminal.set_tooltip_text(self.t("new_local_terminal"))
         add_local_terminal.connect("clicked", self.on_add_local_terminal)
-        self.configure_write_action(add_local_terminal)
+        self.configure_write_action(
+            add_local_terminal,
+            enabled_tooltip=self.t("new_local_terminal"),
+        )
         expand_all = Gtk.Button(icon_name="pan-down-symbolic")
         self.expand_all_button = expand_all
         expand_all.set_tooltip_text(self.t("expand_all"))
@@ -568,12 +573,18 @@ class TermiaWindow(
             self.set_title(f"Termia ({self.t('read_only_badge')})")
         else:
             self.set_title("Termia")
-        self.add_group_button.set_tooltip_text(self.t("new_group"))
-        self.configure_write_action(self.add_group_button)
-        self.add_server_button.set_tooltip_text(self.t("new_server"))
-        self.configure_write_action(self.add_server_button)
-        self.add_local_terminal_button.set_tooltip_text(self.t("new_local_terminal"))
-        self.configure_write_action(self.add_local_terminal_button)
+        self.configure_write_action(
+            self.add_group_button,
+            enabled_tooltip=self.t("new_group"),
+        )
+        self.configure_write_action(
+            self.add_server_button,
+            enabled_tooltip=self.t("new_server"),
+        )
+        self.configure_write_action(
+            self.add_local_terminal_button,
+            enabled_tooltip=self.t("new_local_terminal"),
+        )
         self.expand_all_button.set_tooltip_text(self.t("expand_all"))
         self.collapse_all_button.set_tooltip_text(self.t("collapse_all"))
         self.search_entry.set_placeholder_text(self.t("filter_servers"))

--- a/tests/test_write_actions.py
+++ b/tests/test_write_actions.py
@@ -37,12 +37,25 @@ class WriteActionTests(unittest.TestCase):
         self.assertTrue(widget.sensitive)
         self.assertIsNone(widget.tooltip)
 
+    def test_writable_action_keeps_its_action_tooltip(self) -> None:
+        widget = self.widget()
+
+        self.configure_write_action(
+            self.window(read_only=False, encryption_locked=False),
+            widget,
+            enabled_tooltip="new_group",
+        )
+
+        self.assertTrue(widget.sensitive)
+        self.assertEqual(widget.tooltip, "new_group")
+
     def test_encrypted_store_keeps_write_action_disabled(self) -> None:
         widget = self.widget()
 
         self.configure_write_action(
             self.window(read_only=False, encryption_locked=True),
             widget,
+            enabled_tooltip="new_server",
         )
 
         self.assertFalse(widget.sensitive)
@@ -54,7 +67,25 @@ class WriteActionTests(unittest.TestCase):
         self.configure_write_action(
             self.window(read_only=True, encryption_locked=False),
             widget,
+            enabled_tooltip="new_local_terminal",
         )
 
         self.assertFalse(widget.sensitive)
         self.assertEqual(widget.tooltip, "read_only_mode_tooltip")
+
+    def test_action_tooltip_is_restored_after_write_action_is_unblocked(self) -> None:
+        widget = self.widget()
+
+        self.configure_write_action(
+            self.window(read_only=False, encryption_locked=True),
+            widget,
+            enabled_tooltip="new_server",
+        )
+        self.configure_write_action(
+            self.window(read_only=False, encryption_locked=False),
+            widget,
+            enabled_tooltip="new_server",
+        )
+
+        self.assertTrue(widget.sensitive)
+        self.assertEqual(widget.tooltip, "new_server")


### PR DESCRIPTION
## Summary

- preserve translated tooltips for the icon-only create group, server, and local-terminal sidebar actions
- keep read-only and encrypted-storage explanations while those actions are disabled
- restore the normal action tooltip when write access becomes available
- document the protected behavior and record the fix in the changelog

## Tests

- `python3 -m py_compile src/termia/app.py tests/test_write_actions.py`
- `PYTHONPATH=src python3 -m unittest discover -s tests -p "test_write_actions.py" -v` (5 passed)
- `PYTHONPATH=src python3 -m unittest discover -s tests -v` (75 passed)
- `git diff --check`

Closes #170