### PR TITLE
docs: synchronize localized split-pane features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ Changes merged after `0.5.0-beta.2` (released 2026-07-29).
   saved SSH servers or local terminal profiles, with pane-specific status,
   actions, history, statistics, reconnect state, and process cleanup (`#174`).
 
+### Changed
+
+- Synchronize the Spanish and Catalan feature documentation for independent
+  split-pane connections (`#176`).
+
 ## 0.5.0-beta.2 - 2026-07-29
 
 Changes merged after `0.5.0-beta` (released 2026-07-20).

--- a/docs/README.ca.md
+++ b/docs/README.ca.md
@@ -9,7 +9,9 @@ Documentació en castellà: [README.es.md](README.es.md)
 ## Funcionalitats
 
 - Executar connexions SSH i terminals locals en terminals VTE de GTK 4 integrats.
-- Treballar amb diverses pestanyes, finestres independents i panells de terminal dividits.
+- Treballar amb diverses pestanyes, finestres independents i panells de terminal
+  dividits que es poden connectar independentment a diferents servidors SSH o
+  terminals locals.
 - Desar dissenys de divisió per servidor SSH o perfil de terminal local per reobrir un espai de treball preparat.
 - Pujar fitxers locals a servidors remots amb SCP des del menú contextual del terminal o del servidor.
 - Mantenir les dades de connexió en local amb emmagatzematge en text pla, ofuscat o xifrat opcional protegit per una contrasenya mestra.

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -9,7 +9,9 @@ Documentación en catalán: [README.ca.md](README.ca.md)
 ## Funciones
 
 - Ejecutar conexiones SSH y terminales locales en terminales VTE de GTK 4 integrados.
-- Trabajar con varias pestañas, ventanas independientes y paneles de terminal divididos.
+- Trabajar con varias pestañas, ventanas independientes y paneles de terminal
+  divididos que pueden conectarse de forma independiente a distintos servidores
+  SSH o terminales locales.
 - Guardar diseños de división por servidor SSH o perfil de terminal local para reabrir un espacio de trabajo preparado.
 - Subir ficheros locales a servidores remotos con SCP desde el menú contextual del terminal o del servidor.
 - Mantener los datos de conexión en local con almacenamiento en texto plano, ofuscado o cifrado opcional protegido por una contraseña maestra.


### PR DESCRIPTION
## Summary

- update the Spanish feature list to describe independent SSH and local connections in split panes
- update the Catalan feature list with the same behavior
- record the documentation synchronization under Unreleased

## Validation

- 
- compared the English, Spanish, and Catalan feature descriptions
- reviewed the full staged diff for scope and sensitive data

Closes #176