### PR TITLE
Show tab overflow selector only when needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Changes merged after `0.5.0-beta.3` (released 2026-07-30).
 
 ### Fixed
 
+- Show the tab overflow selector only when the visible tab titles exceed the
+  available tab-strip width (`#211`).
 - Apply the audible-bell preference through the supported VTE API and expose it
   independently in General preferences (`#207`).
 - Apply audible-bell changes immediately to already open terminal panes after

--- a/docs/REGRESSION_CHECKS.md
+++ b/docs/REGRESSION_CHECKS.md
@@ -205,6 +205,10 @@ Before merging changes that touch UI, terminals, tabs, or configuration, verify:
   with the sidebar visible and hidden. Confirm the compact horizontal scrollbar
   appears only while needed, the window and sidebar widths remain unchanged,
   and every tab is reachable from the strip and overflow control.
+- With exactly two tabs whose titles fit, confirm the overflow selector is
+  hidden. Reduce the window width or lengthen a tab title until the strip
+  overflows, then confirm the selector appears; restore the width and confirm
+  it hides again.
 - At each target width, confirm the active tab is revealed after opening,
   closing, keyboard navigation, overflow selection, drag reordering, resizing,
   and toggling the sidebar.

--- a/src/termia/app.py
+++ b/src/termia/app.py
@@ -626,6 +626,12 @@ class TermiaWindow(
         self.session_tab_scroller.get_hadjustment().connect(
             "changed", self.on_tab_scroll_adjustment_changed
         )
+        self.session_tab_scroller.get_hadjustment().connect(
+            "notify::page-size", self.on_tab_scroll_adjustment_changed
+        )
+        self.session_tab_scroller.get_hadjustment().connect(
+            "notify::upper", self.on_tab_scroll_adjustment_changed
+        )
         self.session_tab_controls.append(self.session_tab_scroller)
 
         self.tab_overflow_button = Gtk.MenuButton()

--- a/src/termia/tabs.py
+++ b/src/termia/tabs.py
@@ -14,6 +14,8 @@ from .ui_state import TerminalSession
 
 
 class TabsMixin:
+    TAB_OVERFLOW_EPSILON = 1.0
+
     def add_session_to_main_view(self, session: TerminalSession) -> None:
         self.terminal_stack.add_named(session.page, session.id)
         self.session_tab_bar.append(session.tab_label)
@@ -36,6 +38,17 @@ class TabsMixin:
         if tab_end > current + page_size:
             return min(maximum, tab_end - page_size)
         return min(maximum, max(lower, current))
+
+    @classmethod
+    def tab_strip_has_overflow(
+        cls,
+        *,
+        page_size: float,
+        lower: float,
+        upper: float,
+    ) -> bool:
+        """Return whether the tab strip is wider than its viewport."""
+        return upper - lower > page_size + cls.TAB_OVERFLOW_EPSILON
 
     def visible_sessions_in_tab_order(self) -> list[TerminalSession]:
         sessions_by_label = {
@@ -104,8 +117,34 @@ class TabsMixin:
         )
         return GLib.SOURCE_REMOVE
 
-    def on_tab_scroll_adjustment_changed(self, _adjustment: Gtk.Adjustment) -> None:
+    def on_tab_scroll_adjustment_changed(
+        self,
+        adjustment: Gtk.Adjustment,
+        *_args: object,
+    ) -> None:
         self.schedule_active_tab_reveal()
+        self.schedule_tab_overflow_visibility()
+
+    def schedule_tab_overflow_visibility(self) -> None:
+        pending_id = getattr(self, "tab_overflow_visibility_id", None)
+        if pending_id is not None:
+            GLib.source_remove(pending_id)
+        self.tab_overflow_visibility_id = GLib.idle_add(self.update_tab_overflow_visibility)
+
+    def update_tab_overflow_visibility(self) -> bool:
+        self.tab_overflow_visibility_id = None
+        if not self.session_tab_controls.get_visible():
+            self.tab_overflow_button.set_visible(False)
+            return GLib.SOURCE_REMOVE
+        adjustment = self.session_tab_scroller.get_hadjustment()
+        self.tab_overflow_button.set_visible(
+            self.tab_strip_has_overflow(
+                page_size=adjustment.get_page_size(),
+                lower=adjustment.get_lower(),
+                upper=adjustment.get_upper(),
+            )
+        )
+        return GLib.SOURCE_REMOVE
 
     def rebuild_tab_overflow_popover(self) -> None:
         if not hasattr(self, "tab_overflow_button"):
@@ -181,7 +220,11 @@ class TabsMixin:
 
     def update_session_tab_bar_visibility(self) -> None:
         visible_sessions = [session for session in self.session_registry.sessions() if session.detached_window is None]
-        self.session_tab_controls.set_visible(len(visible_sessions) > 1)
+        has_multiple_tabs = len(visible_sessions) > 1
+        self.session_tab_controls.set_visible(has_multiple_tabs)
+        self.tab_overflow_button.set_visible(False)
+        if has_multiple_tabs:
+            self.schedule_tab_overflow_visibility()
         self.rebuild_tab_overflow_popover()
 
     def sync_window_title_with_visible_session(self) -> None:
@@ -223,6 +266,7 @@ class TabsMixin:
                 label.set_label(title)
         self.rebuild_tab_overflow_popover()
         self.schedule_active_tab_reveal()
+        self.schedule_tab_overflow_visibility()
 
     def build_tab_label(self, title: str, session_id: str, page: Gtk.Widget) -> Gtk.Widget:
         box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=0)

--- a/tests/test_tabs.py
+++ b/tests/test_tabs.py
@@ -202,6 +202,14 @@ class MiddleClickTabTests(unittest.TestCase):
 
 
 class TabOverflowTests(unittest.TestCase):
+    def test_tab_strip_overflow_requires_content_wider_than_viewport(self) -> None:
+        self.assertFalse(
+            TabsMixin.tab_strip_has_overflow(page_size=300, lower=0, upper=300)
+        )
+        self.assertTrue(
+            TabsMixin.tab_strip_has_overflow(page_size=300, lower=0, upper=301.1)
+        )
+
     def test_overflow_order_matches_visual_tab_order_and_skips_detached_tabs(self) -> None:
         first_tab = FakeTab()
         second_tab = FakeTab()


### PR DESCRIPTION
Closes #211

## Summary
- Hide the tab overflow selector while visible tab titles fit in the available width.
- Recalculate visibility when tab-strip geometry changes, including resize and title updates.
- Preserve the existing overflow popover, active-tab reveal, and tab navigation behavior.
- Add a regression test, changelog entry, and manual regression check.

## Validation
- `PYTHONPATH=src python3 -m unittest discover -s tests -q` (134 tests)
- `python3 scripts/compile_translations.py --check`
- `python3 -m py_compile run_termia.py scripts/compile_translations.py src/termia/*.py tests/*.py`
- `git diff --check`
- GTK isolated instance started with `scripts/run_test_instance.sh --fresh pr-211-overflow`.