### PR TITLE
fix: open startup terminal after unlock cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Changes merged after `0.5.0-beta.2` (released 2026-07-29).
 - Preserve translated action tooltips for writable sidebar icon buttons while
   retaining read-only and locked-connection explanations when disabled
   (`#170`).
+- Open the configured startup local terminal after cancelling encrypted
+  connection unlocking, including in read-only instances (`#172`).
 
 ## 0.5.0-beta.2 - 2026-07-29
 

--- a/docs/REGRESSION_CHECKS.md
+++ b/docs/REGRESSION_CHECKS.md
@@ -48,6 +48,10 @@ Protected behavior does not mean the code cannot change. It means regressions sh
 - Failed SSH connections must leave the tab usable and show the reconnect prompt.
 - The reconnect prompt must be readable on both light and dark terminal backgrounds.
 - Pressing Enter on a failed SSH tab must reconnect to the same server.
+- With the startup local-terminal preference enabled, cancelling the
+  encrypted-connections unlock dialog must open exactly one generic local
+  terminal in writable and read-only instances; disabling the preference must
+  open none, and a successful unlock must not create a duplicate.
 - Exiting an SSH session with `exit` must only close the tab when the relevant preference is enabled, and only after the last terminal in the tab has exited with no split panes remaining.
 - Exiting a local shell must follow the configured local terminal close behavior.
 - Exiting a split shell with `exit` must remove only that split pane and keep sibling panes usable.

--- a/src/termia/app.py
+++ b/src/termia/app.py
@@ -161,7 +161,11 @@ class TermiaWindow(
         if self.store.encryption_locked:
             self.toast_label.set_label(self.t("connections_locked"))
             GLib.idle_add(self.request_unlock_connections)
-        elif self.store.data.app.open_local_terminal_on_startup:
+        else:
+            self.schedule_startup_local_terminal()
+
+    def schedule_startup_local_terminal(self) -> None:
+        if self.store.data.app.open_local_terminal_on_startup:
             GLib.idle_add(self.open_startup_local_terminal)
 
     def open_startup_local_terminal(self) -> bool:
@@ -247,6 +251,7 @@ class TermiaWindow(
         if response != Gtk.ResponseType.OK:
             dialog.destroy()
             self.toast_label.set_label(self.t("connections_locked"))
+            self.schedule_startup_local_terminal()
             return
         if self.store.unlock_connections(password_entry.get_text()):
             dialog.destroy()
@@ -254,8 +259,7 @@ class TermiaWindow(
             self.refresh_translated_chrome()
             self.refresh_list()
             self.toast_label.set_label(self.t("connections_unlocked"))
-            if self.store.data.app.open_local_terminal_on_startup:
-                GLib.idle_add(self.open_startup_local_terminal)
+            self.schedule_startup_local_terminal()
             return
         error.set_label(self.t("unlock_connections_failed"))
         password_entry.set_text("")

--- a/tests/test_startup_terminal.py
+++ b/tests/test_startup_terminal.py
@@ -1,0 +1,118 @@
+import importlib.util
+import unittest
+from types import MethodType, SimpleNamespace
+from unittest.mock import Mock, patch
+
+
+@unittest.skipUnless(importlib.util.find_spec("gi"), "GTK bindings are unavailable")
+class StartupTerminalTests(unittest.TestCase):
+    def setUp(self) -> None:
+        from termia.app import TermiaWindow
+
+        self.TermiaWindow = TermiaWindow
+
+    def window(
+        self,
+        *,
+        open_on_startup: bool,
+        read_only: bool = False,
+        unlock_succeeds: bool = False,
+    ) -> SimpleNamespace:
+        window = SimpleNamespace(
+            store=SimpleNamespace(
+                read_only=read_only,
+                data=SimpleNamespace(
+                    app=SimpleNamespace(
+                        open_local_terminal_on_startup=open_on_startup,
+                    )
+                ),
+                unlock_connections=Mock(return_value=unlock_succeeds),
+            ),
+            toast_label=SimpleNamespace(set_label=Mock()),
+            t=lambda key: key,
+            open_startup_local_terminal=Mock(),
+            apply_app_theme=Mock(),
+            refresh_translated_chrome=Mock(),
+            refresh_list=Mock(),
+        )
+        window.schedule_startup_local_terminal = MethodType(
+            self.TermiaWindow.schedule_startup_local_terminal,
+            window,
+        )
+        return window
+
+    def unlock_response(
+        self,
+        window: SimpleNamespace,
+        response,
+    ) -> tuple[Mock, Mock, Mock]:
+        dialog = Mock()
+        password_entry = Mock()
+        password_entry.get_text.return_value = "synthetic-password"
+        error = Mock()
+        self.TermiaWindow.on_unlock_connections_response(
+            window,
+            dialog,
+            response,
+            password_entry,
+            error,
+        )
+        return dialog, password_entry, error
+
+    def test_cancel_schedules_startup_terminal_in_read_only_mode(self) -> None:
+        from gi.repository import Gtk
+
+        window = self.window(open_on_startup=True, read_only=True)
+
+        with patch("termia.app.GLib.idle_add") as idle_add:
+            dialog, _password_entry, _error = self.unlock_response(
+                window,
+                Gtk.ResponseType.CANCEL,
+            )
+
+        dialog.destroy.assert_called_once_with()
+        window.toast_label.set_label.assert_called_once_with("connections_locked")
+        idle_add.assert_called_once_with(window.open_startup_local_terminal)
+
+    def test_cancel_does_not_schedule_disabled_startup_terminal(self) -> None:
+        from gi.repository import Gtk
+
+        window = self.window(open_on_startup=False, read_only=True)
+
+        with patch("termia.app.GLib.idle_add") as idle_add:
+            self.unlock_response(window, Gtk.ResponseType.CANCEL)
+
+        idle_add.assert_not_called()
+
+    def test_successful_unlock_schedules_one_startup_terminal(self) -> None:
+        from gi.repository import Gtk
+
+        window = self.window(open_on_startup=True, unlock_succeeds=True)
+
+        with patch("termia.app.GLib.idle_add") as idle_add:
+            dialog, password_entry, _error = self.unlock_response(
+                window,
+                Gtk.ResponseType.OK,
+            )
+
+        window.store.unlock_connections.assert_called_once_with("synthetic-password")
+        dialog.destroy.assert_called_once_with()
+        window.apply_app_theme.assert_called_once_with()
+        window.refresh_translated_chrome.assert_called_once_with()
+        window.refresh_list.assert_called_once_with()
+        idle_add.assert_called_once_with(window.open_startup_local_terminal)
+        password_entry.set_text.assert_not_called()
+
+    def test_startup_callback_does_not_duplicate_an_existing_session(self) -> None:
+        opened_sessions: list[object] = []
+        window = SimpleNamespace(
+            session_registry=opened_sessions,
+            on_open_local_terminal=lambda _button: opened_sessions.append(object()),
+        )
+
+        first_result = self.TermiaWindow.open_startup_local_terminal(window)
+        second_result = self.TermiaWindow.open_startup_local_terminal(window)
+
+        self.assertEqual(len(opened_sessions), 1)
+        self.assertFalse(first_result)
+        self.assertFalse(second_result)


### PR DESCRIPTION
## Summary
- schedule the configured startup local terminal after cancelling encrypted-connection unlocking
- preserve the same behavior after a successful unlock and during normal unencrypted startup
- keep locked connection data inaccessible while allowing a generic local shell
- prevent duplicate startup terminals through the existing session-registry guard
- document the regression and update the Unreleased changelog

## Tests
- PYTHONPATH=src python3 -m unittest tests.test_startup_terminal -v (4 passed)
- PYTHONPATH=src python3 -m unittest discover -s tests -v (79 passed)
- python3 -m py_compile run_termia.py scripts/compile_translations.py src/termia/*.py tests/*.py
- scripts/compile_translations.py --check
- git diff --check

## Versioning
No version bump in this PR; the fix is recorded under Unreleased and will be versioned when preparing the next publication.

Closes #172
