### PR TITLE
Show window controls on detached tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ Changes merged after `0.5.0-beta.3` (released 2026-07-30).
 
 ### Fixed
 
+- Create detached sessions as normal application windows instead of transient
+  windows so GTK exposes native minimize, maximize, and close controls while
+  preserving tab restoration on close (`#209`).
 - Show the tab overflow selector only when the visible tab titles exceed the
   available tab-strip width (`#211`).
 - Apply the audible-bell preference through the supported VTE API and expose it

--- a/docs/REGRESSION_CHECKS.md
+++ b/docs/REGRESSION_CHECKS.md
@@ -213,6 +213,10 @@ Before merging changes that touch UI, terminals, tabs, or configuration, verify:
   closing, keyboard navigation, overflow selection, drag reordering, resizing,
   and toggling the sidebar.
 - Right-click a tab, move it to a new window, repeat with another tab, and restore both detached windows to the main window.
+- Move a tab to a new window and confirm its title bar shows the configured
+  GNOME minimize, maximize, and close controls. Minimize and maximize it
+  without closing the session, then close the detached window and confirm the
+  tab returns to the main window.
 - Duplicate a local terminal and confirm the custom prompt is applied.
 - Open two SSH sessions and duplicate one of them.
 - With 39 tabs open, confirm one additional local or SSH tab opens; with 40

--- a/src/termia/tabs.py
+++ b/src/termia/tabs.py
@@ -467,9 +467,15 @@ class TabsMixin:
         previous_order = self.visible_sessions_in_tab_order()
         self.remove_session_from_main_view(session)
         self.focus_available_session_after_close(session.id, previous_order)
-        window = Gtk.Window(title=session.title, transient_for=self)
+        window = Gtk.Window(
+            title=session.title,
+            application=self.get_application(),
+        )
         if hasattr(window, "set_handle_menubar_accel"):
             window.set_handle_menubar_accel(False)
+        titlebar = Gtk.HeaderBar()
+        titlebar.set_title_widget(Gtk.Label(label=session.title))
+        window.set_titlebar(titlebar)
         window.set_default_size(860, 520)
         window.set_child(session.page)
         session.detached_window = window

--- a/tests/test_tabs.py
+++ b/tests/test_tabs.py
@@ -16,15 +16,20 @@ class FakePopover:
 
 
 class FakeWindow:
-    def __init__(self, **_kwargs) -> None:
+    def __init__(self, **kwargs) -> None:
+        self.properties = kwargs
         self.child = None
         self.presented = False
+        self.titlebar = None
 
     def set_handle_menubar_accel(self, _enabled: bool) -> None:
         pass
 
     def set_default_size(self, _width: int, _height: int) -> None:
         pass
+
+    def set_titlebar(self, titlebar) -> None:
+        self.titlebar = titlebar
 
     def set_child(self, child) -> None:
         self.child = child
@@ -34,6 +39,14 @@ class FakeWindow:
 
     def present(self) -> None:
         self.presented = True
+
+
+class FakeHeaderBar:
+    def __init__(self) -> None:
+        pass
+
+    def set_title_widget(self, _widget) -> None:
+        pass
 
 
 class FakeTab:
@@ -69,6 +82,7 @@ class DetachTabTests(unittest.TestCase):
 
         class Host(TabsMixin):
             def __init__(self) -> None:
+                self.application = object()
                 self.session_registry = SessionRegistry([session, previous_session])
                 self.focused = None
                 self.removed = None
@@ -76,6 +90,9 @@ class DetachTabTests(unittest.TestCase):
 
             def visible_sessions_in_tab_order(self):
                 return self.visible_sessions
+
+            def get_application(self):
+                return self.application
 
             def remove_session_from_main_view(self, current_session) -> None:
                 self.removed = current_session
@@ -91,13 +108,20 @@ class DetachTabTests(unittest.TestCase):
 
         host = Host()
         popover = FakePopover()
-        with patch("termia.tabs.Gtk.Window", FakeWindow):
+        with (
+            patch("termia.tabs.Gtk.Window", FakeWindow),
+            patch("termia.tabs.Gtk.HeaderBar", FakeHeaderBar),
+            patch("termia.tabs.Gtk.Label", lambda **_kwargs: object()),
+        ):
             host.detach_tab(popover, session)
 
         self.assertTrue(popover.closed)
         self.assertIs(host.removed, session)
         self.assertEqual(host.focused, (session.id, [previous_session, session]))
         self.assertIsInstance(session.detached_window, FakeWindow)
+        self.assertIs(session.detached_window.properties["application"], host.application)
+        self.assertNotIn("transient_for", session.detached_window.properties)
+        self.assertIsInstance(session.detached_window.titlebar, FakeHeaderBar)
         self.assertTrue(session.detached_window.presented)
 
 


### PR DESCRIPTION
Closes #209

## Summary
- Create detached sessions as normal application windows instead of transient child windows.
- Use the same standard GTK HeaderBar pattern as the main Termia window.
- Let GTK/GNOME expose native minimize, maximize, and close controls.
- Preserve the current behavior that restores the detached tab to the main window on close.
- Add focused unit coverage, changelog, and manual regression checks.

## Validation
- PYTHONPATH=src python3 -m unittest discover -s tests -q (134 tests)
- python3 scripts/compile_translations.py --check
- python3 -m py_compile run_termia.py scripts/compile_translations.py src/termia/*.py tests/*.py
- git diff --check
- Manual validation completed with scripts/run_test_instance.sh --fresh pr-209-normal-window.

The PR is assigned to @buuuki.