### PR TITLE
fix: preserve split position when toggling status bars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Changes merged after `0.5.0-beta.3` (released 2026-07-30).
 - Show the startup master-password prompt as a modal layer inside the Termia
   window so it cannot appear on a different monitor, while keeping the locked
   window movable through its header bar (`#182`).
+- Preserve split-divider positions when showing or hiding a pane status bar
+  and allow status labels to ellipsize instead of forcing pane width (`#189`).
 
 ### Added
 

--- a/docs/REGRESSION_CHECKS.md
+++ b/docs/REGRESSION_CHECKS.md
@@ -138,6 +138,8 @@ Protected behavior does not mean the code cannot change. It means regressions sh
 - Split pane separators must remain visible, narrow, and readable on both light and dark themes.
 - Showing pane status bars must not enlarge split separators; narrow panes may
   ellipsize the connection name while keeping the timer and actions usable.
+- Showing or hiding a pane status bar must preserve the existing position of
+  every affected split divider.
 
 ### Terminal Appearance
 
@@ -183,6 +185,9 @@ Before merging changes that touch UI, terminals, tabs, or configuration, verify:
 - Confirm terminal context-menu actions still work: disconnect, show and hide
   the selected pane's status bar, copy, paste, terminal preferences, session
   statistics, file transfer, all split directions, and all Tab submenu actions.
+- Drag a horizontal split divider away from the centre, then show and hide its
+  pane status bar from both the context menu and `Hide` button; the divider
+  must remain at the chosen position and long status titles must ellipsize.
 - Create split panes in all four directions and confirm each new pane opens a working shell.
 - From an SSH pane, use `Open connection in split…` to open a different SSH
   server and then a saved local terminal; verify each pane's status bar, PID,

--- a/src/termia/styles.py
+++ b/src/termia/styles.py
@@ -21,6 +21,7 @@ def build_application_css(
         "border: 0; box-shadow: none; } "
         ".termia-terminal-stack { border: 0; box-shadow: none; } "
         ".termia-pane-status.active { background-color: alpha(@theme_selected_bg_color, 0.12); } "
+        ".termia-pane-status > label { min-width: 0; } "
         ".termia-terminal-pane.in-split > .termia-pane-status { padding: 6px; } "
         f".termia-split-pane.horizontal > separator {{ min-width: {handle_size}px; "
         f"background: transparent; border-left: {thickness}px solid {split_separator_color}; }} "

--- a/src/termia/terminal_sessions.py
+++ b/src/termia/terminal_sessions.py
@@ -136,6 +136,7 @@ class TerminalSessionsMixin:
         status_label = Gtk.Label(label=self.t("connecting"))
         status_label.set_xalign(0)
         status_label.set_hexpand(True)
+        status_label.set_size_request(0, -1)
         status_label.set_ellipsize(Pango.EllipsizeMode.END)
         status_label.add_css_class("dim-label")
         timer_label = Gtk.Label(label="00:00:00")
@@ -817,14 +818,38 @@ class TerminalSessionsMixin:
         terminal: Vte.Terminal,
     ) -> None:
         pane = self.pane_state(session, terminal)
-        pane.status_bar.set_visible(False)
+        self.set_pane_status_bar_visibility(pane, False)
         terminal.grab_focus()
+
+    def set_pane_status_bar_visibility(self, pane: TerminalPane, visible: bool) -> None:
+        """Toggle a pane bar without allowing its new width to move a split."""
+
+        parent_getter = getattr(pane.container, "get_parent", None)
+        parent = parent_getter() if callable(parent_getter) else None
+        ratio: float | None = None
+        if isinstance(parent, Gtk.Paned):
+            size = parent.get_width() if parent.get_orientation() == Gtk.Orientation.HORIZONTAL else parent.get_height()
+            if size > 0:
+                ratio = parent.get_position() / size
+
+        pane.status_bar.set_visible(visible)
+        if ratio is not None and isinstance(parent, Gtk.Paned):
+            self.restore_split_position_after_status_bar_toggle(parent, ratio)
+
+    def restore_split_position_after_status_bar_toggle(self, paned: Gtk.Paned, ratio: float) -> None:
+        def restore_position() -> bool:
+            size = paned.get_width() if paned.get_orientation() == Gtk.Orientation.HORIZONTAL else paned.get_height()
+            if size > 0:
+                paned.set_position(round(size * max(0.0, min(ratio, 1.0))))
+            return GLib.SOURCE_REMOVE
+
+        GLib.idle_add(restore_position)
 
     def apply_session_status_bar_visibility_to_open_tabs(self) -> None:
         visible = self.should_show_session_status_bar()
         for session in self.session_registry.sessions():
             for pane in session.panes.values():
-                pane.status_bar.set_visible(visible)
+                self.set_pane_status_bar_visibility(pane, visible)
 
     def change_terminal_font_size(self, delta: int) -> None:
         if not self.ensure_writable():
@@ -1493,7 +1518,7 @@ class TerminalSessionsMixin:
     ) -> None:
         popover.popdown()
         pane = self.pane_state(session, terminal)
-        pane.status_bar.set_visible(not pane.status_bar.get_visible())
+        self.set_pane_status_bar_visibility(pane, not pane.status_bar.get_visible())
         terminal.grab_focus()
 
     def disconnect_from_terminal_menu(

--- a/tests/test_styles.py
+++ b/tests/test_styles.py
@@ -19,6 +19,7 @@ class SplitSeparatorStyleTests(unittest.TestCase):
         self.assertIn(".termia-split-pane.vertical > separator", css)
         self.assertIn("min-height: 5px", css)
         self.assertIn("border-top: 1px solid #008712", css)
+        self.assertIn(".termia-pane-status > label { min-width: 0; }", css)
 
     def test_configured_thickness_expands_the_handle_when_needed(self) -> None:
         css = build_application_css("#202020", "#008712", 8).decode()

--- a/tests/test_terminal_panes.py
+++ b/tests/test_terminal_panes.py
@@ -125,6 +125,17 @@ class TerminalPaneStateTests(unittest.TestCase):
         self.assertFalse(split.status_bar.visible)
         self.assertTrue(root.status_bar.visible)
 
+    def test_hiding_status_bar_uses_the_same_selected_pane_path(self) -> None:
+        root_terminal = FakeTerminal()
+        root = make_pane(root_terminal, "root")
+        session = make_session(root_terminal, root)
+        root.status_bar.set_visible(True)
+
+        TerminalSessionsMixin().on_hide_pane_status_bar(None, session, root_terminal)
+
+        self.assertFalse(root.status_bar.visible)
+        self.assertTrue(root_terminal.focused)
+
     def test_session_resolves_each_terminal_to_its_independent_pane(self) -> None:
         root_terminal = FakeTerminal()
         split_terminal = FakeTerminal()


### PR DESCRIPTION
## Summary

- preserve a split divider position when a pane status bar is shown or hidden
- allow status labels to shrink and ellipsize instead of forcing pane width
- cover menu and in-bar hiding paths with regression checks

## Validation

- full unit test suite: 105 tests passed
- Python syntax checks passed
- diff whitespace check passed

Closes #189