### PR TITLE
release: prepare Termia 0.5.0-beta.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Changes merged after `0.5.0-beta.3` (released 2026-07-30).
+
+## 0.5.0-beta.3 - 2026-07-30
+
 Changes merged after `0.5.0-beta.2` (released 2026-07-29).
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ Roadmap: [ROADMAP.md](ROADMAP.md)
 
 ## Download and install (Ubuntu 24.04+)
 
-Download [termia_0.5.0.beta.2-1_all.deb](https://github.com/buuuki/termia/releases/download/v0.5.0-beta.2/termia_0.5.0.beta.2-1_all.deb)
+Download [termia_0.5.0.beta.3-1_all.deb](https://github.com/buuuki/termia/releases/download/v0.5.0-beta.3/termia_0.5.0.beta.3-1_all.deb)
 and install it with APT, which resolves the required dependencies:
 
 ```bash
-sudo apt install ./termia_0.5.0.beta.2-1_all.deb
+sudo apt install ./termia_0.5.0.beta.3-1_all.deb
 ```
 
 ## Download from source
@@ -121,11 +121,11 @@ sudo apt build-dep .
 dpkg-buildpackage -us -uc -b
 ```
 
-The resulting `termia_0.5.0~beta.2-1_all.deb` is created in the parent directory.
+The resulting `termia_0.5.0~beta.3-1_all.deb` is created in the parent directory.
 Install it with:
 
 ```bash
-sudo apt install ../termia_0.5.0~beta.2-1_all.deb
+sudo apt install ../termia_0.5.0~beta.3-1_all.deb
 ```
 
 The Debian package installs the `termia` command, desktop launcher, and icon;

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+termia (0.5.0~beta.3-1) unstable; urgency=medium
+
+  * Release Termia 0.5.0-beta.3 with independent split-pane connections and
+    the fixes accumulated since 0.5.0-beta.2.
+  * Synchronize application, Debian package, changelog, and download versions.
+
+ -- Jordi Pons <jpons.git@proton.me>  Thu, 30 Jul 2026 17:52:46 +0200
+
 termia (0.5.0~beta.2-1) unstable; urgency=medium
 
   * Release Termia 0.5.0-beta.2 with the fixes and refactors accumulated since

--- a/docs/README.ca.md
+++ b/docs/README.ca.md
@@ -23,11 +23,11 @@ Documentació en castellà: [README.es.md](README.es.md)
 
 ## Descarregar i instal·lar (Ubuntu 24.04+)
 
-Descarrega [termia_0.5.0.beta.2-1_all.deb](https://github.com/buuuki/termia/releases/download/v0.5.0-beta.2/termia_0.5.0.beta.2-1_all.deb)
+Descarrega [termia_0.5.0.beta.3-1_all.deb](https://github.com/buuuki/termia/releases/download/v0.5.0-beta.3/termia_0.5.0.beta.3-1_all.deb)
 i instal·la'l amb APT, que resoldrà les dependències necessàries:
 
 ```bash
-sudo apt install ./termia_0.5.0.beta.2-1_all.deb
+sudo apt install ./termia_0.5.0.beta.3-1_all.deb
 ```
 
 ## Descarregar i instal·lar des del codi font
@@ -106,11 +106,11 @@ sudo apt build-dep .
 dpkg-buildpackage -us -uc -b
 ```
 
-El fitxer `termia_0.5.0~beta.2-1_all.deb` es crea al directori pare. Instal·la'l
+El fitxer `termia_0.5.0~beta.3-1_all.deb` es crea al directori pare. Instal·la'l
 amb:
 
 ```bash
-sudo apt install ../termia_0.5.0~beta.2-1_all.deb
+sudo apt install ../termia_0.5.0~beta.3-1_all.deb
 ```
 
 El paquet Debian instal·la l'ordre `termia`, el llançador d'escriptori i la

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -23,11 +23,11 @@ Documentación en catalán: [README.ca.md](README.ca.md)
 
 ## Descargar e instalar (Ubuntu 24.04+)
 
-Descarga [termia_0.5.0.beta.2-1_all.deb](https://github.com/buuuki/termia/releases/download/v0.5.0-beta.2/termia_0.5.0.beta.2-1_all.deb)
+Descarga [termia_0.5.0.beta.3-1_all.deb](https://github.com/buuuki/termia/releases/download/v0.5.0-beta.3/termia_0.5.0.beta.3-1_all.deb)
 e instálalo con APT, que resolverá las dependencias necesarias:
 
 ```bash
-sudo apt install ./termia_0.5.0.beta.2-1_all.deb
+sudo apt install ./termia_0.5.0.beta.3-1_all.deb
 ```
 
 ## Descargar e instalar desde el código fuente
@@ -106,11 +106,11 @@ sudo apt build-dep .
 dpkg-buildpackage -us -uc -b
 ```
 
-El fichero `termia_0.5.0~beta.2-1_all.deb` se crea en el directorio padre.
+El fichero `termia_0.5.0~beta.3-1_all.deb` se crea en el directorio padre.
 Instálalo con:
 
 ```bash
-sudo apt install ../termia_0.5.0~beta.2-1_all.deb
+sudo apt install ../termia_0.5.0~beta.3-1_all.deb
 ```
 
 El paquete Debian instala el comando `termia`, el lanzador de escritorio y el

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -42,8 +42,8 @@ since the previous release.
 ## Current beta baseline
 
 The existing `0.5.0-beta` release is treated as the first beta iteration of
-`0.5.0`; its historical tag and release are not renamed. The next publication
-on the same line must use `0.5.0-beta.2`.
+`0.5.0`; its historical tag and release are not renamed. The current source
+release line is `0.5.0-beta.3`.
 
 ## Debian package versions
 
@@ -60,6 +60,7 @@ version. The mapping is:
 | --- | --- |
 | `0.5.0-beta.1` | `0.5.0~beta.1-1` |
 | `0.5.0-beta.2` | `0.5.0~beta.2-1` |
+| `0.5.0-beta.3` | `0.5.0~beta.3-1` |
 | `0.5.1-beta.1` | `0.5.1~beta.1-1` |
 | `0.6.0-beta.1` | `0.6.0~beta.1-1` |
 | `0.5.0` | `0.5.0-1` |
@@ -67,7 +68,7 @@ version. The mapping is:
 This produces the required upgrade ordering:
 
 ```text
-0.5.0~beta.1-1 < 0.5.0~beta.2-1 < 0.5.0-1
+0.5.0~beta.1-1 < 0.5.0~beta.2-1 < 0.5.0~beta.3-1 < 0.5.0-1
 ```
 
 The Debian revision starts at `-1` for every Termia application version.

--- a/src/termia/__init__.py
+++ b/src/termia/__init__.py
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 """Termia SSH connection manager."""
 
-__version__ = "0.5.0-beta.2"
+__version__ = "0.5.0-beta.3"


### PR DESCRIPTION
## Summary

- set the Termia application version to 0.5.0-beta.3
- publish the accumulated Unreleased entries as the dated beta.3 changelog section
- set the Debian package version to 0.5.0~beta.3-1
- update English, Spanish, and Catalan download and local-build examples
- update the documented current beta baseline and Debian version ordering

## Validation

- PYTHONPATH=src python3 -m unittest discover -s tests -v: 93 tests passed
- python3 -m py_compile run_termia.py scripts/compile_translations.py src/termia/*.py tests/*.py
- python3 scripts/compile_translations.py --check: 290 messages synchronized
- bash -n scripts/termia-setup.sh
- dpkg-checkbuilddeps
- dpkg-buildpackage -us -uc -b: successful, including 93 Debian build tests
- dpkg-deb metadata: Version 0.5.0~beta.3-1, Architecture all
- verified installed application version 0.5.0-beta.3 and Python metadata 0.5.0b3
- verified package contents, desktop launcher, icon, translations, dependencies, and Debian upgrade ordering
- package SHA-256: 486e5a76adb88ba0ff8a397cdce0d5580bc4a02952e676a6654f3d522a8b8979
- git diff --check and full privacy/scope review

## Post-merge release steps

After explicit merge approval, rebuild from merged main, verify reproducibility and metadata, create annotated tag v0.5.0-beta.3, publish a prerelease GitHub Release, upload termia_0.5.0.beta.3-1_all.deb, and verify the public download.

Closes #180