### PR TITLE
fix: embed startup unlock prompt in main window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 Changes merged after `0.5.0-beta.3` (released 2026-07-30).
 
+### Fixed
+
+- Open the startup master-password dialog only after its Termia window is
+  mapped so the modal transient stays with its parent on multi-monitor desktops
+  (`#182`).
+
 ## 0.5.0-beta.3 - 2026-07-30
 
 Changes merged after `0.5.0-beta.2` (released 2026-07-29).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ Changes merged after `0.5.0-beta.3` (released 2026-07-30).
 ### Fixed
 
 - Show the startup master-password prompt as a modal layer inside the Termia
-  window so it cannot appear on a different monitor (`#182`).
+  window so it cannot appear on a different monitor, while keeping the locked
+  window movable through its header bar (`#182`).
 
 ## 0.5.0-beta.3 - 2026-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,8 @@ Changes merged after `0.5.0-beta.3` (released 2026-07-30).
 
 ### Fixed
 
-- Open the startup master-password dialog only after its Termia window is
-  mapped so the modal transient stays with its parent on multi-monitor desktops
-  (`#182`).
+- Show the startup master-password prompt as a modal layer inside the Termia
+  window so it cannot appear on a different monitor (`#182`).
 
 ## 0.5.0-beta.3 - 2026-07-30
 

--- a/docs/REGRESSION_CHECKS.md
+++ b/docs/REGRESSION_CHECKS.md
@@ -111,6 +111,9 @@ Protected behavior does not mean the code cannot change. It means regressions sh
 - New plain `connections.json` writes must contain only groups and servers; app and terminal preferences must be written to `settings.json`.
 - Obfuscated connection storage must decode back to the same groups, servers, passwords, and private key paths, and switching modes must rewrite the file immediately.
 - Encrypted connection storage must require a master password on startup, preserve groups, servers, passwords, and private key paths after unlock, allow canceling activation before setting a password, and never silently recover data if the master password is lost.
+- The startup master-password dialog must open only after the main Termia
+  window is mapped and remain modal and transient for that window so both stay
+  together on single- and multi-monitor desktops.
 - Import/export configuration must preserve groups, subgroups, servers, SSH user, port, host, password, and private key path where available.
 - Importing Asbru configuration must not add unwanted suffixes such as `- copy`.
 - Launching a second Termia process must open a separate window and leave the new instance in read-only mode instead of writing shared config files concurrently.
@@ -200,6 +203,10 @@ Before merging changes that touch UI, terminals, tabs, or configuration, verify:
 - Open Import/Export, close the menu with `Esc` or its menu button, and confirm reopening starts at the top-level menu.
 - Open Preferences from Configuration and confirm the app does not hang.
 - Start a second Termia process and confirm it opens as a separate window with the read-only badge visible.
+- With encrypted connection storage, start Termia on each monitor in turn and
+  confirm the master-password dialog stays above the mapped Termia window on
+  that same monitor; verify successful unlock and cancellation in writable and
+  read-only instances.
 - In the read-only instance, confirm add/edit/delete/import/clear/preferences actions are disabled or rejected, while connecting and exporting still work.
 - Switch between available app themes and confirm header, menus, sidebars, dialogs, selected rows, and tabs remain readable.
 - Change terminal foreground/background/palette and confirm only VTE terminal colors change, not the app chrome.

--- a/docs/REGRESSION_CHECKS.md
+++ b/docs/REGRESSION_CHECKS.md
@@ -114,7 +114,8 @@ Protected behavior does not mean the code cannot change. It means regressions sh
 - The startup master-password prompt must be an in-window modal layer rather
   than a separate desktop window, so it always stays inside Termia on single-
   and multi-monitor desktops and blocks the underlying controls until it is
-  unlocked or cancelled.
+  unlocked or cancelled. Window-management actions must remain available so
+  the locked window can still be moved, minimized, maximized, or closed.
 - Import/export configuration must preserve groups, subgroups, servers, SSH user, port, host, password, and private key path where available.
 - Importing Asbru configuration must not add unwanted suffixes such as `- copy`.
 - Launching a second Termia process must open a separate window and leave the new instance in read-only mode instead of writing shared config files concurrently.
@@ -206,8 +207,9 @@ Before merging changes that touch UI, terminals, tabs, or configuration, verify:
 - Start a second Termia process and confirm it opens as a separate window with the read-only badge visible.
 - With encrypted connection storage, start Termia on each monitor in turn and
   confirm the master-password prompt is rendered inside the Termia window;
-  verify that underlying controls are blocked and that successful unlock and
-  cancellation work in writable and read-only instances.
+  move the locked window between monitors, verify that underlying application
+  controls are blocked, and confirm that successful unlock and cancellation
+  work in writable and read-only instances.
 - In the read-only instance, confirm add/edit/delete/import/clear/preferences actions are disabled or rejected, while connecting and exporting still work.
 - Switch between available app themes and confirm header, menus, sidebars, dialogs, selected rows, and tabs remain readable.
 - Change terminal foreground/background/palette and confirm only VTE terminal colors change, not the app chrome.

--- a/docs/REGRESSION_CHECKS.md
+++ b/docs/REGRESSION_CHECKS.md
@@ -111,9 +111,10 @@ Protected behavior does not mean the code cannot change. It means regressions sh
 - New plain `connections.json` writes must contain only groups and servers; app and terminal preferences must be written to `settings.json`.
 - Obfuscated connection storage must decode back to the same groups, servers, passwords, and private key paths, and switching modes must rewrite the file immediately.
 - Encrypted connection storage must require a master password on startup, preserve groups, servers, passwords, and private key paths after unlock, allow canceling activation before setting a password, and never silently recover data if the master password is lost.
-- The startup master-password dialog must open only after the main Termia
-  window is mapped and remain modal and transient for that window so both stay
-  together on single- and multi-monitor desktops.
+- The startup master-password prompt must be an in-window modal layer rather
+  than a separate desktop window, so it always stays inside Termia on single-
+  and multi-monitor desktops and blocks the underlying controls until it is
+  unlocked or cancelled.
 - Import/export configuration must preserve groups, subgroups, servers, SSH user, port, host, password, and private key path where available.
 - Importing Asbru configuration must not add unwanted suffixes such as `- copy`.
 - Launching a second Termia process must open a separate window and leave the new instance in read-only mode instead of writing shared config files concurrently.
@@ -204,9 +205,9 @@ Before merging changes that touch UI, terminals, tabs, or configuration, verify:
 - Open Preferences from Configuration and confirm the app does not hang.
 - Start a second Termia process and confirm it opens as a separate window with the read-only badge visible.
 - With encrypted connection storage, start Termia on each monitor in turn and
-  confirm the master-password dialog stays above the mapped Termia window on
-  that same monitor; verify successful unlock and cancellation in writable and
-  read-only instances.
+  confirm the master-password prompt is rendered inside the Termia window;
+  verify that underlying controls are blocked and that successful unlock and
+  cancellation work in writable and read-only instances.
 - In the read-only instance, confirm add/edit/delete/import/clear/preferences actions are disabled or rejected, while connecting and exporting still work.
 - Switch between available app themes and confirm header, menus, sidebars, dialogs, selected rows, and tabs remain readable.
 - Change terminal foreground/background/palette and confirm only VTE terminal colors change, not the app chrome.

--- a/src/termia/app.py
+++ b/src/termia/app.py
@@ -212,15 +212,23 @@ class TermiaWindow(
         self.unlock_scrim.set_visible(True)
         self.unlock_panel.set_visible(True)
         self.main_root.set_sensitive(False)
-        self.header.set_sensitive(False)
+        self.set_unlock_header_actions_sensitive(False)
         self.unlock_password_entry.grab_focus()
         return GLib.SOURCE_REMOVE
+
+    def set_unlock_header_actions_sensitive(self, sensitive: bool) -> None:
+        for control in (
+            self.toggle_sidebar_button,
+            self.new_tab_button,
+            self.main_menu_button,
+        ):
+            control.set_sensitive(sensitive)
 
     def hide_unlock_panel(self) -> None:
         self.unlock_panel.set_visible(False)
         self.unlock_scrim.set_visible(False)
         self.main_root.set_sensitive(True)
-        self.header.set_sensitive(True)
+        self.set_unlock_header_actions_sensitive(True)
 
     def on_unlock_connections_cancelled(self, _button: Gtk.Button | None = None) -> None:
         self.hide_unlock_panel()

--- a/src/termia/app.py
+++ b/src/termia/app.py
@@ -145,6 +145,8 @@ class TermiaWindow(
         self.stats_save_id: int | None = None
         self.close_confirmation_pending = False
         self.shutdown_in_progress = False
+        self.startup_started = False
+        self.startup_source_id: int | None = None
         self.connect("close-request", self.on_main_window_close_request)
         self.connect("destroy", lambda *_args: self.store.close())
         if hasattr(GLib, "unix_signal_add"):
@@ -161,9 +163,27 @@ class TermiaWindow(
         self.refresh_list()
         if self.store.encryption_locked:
             self.toast_label.set_label(self.t("connections_locked"))
-            GLib.idle_add(self.request_unlock_connections)
+
+    def begin_startup_after_present(self) -> None:
+        if self.startup_started or self.startup_source_id is not None:
+            return
+        self.startup_source_id = GLib.idle_add(
+            self.continue_startup_after_map,
+        )
+
+    def continue_startup_after_map(self) -> bool:
+        if self.startup_started:
+            self.startup_source_id = None
+            return GLib.SOURCE_REMOVE
+        if not self.get_mapped():
+            return GLib.SOURCE_CONTINUE
+        self.startup_started = True
+        self.startup_source_id = None
+        if self.store.encryption_locked:
+            self.request_unlock_connections()
         else:
             self.schedule_startup_local_terminal()
+        return GLib.SOURCE_REMOVE
 
     def schedule_startup_local_terminal(self) -> None:
         if self.store.data.app.open_local_terminal_on_startup:
@@ -602,9 +622,12 @@ class TermiaApp(Gtk.Application):
 
     def do_activate(self) -> None:
         window = self.props.active_window
+        created = window is None
         if window is None:
             window = TermiaWindow(self)
         window.present()
+        if created:
+            window.begin_startup_after_present()
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/src/termia/app.py
+++ b/src/termia/app.py
@@ -145,8 +145,6 @@ class TermiaWindow(
         self.stats_save_id: int | None = None
         self.close_confirmation_pending = False
         self.shutdown_in_progress = False
-        self.startup_started = False
-        self.startup_source_id: int | None = None
         self.connect("close-request", self.on_main_window_close_request)
         self.connect("destroy", lambda *_args: self.store.close())
         if hasattr(GLib, "unix_signal_add"):
@@ -163,27 +161,9 @@ class TermiaWindow(
         self.refresh_list()
         if self.store.encryption_locked:
             self.toast_label.set_label(self.t("connections_locked"))
-
-    def begin_startup_after_present(self) -> None:
-        if self.startup_started or self.startup_source_id is not None:
-            return
-        self.startup_source_id = GLib.idle_add(
-            self.continue_startup_after_map,
-        )
-
-    def continue_startup_after_map(self) -> bool:
-        if self.startup_started:
-            self.startup_source_id = None
-            return GLib.SOURCE_REMOVE
-        if not self.get_mapped():
-            return GLib.SOURCE_CONTINUE
-        self.startup_started = True
-        self.startup_source_id = None
-        if self.store.encryption_locked:
             self.request_unlock_connections()
         else:
             self.schedule_startup_local_terminal()
-        return GLib.SOURCE_REMOVE
 
     def schedule_startup_local_terminal(self) -> None:
         if self.store.data.app.open_local_terminal_on_startup:
@@ -227,64 +207,42 @@ class TermiaWindow(
         return widget
 
     def request_unlock_connections(self) -> bool:
-        dialog = Gtk.Dialog(title=self.t("unlock_connections_title"), transient_for=self, modal=True)
-        dialog.set_resizable(False)
-        dialog.set_default_size(420, -1)
-        dialog.add_button(self.t("cancel"), Gtk.ResponseType.CANCEL)
-        dialog.add_button(self.t("unlock"), Gtk.ResponseType.OK)
-        dialog.set_default_response(Gtk.ResponseType.OK)
-
-        content = dialog.get_content_area()
-        content.set_margin_top(16)
-        content.set_margin_bottom(16)
-        content.set_margin_start(16)
-        content.set_margin_end(16)
-        content.set_spacing(12)
-
-        detail = Gtk.Label(label=self.t("unlock_connections_detail"))
-        detail.set_xalign(0)
-        detail.set_wrap(True)
-        content.append(detail)
-
-        password_entry = Gtk.PasswordEntry()
-        password_entry.set_show_peek_icon(True)
-        password_entry.connect("activate", lambda _entry: dialog.response(Gtk.ResponseType.OK))
-        content.append(password_entry)
-
-        error = Gtk.Label(label=self.store.encryption_error)
-        error.set_xalign(0)
-        error.set_wrap(True)
-        error.add_css_class("error")
-        content.append(error)
-
-        dialog.connect("response", self.on_unlock_connections_response, password_entry, error)
-        dialog.present()
-        password_entry.grab_focus()
+        self.unlock_password_entry.set_text("")
+        self.unlock_error_label.set_label(self.store.encryption_error)
+        self.unlock_scrim.set_visible(True)
+        self.unlock_panel.set_visible(True)
+        self.main_root.set_sensitive(False)
+        self.header.set_sensitive(False)
+        self.unlock_password_entry.grab_focus()
         return GLib.SOURCE_REMOVE
 
-    def on_unlock_connections_response(
-        self,
-        dialog: Gtk.Dialog,
-        response: Gtk.ResponseType,
-        password_entry: Gtk.PasswordEntry,
-        error: Gtk.Label,
-    ) -> None:
-        if response != Gtk.ResponseType.OK:
-            dialog.destroy()
-            self.toast_label.set_label(self.t("connections_locked"))
-            self.schedule_startup_local_terminal()
-            return
-        if self.store.unlock_connections(password_entry.get_text()):
-            dialog.destroy()
+    def hide_unlock_panel(self) -> None:
+        self.unlock_panel.set_visible(False)
+        self.unlock_scrim.set_visible(False)
+        self.main_root.set_sensitive(True)
+        self.header.set_sensitive(True)
+
+    def on_unlock_connections_cancelled(self, _button: Gtk.Button | None = None) -> None:
+        self.hide_unlock_panel()
+        self.toast_label.set_label(self.t("connections_locked"))
+        self.schedule_startup_local_terminal()
+
+    def on_unlock_connections_requested(self, _button: Gtk.Button | None = None) -> None:
+        if self.store.unlock_connections(self.unlock_password_entry.get_text()):
+            self.hide_unlock_panel()
             self.apply_app_theme()
             self.refresh_translated_chrome()
             self.refresh_list()
             self.toast_label.set_label(self.t("connections_unlocked"))
             self.schedule_startup_local_terminal()
             return
-        error.set_label(self.t("unlock_connections_failed"))
-        password_entry.set_text("")
-        password_entry.grab_focus()
+        self.unlock_error_label.set_label(self.t("unlock_connections_failed"))
+        self.unlock_password_entry.set_text("")
+        self.unlock_password_entry.grab_focus()
+
+    def focus_startup_control(self) -> None:
+        if self.unlock_panel.get_visible():
+            self.unlock_password_entry.grab_focus()
 
     def on_main_window_close_request(self, _window: Gtk.Window) -> bool:
         if self.shutdown_in_progress:
@@ -363,8 +321,12 @@ class TermiaWindow(
         )
 
     def _build_ui(self) -> None:
+        window_overlay = Gtk.Overlay()
+        self.set_child(window_overlay)
+
         root = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
-        self.set_child(root)
+        self.main_root = root
+        window_overlay.set_child(root)
 
         window_keys = Gtk.EventControllerKey.new()
         window_keys.set_propagation_phase(Gtk.PropagationPhase.CAPTURE)
@@ -372,6 +334,7 @@ class TermiaWindow(
         self.add_controller(window_keys)
 
         header = Gtk.HeaderBar()
+        self.header = header
         self.set_titlebar(header)
 
         toggle_sidebar = Gtk.Button(icon_name="sidebar-hide-symbolic")
@@ -509,6 +472,70 @@ class TermiaWindow(
         self.terminal_stack.set_vexpand(True)
         detail.append(self.terminal_stack)
 
+        unlock_scrim = Gtk.Box()
+        self.unlock_scrim = unlock_scrim
+        unlock_scrim.set_halign(Gtk.Align.FILL)
+        unlock_scrim.set_valign(Gtk.Align.FILL)
+        unlock_scrim.set_hexpand(True)
+        unlock_scrim.set_vexpand(True)
+        unlock_scrim.set_visible(False)
+        window_overlay.add_overlay(unlock_scrim)
+
+        unlock_panel = Gtk.Frame()
+        self.unlock_panel = unlock_panel
+        unlock_panel.add_css_class("background")
+        unlock_panel.add_css_class("card")
+        unlock_panel.set_halign(Gtk.Align.CENTER)
+        unlock_panel.set_valign(Gtk.Align.CENTER)
+        unlock_panel.set_size_request(420, -1)
+        unlock_panel.set_margin_top(20)
+        unlock_panel.set_margin_bottom(20)
+        unlock_panel.set_margin_start(20)
+        unlock_panel.set_margin_end(20)
+        unlock_panel.set_visible(False)
+
+        unlock_content = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
+        unlock_content.set_margin_top(20)
+        unlock_content.set_margin_bottom(20)
+        unlock_content.set_margin_start(20)
+        unlock_content.set_margin_end(20)
+        unlock_panel.set_child(unlock_content)
+
+        unlock_title = Gtk.Label(label=self.t("unlock_connections_title"))
+        unlock_title.set_xalign(0)
+        unlock_title.add_css_class("title-2")
+        unlock_content.append(unlock_title)
+
+        unlock_detail = Gtk.Label(label=self.t("unlock_connections_detail"))
+        unlock_detail.set_xalign(0)
+        unlock_detail.set_wrap(True)
+        unlock_content.append(unlock_detail)
+
+        unlock_password_entry = Gtk.PasswordEntry()
+        self.unlock_password_entry = unlock_password_entry
+        unlock_password_entry.set_show_peek_icon(True)
+        unlock_password_entry.connect("activate", self.on_unlock_connections_requested)
+        unlock_content.append(unlock_password_entry)
+
+        unlock_error = Gtk.Label()
+        self.unlock_error_label = unlock_error
+        unlock_error.set_xalign(0)
+        unlock_error.set_wrap(True)
+        unlock_error.add_css_class("error")
+        unlock_content.append(unlock_error)
+
+        unlock_actions = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+        unlock_actions.set_halign(Gtk.Align.END)
+        cancel_button = Gtk.Button(label=self.t("cancel"))
+        cancel_button.connect("clicked", self.on_unlock_connections_cancelled)
+        unlock_actions.append(cancel_button)
+        unlock_button = Gtk.Button(label=self.t("unlock"))
+        unlock_button.add_css_class("suggested-action")
+        unlock_button.connect("clicked", self.on_unlock_connections_requested)
+        unlock_actions.append(unlock_button)
+        unlock_content.append(unlock_actions)
+        window_overlay.add_overlay(unlock_panel)
+
     def on_window_key_pressed(
         self,
         _controller: Gtk.EventControllerKey,
@@ -516,6 +543,11 @@ class TermiaWindow(
         _keycode: int,
         state: Gdk.ModifierType,
     ) -> bool:
+        if self.unlock_panel.get_visible():
+            if keyval == Gdk.KEY_Escape:
+                self.on_unlock_connections_cancelled()
+                return True
+            return False
         keybindings = self.store.data.app.keybindings
         if keybinding_matches(keybindings.get("filter_servers", ""), keyval, state):
             return self.focus_server_filter()
@@ -627,7 +659,7 @@ class TermiaApp(Gtk.Application):
             window = TermiaWindow(self)
         window.present()
         if created:
-            window.begin_startup_after_present()
+            window.focus_startup_control()
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tests/test_startup_terminal.py
+++ b/tests/test_startup_terminal.py
@@ -59,7 +59,9 @@ class StartupTerminalTests(unittest.TestCase):
             unlock_panel=Mock(),
             unlock_scrim=Mock(),
             main_root=Mock(),
-            header=Mock(),
+            toggle_sidebar_button=Mock(),
+            new_tab_button=Mock(),
+            main_menu_button=Mock(),
             unlock_password_entry=Mock(),
             unlock_error_label=Mock(),
         )
@@ -72,6 +74,10 @@ class StartupTerminalTests(unittest.TestCase):
             self.TermiaWindow.hide_unlock_panel,
             window,
         )
+        window.set_unlock_header_actions_sensitive = MethodType(
+            self.TermiaWindow.set_unlock_header_actions_sensitive,
+            window,
+        )
         return window
 
     def test_unlock_panel_is_shown_inside_the_main_window(self) -> None:
@@ -82,7 +88,9 @@ class StartupTerminalTests(unittest.TestCase):
         window.unlock_panel.set_visible.assert_called_once_with(True)
         window.unlock_scrim.set_visible.assert_called_once_with(True)
         window.main_root.set_sensitive.assert_called_once_with(False)
-        window.header.set_sensitive.assert_called_once_with(False)
+        window.toggle_sidebar_button.set_sensitive.assert_called_once_with(False)
+        window.new_tab_button.set_sensitive.assert_called_once_with(False)
+        window.main_menu_button.set_sensitive.assert_called_once_with(False)
         window.unlock_error_label.set_label.assert_called_once_with("synthetic encryption error")
         window.unlock_password_entry.grab_focus.assert_called_once_with()
         self.assertFalse(result)
@@ -98,7 +106,9 @@ class StartupTerminalTests(unittest.TestCase):
         window.unlock_panel.set_visible.assert_called_once_with(False)
         window.unlock_scrim.set_visible.assert_called_once_with(False)
         window.main_root.set_sensitive.assert_called_once_with(True)
-        window.header.set_sensitive.assert_called_once_with(True)
+        window.toggle_sidebar_button.set_sensitive.assert_called_once_with(True)
+        window.new_tab_button.set_sensitive.assert_called_once_with(True)
+        window.main_menu_button.set_sensitive.assert_called_once_with(True)
         window.toast_label.set_label.assert_called_once_with("connections_locked")
         idle_add.assert_called_once_with(window.open_startup_local_terminal)
 

--- a/tests/test_startup_terminal.py
+++ b/tests/test_startup_terminal.py
@@ -1,15 +1,104 @@
 import importlib.util
 import unittest
 from types import MethodType, SimpleNamespace
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, call, patch
 
 
 @unittest.skipUnless(importlib.util.find_spec("gi"), "GTK bindings are unavailable")
 class StartupTerminalTests(unittest.TestCase):
     def setUp(self) -> None:
-        from termia.app import TermiaWindow
+        from termia.app import TermiaApp, TermiaWindow
 
+        self.TermiaApp = TermiaApp
         self.TermiaWindow = TermiaWindow
+
+    def startup_window(
+        self,
+        *,
+        encryption_locked: bool,
+        mapped: bool,
+    ) -> SimpleNamespace:
+        window = SimpleNamespace(
+            store=SimpleNamespace(encryption_locked=encryption_locked),
+            startup_started=False,
+            startup_source_id=None,
+            get_mapped=Mock(return_value=mapped),
+            request_unlock_connections=Mock(),
+            schedule_startup_local_terminal=Mock(),
+        )
+        window.begin_startup_after_present = MethodType(
+            self.TermiaWindow.begin_startup_after_present,
+            window,
+        )
+        window.continue_startup_after_map = MethodType(
+            self.TermiaWindow.continue_startup_after_map,
+            window,
+        )
+        return window
+
+    def test_application_presents_new_window_before_startup(self) -> None:
+        app = SimpleNamespace(props=SimpleNamespace(active_window=None))
+        window = Mock()
+
+        with patch("termia.app.TermiaWindow", return_value=window):
+            self.TermiaApp.do_activate(app)
+
+        self.assertEqual(
+            window.method_calls,
+            [call.present(), call.begin_startup_after_present()],
+        )
+
+    def test_application_does_not_restart_an_existing_window(self) -> None:
+        window = Mock()
+        app = SimpleNamespace(props=SimpleNamespace(active_window=window))
+
+        self.TermiaApp.do_activate(app)
+
+        self.assertEqual(window.method_calls, [call.present()])
+
+    def test_locked_startup_waits_for_the_first_window_map(self) -> None:
+        window = self.startup_window(encryption_locked=True, mapped=False)
+
+        with patch("termia.app.GLib.idle_add", return_value=73) as idle_add:
+            window.begin_startup_after_present()
+            waiting_result = window.continue_startup_after_map()
+            window.get_mapped.return_value = True
+            mapped_result = window.continue_startup_after_map()
+            duplicate_result = window.continue_startup_after_map()
+
+        idle_add.assert_called_once_with(window.continue_startup_after_map)
+        self.assertTrue(waiting_result)
+        self.assertFalse(mapped_result)
+        self.assertFalse(duplicate_result)
+        window.request_unlock_connections.assert_called_once_with()
+        self.assertTrue(window.startup_started)
+        self.assertIsNone(window.startup_source_id)
+
+    def test_already_mapped_locked_window_schedules_unlock_immediately(self) -> None:
+        window = self.startup_window(encryption_locked=True, mapped=True)
+
+        with patch("termia.app.GLib.idle_add", return_value=73) as idle_add:
+            window.begin_startup_after_present()
+            window.begin_startup_after_present()
+            result = window.continue_startup_after_map()
+
+        idle_add.assert_called_once_with(window.continue_startup_after_map)
+        window.request_unlock_connections.assert_called_once_with()
+        self.assertFalse(result)
+
+    def test_unlocked_startup_waits_for_map_before_opening_terminal(self) -> None:
+        window = self.startup_window(encryption_locked=False, mapped=False)
+
+        with patch("termia.app.GLib.idle_add", return_value=73) as idle_add:
+            window.begin_startup_after_present()
+            waiting_result = window.continue_startup_after_map()
+            window.get_mapped.return_value = True
+            mapped_result = window.continue_startup_after_map()
+
+        idle_add.assert_called_once_with(window.continue_startup_after_map)
+        self.assertTrue(waiting_result)
+        self.assertFalse(mapped_result)
+        window.schedule_startup_local_terminal.assert_called_once_with()
 
     def window(
         self,

--- a/tests/test_startup_terminal.py
+++ b/tests/test_startup_terminal.py
@@ -12,31 +12,7 @@ class StartupTerminalTests(unittest.TestCase):
         self.TermiaApp = TermiaApp
         self.TermiaWindow = TermiaWindow
 
-    def startup_window(
-        self,
-        *,
-        encryption_locked: bool,
-        mapped: bool,
-    ) -> SimpleNamespace:
-        window = SimpleNamespace(
-            store=SimpleNamespace(encryption_locked=encryption_locked),
-            startup_started=False,
-            startup_source_id=None,
-            get_mapped=Mock(return_value=mapped),
-            request_unlock_connections=Mock(),
-            schedule_startup_local_terminal=Mock(),
-        )
-        window.begin_startup_after_present = MethodType(
-            self.TermiaWindow.begin_startup_after_present,
-            window,
-        )
-        window.continue_startup_after_map = MethodType(
-            self.TermiaWindow.continue_startup_after_map,
-            window,
-        )
-        return window
-
-    def test_application_presents_new_window_before_startup(self) -> None:
+    def test_application_presents_new_window_and_focuses_startup_control(self) -> None:
         app = SimpleNamespace(props=SimpleNamespace(active_window=None))
         window = Mock()
 
@@ -45,7 +21,7 @@ class StartupTerminalTests(unittest.TestCase):
 
         self.assertEqual(
             window.method_calls,
-            [call.present(), call.begin_startup_after_present()],
+            [call.present(), call.focus_startup_control()],
         )
 
     def test_application_does_not_restart_an_existing_window(self) -> None:
@@ -55,50 +31,6 @@ class StartupTerminalTests(unittest.TestCase):
         self.TermiaApp.do_activate(app)
 
         self.assertEqual(window.method_calls, [call.present()])
-
-    def test_locked_startup_waits_for_the_first_window_map(self) -> None:
-        window = self.startup_window(encryption_locked=True, mapped=False)
-
-        with patch("termia.app.GLib.idle_add", return_value=73) as idle_add:
-            window.begin_startup_after_present()
-            waiting_result = window.continue_startup_after_map()
-            window.get_mapped.return_value = True
-            mapped_result = window.continue_startup_after_map()
-            duplicate_result = window.continue_startup_after_map()
-
-        idle_add.assert_called_once_with(window.continue_startup_after_map)
-        self.assertTrue(waiting_result)
-        self.assertFalse(mapped_result)
-        self.assertFalse(duplicate_result)
-        window.request_unlock_connections.assert_called_once_with()
-        self.assertTrue(window.startup_started)
-        self.assertIsNone(window.startup_source_id)
-
-    def test_already_mapped_locked_window_schedules_unlock_immediately(self) -> None:
-        window = self.startup_window(encryption_locked=True, mapped=True)
-
-        with patch("termia.app.GLib.idle_add", return_value=73) as idle_add:
-            window.begin_startup_after_present()
-            window.begin_startup_after_present()
-            result = window.continue_startup_after_map()
-
-        idle_add.assert_called_once_with(window.continue_startup_after_map)
-        window.request_unlock_connections.assert_called_once_with()
-        self.assertFalse(result)
-
-    def test_unlocked_startup_waits_for_map_before_opening_terminal(self) -> None:
-        window = self.startup_window(encryption_locked=False, mapped=False)
-
-        with patch("termia.app.GLib.idle_add", return_value=73) as idle_add:
-            window.begin_startup_after_present()
-            waiting_result = window.continue_startup_after_map()
-            window.get_mapped.return_value = True
-            mapped_result = window.continue_startup_after_map()
-
-        idle_add.assert_called_once_with(window.continue_startup_after_map)
-        self.assertTrue(waiting_result)
-        self.assertFalse(mapped_result)
-        window.schedule_startup_local_terminal.assert_called_once_with()
 
     def window(
         self,
@@ -115,6 +47,7 @@ class StartupTerminalTests(unittest.TestCase):
                         open_local_terminal_on_startup=open_on_startup,
                     )
                 ),
+                encryption_error="synthetic encryption error",
                 unlock_connections=Mock(return_value=unlock_succeeds),
             ),
             toast_label=SimpleNamespace(set_label=Mock()),
@@ -123,74 +56,87 @@ class StartupTerminalTests(unittest.TestCase):
             apply_app_theme=Mock(),
             refresh_translated_chrome=Mock(),
             refresh_list=Mock(),
+            unlock_panel=Mock(),
+            unlock_scrim=Mock(),
+            main_root=Mock(),
+            header=Mock(),
+            unlock_password_entry=Mock(),
+            unlock_error_label=Mock(),
         )
+        window.unlock_password_entry.get_text.return_value = "synthetic-password"
         window.schedule_startup_local_terminal = MethodType(
             self.TermiaWindow.schedule_startup_local_terminal,
             window,
         )
+        window.hide_unlock_panel = MethodType(
+            self.TermiaWindow.hide_unlock_panel,
+            window,
+        )
         return window
 
-    def unlock_response(
-        self,
-        window: SimpleNamespace,
-        response,
-    ) -> tuple[Mock, Mock, Mock]:
-        dialog = Mock()
-        password_entry = Mock()
-        password_entry.get_text.return_value = "synthetic-password"
-        error = Mock()
-        self.TermiaWindow.on_unlock_connections_response(
-            window,
-            dialog,
-            response,
-            password_entry,
-            error,
-        )
-        return dialog, password_entry, error
+    def test_unlock_panel_is_shown_inside_the_main_window(self) -> None:
+        window = self.window(open_on_startup=True)
+
+        result = self.TermiaWindow.request_unlock_connections(window)
+
+        window.unlock_panel.set_visible.assert_called_once_with(True)
+        window.unlock_scrim.set_visible.assert_called_once_with(True)
+        window.main_root.set_sensitive.assert_called_once_with(False)
+        window.header.set_sensitive.assert_called_once_with(False)
+        window.unlock_error_label.set_label.assert_called_once_with("synthetic encryption error")
+        window.unlock_password_entry.grab_focus.assert_called_once_with()
+        self.assertFalse(result)
 
     def test_cancel_schedules_startup_terminal_in_read_only_mode(self) -> None:
-        from gi.repository import Gtk
-
         window = self.window(open_on_startup=True, read_only=True)
 
         with patch("termia.app.GLib.idle_add") as idle_add:
-            dialog, _password_entry, _error = self.unlock_response(
+            self.TermiaWindow.on_unlock_connections_cancelled(
                 window,
-                Gtk.ResponseType.CANCEL,
             )
 
-        dialog.destroy.assert_called_once_with()
+        window.unlock_panel.set_visible.assert_called_once_with(False)
+        window.unlock_scrim.set_visible.assert_called_once_with(False)
+        window.main_root.set_sensitive.assert_called_once_with(True)
+        window.header.set_sensitive.assert_called_once_with(True)
         window.toast_label.set_label.assert_called_once_with("connections_locked")
         idle_add.assert_called_once_with(window.open_startup_local_terminal)
 
     def test_cancel_does_not_schedule_disabled_startup_terminal(self) -> None:
-        from gi.repository import Gtk
-
         window = self.window(open_on_startup=False, read_only=True)
 
         with patch("termia.app.GLib.idle_add") as idle_add:
-            self.unlock_response(window, Gtk.ResponseType.CANCEL)
+            self.TermiaWindow.on_unlock_connections_cancelled(window)
 
         idle_add.assert_not_called()
 
     def test_successful_unlock_schedules_one_startup_terminal(self) -> None:
-        from gi.repository import Gtk
-
         window = self.window(open_on_startup=True, unlock_succeeds=True)
 
         with patch("termia.app.GLib.idle_add") as idle_add:
-            dialog, password_entry, _error = self.unlock_response(
+            self.TermiaWindow.on_unlock_connections_requested(
                 window,
-                Gtk.ResponseType.OK,
             )
 
         window.store.unlock_connections.assert_called_once_with("synthetic-password")
-        dialog.destroy.assert_called_once_with()
+        window.unlock_panel.set_visible.assert_called_once_with(False)
         window.apply_app_theme.assert_called_once_with()
         window.refresh_translated_chrome.assert_called_once_with()
         window.refresh_list.assert_called_once_with()
         idle_add.assert_called_once_with(window.open_startup_local_terminal)
-        password_entry.set_text.assert_not_called()
+        window.unlock_password_entry.set_text.assert_not_called()
+
+    def test_failed_unlock_keeps_panel_open_and_clears_password(self) -> None:
+        window = self.window(open_on_startup=True, unlock_succeeds=False)
+
+        with patch("termia.app.GLib.idle_add") as idle_add:
+            self.TermiaWindow.on_unlock_connections_requested(window)
+
+        window.unlock_panel.set_visible.assert_not_called()
+        window.unlock_error_label.set_label.assert_called_once_with("unlock_connections_failed")
+        window.unlock_password_entry.set_text.assert_called_once_with("")
+        window.unlock_password_entry.grab_focus.assert_called_once_with()
+        idle_add.assert_not_called()
 
     def test_startup_callback_does_not_duplicate_an_existing_session(self) -> None:
         opened_sessions: list[object] = []


### PR DESCRIPTION
## Summary

- replace the separate startup password dialog with a modal layer rendered inside the Termia window
- disable the underlying content and Termia header actions until unlocking is completed or cancelled
- keep window management available so the locked window remains movable between monitors
- preserve successful unlock, invalid-password, cancellation, startup-terminal, and read-only behavior
- remove the mapped-window polling and all tests and documentation for the discarded approach
- document the protected in-window behavior and manual regression path

## Root cause

GTK mapping and modal/transient hints do not guarantee that two independent Wayland surfaces will be placed on the same monitor. The reliable solution is to avoid a second desktop surface: the password prompt now belongs to the main window overlay.

## Validation

- PYTHONPATH=src python3 -m unittest tests.test_startup_terminal -v: 8 tests passed
- PYTHONPATH=src python3 -m unittest discover -s tests -v: 97 tests passed
- python3 -m py_compile run_termia.py scripts/compile_translations.py src/termia/*.py tests/*.py
- scripts/compile_translations.py and scripts/compile_translations.py --check: 290 messages synchronized
- bash -n scripts/termia-setup.sh
- encrypted and unencrypted isolated graphical startup smoke tests completed without GTK errors
- git diff --check and full privacy/scope review

## Manual verification

1. Start Termia with encrypted connection storage on each monitor in turn.
2. Confirm the password prompt is inside the Termia window.
3. Drag the locked Termia window between monitors and verify the prompt moves with it.
4. Confirm the underlying content and Termia action buttons cannot be used while window controls remain available.
5. Verify Enter, the Unlock button, Escape, Cancel, and an invalid password.
6. Repeat with the startup-terminal preference enabled and disabled.
7. Repeat in a read-only secondary instance.
8. Start without encrypted storage and confirm the configured startup terminal still opens exactly once.

Closes #182