### PR TITLE
Preserve local workspace context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Changes merged after `0.5.0-beta.3` (released 2026-07-30).
 
 ### Added
 
+- Preserve custom tab titles and per-pane local working directories in saved
+  workspaces, with safe fallback for unavailable paths and no SSH path capture
+  (`#214`).
 - Add a terminal preference to enable or disable the audible bell, disabled by
   default (`#207`).
 - Restore the previous tabs and split layouts on startup after explicit user

--- a/README.md
+++ b/README.md
@@ -164,7 +164,10 @@ Use the save button in the sidebar to store the current tabs and split layout
 as a named workspace. Workspaces appear in the sidebar with a grid icon; open,
 update, rename, duplicate, or delete them from their context menu. A workspace
 can contain up to 32 panes across all tabs and opens without an additional
-confirmation.
+confirmation. Saved workspaces also restore custom tab titles and the working
+directory of each local terminal pane. SSH working directories are not
+captured; unavailable local directories fall back to the terminal profile's
+normal startup directory.
 
 ## Tested environment
 

--- a/docs/README.ca.md
+++ b/docs/README.ca.md
@@ -149,7 +149,10 @@ i divisions actuals com un espai de treball amb nom. Els espais de treball
 apareixen a la barra lateral amb una icona de quadrícula; des del menú
 contextual els pots obrir, actualitzar, reanomenar, duplicar o eliminar. Un
 espai de treball pot contenir fins a 32 panells entre totes les pestanyes i
-s'obre sense cap confirmació addicional.
+s'obre sense cap confirmació addicional. Els espais de treball també restauren
+els títols personalitzats i el directori de treball de cada panell local. No es
+capturen directoris SSH; si un directori local ja no està disponible, s'utilitza
+el directori inicial normal del perfil.
 
 ## Entorn provat
 

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -149,7 +149,10 @@ divisiones actuales como un espacio de trabajo con nombre. Los espacios de
 trabajo aparecen en la barra lateral con un icono de cuadrícula; desde su menú
 contextual puedes abrirlos, actualizarlos, renombrarlos, duplicarlos o
 eliminarlos. Un espacio de trabajo puede contener hasta 32 paneles entre todas
-sus pestañas y se abre sin una confirmación adicional.
+sus pestañas y se abre sin una confirmación adicional. Los espacios de trabajo
+también restauran los títulos personalizados y el directorio de trabajo de cada
+panel local. No se capturan directorios SSH; si un directorio local ya no está
+disponible, se usa el directorio inicial normal del perfil.
 
 ## Entorno probado
 

--- a/docs/REGRESSION_CHECKS.md
+++ b/docs/REGRESSION_CHECKS.md
@@ -250,6 +250,11 @@ Before merging changes that touch UI, terminals, tabs, or configuration, verify:
   connection identities, split orientations, and usable split panes as new
   terminal processes. Confirm its context menu can update, rename, duplicate,
   and delete it, while write actions are disabled in a read-only instance.
+- Rename a tab, change the working directory independently in two local split
+  panes, save the workspace, and reopen it. Confirm the custom tab title and
+  both local directories are restored. Remove one saved directory and confirm
+  that pane falls back to its normal startup directory without blocking the
+  rest of the workspace. Confirm SSH panes do not persist a remote directory.
 - Confirm a workspace with 32 total panes opens directly without confirmation,
   while saving, updating, duplicating, or opening one with more than 32 total
   panes is rejected without starting terminal processes or deleting the saved

--- a/src/termia/app.py
+++ b/src/termia/app.py
@@ -409,7 +409,10 @@ class TermiaWindow(
         from .workspace_layout import capture_workspace_tabs
 
         self.session_snapshot_store.save(
-            capture_workspace_tabs(self.session_registry.sessions())
+            capture_workspace_tabs(
+                self.session_registry.sessions(),
+                include_local_context=False,
+            )
         )
 
     def finish_main_window_shutdown(self) -> bool:

--- a/src/termia/config_io.py
+++ b/src/termia/config_io.py
@@ -16,7 +16,7 @@ from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 
 from .models import Group, LocalTerminalProfile, Server, StoreData, Workspace
 from .migrations import CURRENT_SCHEMA_VERSION, migrate_connections_payload
-from .workspace_layout import workspace_tab_layouts
+from .workspace_layout import normalized_workspace_tabs
 
 CONNECTION_STORAGE_PLAIN = "plain"
 CONNECTION_STORAGE_OBFUSCATED = "obfuscated"
@@ -210,7 +210,7 @@ def workspaces_from_payload(payload: object) -> list[Workspace]:
             Workspace(
                 id=workspace_id,
                 name=name,
-                tabs=[{"layout": layout} for layout in workspace_tab_layouts(tabs)],
+                tabs=normalized_workspace_tabs(tabs),
             )
         )
     return workspaces

--- a/src/termia/models.py
+++ b/src/termia/models.py
@@ -58,9 +58,9 @@ class LocalTerminalProfile:
 class Workspace:
     """A reusable arrangement of saved terminal connections.
 
-    ``tabs`` contains only saved connection/profile IDs and split-layout
-    metadata. It never contains terminal output, live processes, credentials,
-    or directories captured from a terminal.
+    ``tabs`` contains only saved connection/profile IDs, split-layout metadata,
+    optional custom tab titles, and local shell working directories. It never
+    contains terminal output, live processes, credentials, or remote paths.
     """
 
     id: str

--- a/src/termia/terminal_sessions.py
+++ b/src/termia/terminal_sessions.py
@@ -42,6 +42,7 @@ from .terminal_view import TerminalViewFactory
 from .ui_state import TerminalPane, TerminalSession
 from .workspace_layout import (
     MAX_WORKSPACE_PANES,
+    normalized_workspace_tabs,
     workspace_layout_is_valid,
     workspace_pane_count,
     workspace_root_pane,
@@ -64,6 +65,7 @@ class TerminalSessionsMixin:
         profile: LocalTerminalProfile | None,
         *,
         split_layout: str | None = None,
+        working_directory_override: str | None = None,
     ) -> TerminalSession | None:
         title = self.local_terminal_session_title(profile)
         try:
@@ -71,7 +73,11 @@ class TerminalSessionsMixin:
         except ValueError as exc:
             self.toast_label.set_label(self.t("local_terminal_invalid_arguments").format(error=exc))
             return None
-        working_directory = self.local_terminal_profile_working_directory(profile)
+        working_directory = (
+            working_directory_override
+            if working_directory_override is not None
+            else self.local_terminal_profile_working_directory(profile)
+        )
         return self.open_process_terminal_tab(
             title,
             command,
@@ -380,7 +386,8 @@ class TerminalSessionsMixin:
     def open_workspace_tabs(self, workspace: Workspace) -> None:
         opened_tabs = 0
         skipped_tabs = 0
-        for layout in workspace_tab_layouts(workspace.tabs):
+        for tab in normalized_workspace_tabs(workspace.tabs):
+            layout = tab["layout"]
             if not self.workspace_layout_available(layout):
                 skipped_tabs += 1
                 continue
@@ -393,6 +400,7 @@ class TerminalSessionsMixin:
                 skipped_tabs += 1
                 continue
             self.restore_workspace_node(session, session.terminal, layout)
+            self.restore_workspace_tab_title(session, tab.get("title"))
             opened_tabs += 1
         if opened_tabs:
             self.toast_label.set_label(
@@ -411,14 +419,16 @@ class TerminalSessionsMixin:
 
     def restore_session_snapshot(self, tabs: list[dict[str, object]]) -> None:
         """Reopen the last session from safe connection references."""
-        layouts = workspace_tab_layouts(tabs)
+        saved_tabs = normalized_workspace_tabs(tabs)
+        layouts = [tab["layout"] for tab in saved_tabs]
         pane_count = workspace_total_pane_count(tabs)
         if pane_count > MAX_WORKSPACE_PANES or not self.can_open_terminal_tabs(len(layouts)):
             return
 
         opened_tabs = 0
         skipped_tabs = 0
-        for layout in layouts:
+        for tab in saved_tabs:
+            layout = tab["layout"]
             if not self.workspace_layout_available(layout):
                 skipped_tabs += 1
                 continue
@@ -431,6 +441,7 @@ class TerminalSessionsMixin:
                 skipped_tabs += 1
                 continue
             self.restore_workspace_node(session, session.terminal, layout)
+            self.restore_workspace_tab_title(session, tab.get("title"))
             opened_tabs += 1
 
         if opened_tabs:
@@ -466,7 +477,35 @@ class TerminalSessionsMixin:
             server = find_server(self.store.data.servers, connection_id)
             return self.open_terminal_tab(server, split_layout="none") if server is not None else None
         profile = find_local_terminal_profile(self.store.data.local_terminals, connection_id) if connection_id else None
-        return self.open_local_terminal_profile(profile, split_layout="none")
+        working_directory = self.available_workspace_working_directory(node)
+        if working_directory is None:
+            return self.open_local_terminal_profile(profile, split_layout="none")
+        return self.open_local_terminal_profile(
+            profile,
+            split_layout="none",
+            working_directory_override=working_directory,
+        )
+
+    @staticmethod
+    def available_workspace_working_directory(node: dict[str, object]) -> str | None:
+        working_directory = node.get("working_directory")
+        if not isinstance(working_directory, str):
+            return None
+        path = Path(working_directory)
+        if not path.is_absolute() or not path.is_dir() or not os.access(path, os.X_OK):
+            return None
+        return str(path)
+
+    def restore_workspace_tab_title(self, session: TerminalSession, title: object) -> None:
+        if not isinstance(title, str) or not title.strip():
+            return
+        session.title = title.strip()
+        session.title_locked = True
+        pane = session.pane_for_terminal(session.terminal)
+        if pane is not None:
+            pane.title = session.title
+        self.update_session_tab_title(session, session.title)
+        self.sync_window_title_with_visible_session()
 
     def restore_workspace_node(
         self,
@@ -508,7 +547,14 @@ class TerminalSessionsMixin:
             self.start_ssh_split_terminal(session, terminal, server, announce=False)
             return True
         profile = find_local_terminal_profile(self.store.data.local_terminals, connection_id) if connection_id else None
-        self.start_local_split_terminal(session, terminal, source_terminal, profile=profile)
+        working_directory = self.available_workspace_working_directory(node)
+        self.start_local_split_terminal(
+            session,
+            terminal,
+            source_terminal,
+            profile=profile,
+            working_directory_override=working_directory,
+        )
         return True
 
     def restore_workspace_split_position(self, paned: Gtk.Paned, ratio: float, attempts: int = 4) -> None:
@@ -1356,6 +1402,7 @@ class TerminalSessionsMixin:
         fallback_working_directory: str | None = None,
         *,
         profile: LocalTerminalProfile | None = None,
+        working_directory_override: str | None = None,
     ) -> None:
         pane = self.pane_state(session, terminal)
         pane.server_id = None
@@ -1378,7 +1425,7 @@ class TerminalSessionsMixin:
             pane.status_label.set_label("Error")
             self.mark_pane_for_reconnect(session, pane, message)
             return
-        working_directory = (
+        working_directory = working_directory_override or (
             self.local_terminal_profile_working_directory(profile)
             if profile is not None
             else self.local_terminal_working_directory(source_terminal, fallback_working_directory)

--- a/src/termia/workspace_layout.py
+++ b/src/termia/workspace_layout.py
@@ -3,7 +3,9 @@
 """Capture and validate the safe, persistent part of terminal layouts."""
 from __future__ import annotations
 
+import os
 from collections.abc import Iterable
+from pathlib import Path
 from typing import Any
 
 import gi
@@ -17,36 +19,94 @@ WorkspaceNode = dict[str, Any]
 MAX_WORKSPACE_PANES = 32
 
 
-def pane_workspace_node(pane: TerminalPane) -> WorkspaceNode:
+def pane_workspace_node(
+    pane: TerminalPane,
+    *,
+    include_local_context: bool = True,
+) -> WorkspaceNode:
     if pane.server_id is not None:
         return {"type": "pane", "connection_type": "server", "connection_id": pane.server_id}
-    return {
+    node: WorkspaceNode = {
         "type": "pane",
         "connection_type": "local",
         "connection_id": pane.local_profile_id or "",
     }
+    working_directory = local_pane_working_directory(pane) if include_local_context else None
+    if working_directory is not None:
+        node["working_directory"] = working_directory
+    return node
 
 
-def capture_workspace_tab(session: TerminalSession) -> dict[str, WorkspaceNode] | None:
+def local_pane_working_directory(pane: TerminalPane) -> str | None:
+    if pane.server_id is not None or pane.child_pid is None:
+        return None
+    try:
+        path = Path(os.readlink(f"/proc/{pane.child_pid}/cwd"))
+    except OSError:
+        return None
+    return str(path) if path.is_absolute() else None
+
+
+def capture_workspace_tab(
+    session: TerminalSession,
+    *,
+    include_local_context: bool = True,
+) -> dict[str, WorkspaceNode | str] | None:
     root = session.page.get_first_child()
     if root is None:
         return None
-    layout = capture_workspace_node(root, session)
-    return {"layout": layout} if layout is not None else None
+    layout = capture_workspace_node(
+        root,
+        session,
+        include_local_context=include_local_context,
+    )
+    if layout is None:
+        return None
+    tab: dict[str, WorkspaceNode | str] = {"layout": layout}
+    if include_local_context and session.title_locked and session.title.strip():
+        tab["title"] = session.title.strip()
+    return tab
 
 
-def capture_workspace_tabs(sessions: Iterable[TerminalSession]) -> list[dict[str, WorkspaceNode]]:
-    return [tab for session in sessions if (tab := capture_workspace_tab(session)) is not None]
+def capture_workspace_tabs(
+    sessions: Iterable[TerminalSession],
+    *,
+    include_local_context: bool = True,
+) -> list[dict[str, WorkspaceNode | str]]:
+    return [
+        tab
+        for session in sessions
+        if (
+            tab := capture_workspace_tab(
+                session,
+                include_local_context=include_local_context,
+            )
+        )
+        is not None
+    ]
 
 
-def capture_workspace_node(widget: Gtk.Widget, session: TerminalSession) -> WorkspaceNode | None:
+def capture_workspace_node(
+    widget: Gtk.Widget,
+    session: TerminalSession,
+    *,
+    include_local_context: bool = True,
+) -> WorkspaceNode | None:
     if isinstance(widget, Gtk.Paned):
         start = widget.get_start_child()
         end = widget.get_end_child()
         if start is None or end is None:
             return None
-        start_node = capture_workspace_node(start, session)
-        end_node = capture_workspace_node(end, session)
+        start_node = capture_workspace_node(
+            start,
+            session,
+            include_local_context=include_local_context,
+        )
+        end_node = capture_workspace_node(
+            end,
+            session,
+            include_local_context=include_local_context,
+        )
         if start_node is None or end_node is None:
             return None
         orientation = "horizontal" if widget.get_orientation() == Gtk.Orientation.HORIZONTAL else "vertical"
@@ -60,7 +120,11 @@ def capture_workspace_node(widget: Gtk.Widget, session: TerminalSession) -> Work
             "end": end_node,
         }
     pane = next((item for item in session.panes.values() if item.container is widget), None)
-    return pane_workspace_node(pane) if pane is not None else None
+    return (
+        pane_workspace_node(pane, include_local_context=include_local_context)
+        if pane is not None
+        else None
+    )
 
 
 def workspace_layout_is_valid(node: object) -> bool:
@@ -89,11 +153,19 @@ def normalized_workspace_node(node: object) -> WorkspaceNode | None:
     if not workspace_layout_is_valid(node) or not isinstance(node, dict):
         return None
     if node["type"] == "pane":
-        return {
+        normalized = {
             "type": "pane",
             "connection_type": node["connection_type"],
             "connection_id": node["connection_id"],
         }
+        working_directory = node.get("working_directory")
+        if (
+            node["connection_type"] == "local"
+            and isinstance(working_directory, str)
+            and Path(working_directory).is_absolute()
+        ):
+            normalized["working_directory"] = working_directory
+        return normalized
     start = normalized_workspace_node(node["start"])
     end = normalized_workspace_node(node["end"])
     if start is None or end is None:
@@ -125,16 +197,24 @@ def workspace_pane_count(node: object) -> int:
 
 
 def workspace_tab_layouts(tabs: object) -> list[WorkspaceNode]:
+    return [tab["layout"] for tab in normalized_workspace_tabs(tabs)]
+
+
+def normalized_workspace_tabs(tabs: object) -> list[dict[str, Any]]:
     if not isinstance(tabs, list):
         return []
-    layouts: list[WorkspaceNode] = []
+    normalized_tabs: list[dict[str, Any]] = []
     for tab in tabs:
         if not isinstance(tab, dict):
             continue
         layout = normalized_workspace_node(tab.get("layout"))
         if layout is not None:
-            layouts.append(layout)
-    return layouts
+            normalized_tab: dict[str, Any] = {"layout": layout}
+            title = tab.get("title")
+            if isinstance(title, str) and title.strip():
+                normalized_tab["title"] = title.strip()
+            normalized_tabs.append(normalized_tab)
+    return normalized_tabs
 
 
 def workspace_total_pane_count(tabs: object) -> int:

--- a/tests/test_config_io.py
+++ b/tests/test_config_io.py
@@ -86,7 +86,7 @@ class ConfigIOTests(unittest.TestCase):
             with self.assertRaises(ValueError):
                 read_connections_payload(path)
 
-    def test_workspace_import_discards_non_layout_data(self) -> None:
+    def test_workspace_import_keeps_safe_local_context_and_discards_private_data(self) -> None:
         workspaces = workspaces_from_payload(
             [
                 {
@@ -94,10 +94,12 @@ class ConfigIOTests(unittest.TestCase):
                     "name": "Production",
                     "tabs": [
                         {
+                            "title": "Project shell",
                             "layout": {
                                 "type": "pane",
-                                "connection_type": "server",
-                                "connection_id": "server-1",
+                                "connection_type": "local",
+                                "connection_id": "local-1",
+                                "working_directory": "/srv/project",
                                 "password": "must-not-be-persisted",
                             }
                         }
@@ -106,8 +108,12 @@ class ConfigIOTests(unittest.TestCase):
             ]
         )
 
-        self.assertEqual(workspaces[0].tabs[0]["layout"], {
-            "type": "pane",
-            "connection_type": "server",
-            "connection_id": "server-1",
+        self.assertEqual(workspaces[0].tabs[0], {
+            "title": "Project shell",
+            "layout": {
+                "type": "pane",
+                "connection_type": "local",
+                "connection_id": "local-1",
+                "working_directory": "/srv/project",
+            },
         })

--- a/tests/test_workspace_layout.py
+++ b/tests/test_workspace_layout.py
@@ -1,7 +1,11 @@
 import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
 
 from termia.workspace_layout import (
     MAX_WORKSPACE_PANES,
+    capture_workspace_tab,
+    normalized_workspace_tabs,
     workspace_layout_is_valid,
     workspace_pane_count,
     workspace_root_pane,
@@ -47,3 +51,103 @@ class WorkspaceLayoutTests(unittest.TestCase):
         tabs = [{"layout": self.layout} for _index in range(MAX_WORKSPACE_PANES // 2)]
 
         self.assertEqual(workspace_total_pane_count(tabs), MAX_WORKSPACE_PANES)
+
+    def test_normalization_keeps_titles_and_only_local_absolute_directories(self) -> None:
+        tabs = [
+            {
+                "title": "  Project shell  ",
+                "layout": {
+                    "type": "pane",
+                    "connection_type": "local",
+                    "connection_id": "shell",
+                    "working_directory": "/srv/project",
+                    "terminal_output": "private",
+                },
+            },
+            {
+                "layout": {
+                    "type": "pane",
+                    "connection_type": "server",
+                    "connection_id": "web",
+                    "working_directory": "/remote/private",
+                }
+            },
+            {
+                "layout": {
+                    "type": "pane",
+                    "connection_type": "local",
+                    "connection_id": "",
+                    "working_directory": "relative/path",
+                }
+            },
+        ]
+
+        normalized = normalized_workspace_tabs(tabs)
+
+        self.assertEqual(normalized[0]["title"], "Project shell")
+        self.assertEqual(normalized[0]["layout"]["working_directory"], "/srv/project")
+        self.assertNotIn("terminal_output", normalized[0]["layout"])
+        self.assertNotIn("working_directory", normalized[1]["layout"])
+        self.assertNotIn("working_directory", normalized[2]["layout"])
+
+    def test_capture_saves_locked_title_and_local_pane_cwd(self) -> None:
+        container = object()
+        pane = SimpleNamespace(
+            container=container,
+            server_id=None,
+            local_profile_id="shell",
+            child_pid=42,
+        )
+        session = SimpleNamespace(
+            page=SimpleNamespace(get_first_child=lambda: container),
+            panes={1: pane},
+            title="Project shell",
+            title_locked=True,
+        )
+
+        with patch("termia.workspace_layout.os.readlink", return_value="/srv/project"):
+            tab = capture_workspace_tab(session)
+
+        self.assertEqual(tab["title"], "Project shell")
+        self.assertEqual(tab["layout"]["working_directory"], "/srv/project")
+
+    def test_capture_does_not_save_remote_cwd_or_unlocked_title(self) -> None:
+        container = object()
+        pane = SimpleNamespace(
+            container=container,
+            server_id="web",
+            local_profile_id=None,
+            child_pid=42,
+        )
+        session = SimpleNamespace(
+            page=SimpleNamespace(get_first_child=lambda: container),
+            panes={1: pane},
+            title="Web",
+            title_locked=False,
+        )
+
+        tab = capture_workspace_tab(session)
+
+        self.assertNotIn("title", tab)
+        self.assertNotIn("working_directory", tab["layout"])
+
+    def test_minimal_snapshot_capture_omits_local_context(self) -> None:
+        container = object()
+        pane = SimpleNamespace(
+            container=container,
+            server_id=None,
+            local_profile_id="shell",
+            child_pid=42,
+        )
+        session = SimpleNamespace(
+            page=SimpleNamespace(get_first_child=lambda: container),
+            panes={1: pane},
+            title="Project shell",
+            title_locked=True,
+        )
+
+        with patch("termia.workspace_layout.os.readlink", return_value="/srv/project"):
+            tab = capture_workspace_tab(session, include_local_context=False)
+
+        self.assertNotIn("title", tab)
+        self.assertNotIn("working_directory", tab["layout"])

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -1,4 +1,6 @@
+import tempfile
 import unittest
+from pathlib import Path
 from types import SimpleNamespace
 
 from termia.models import LocalTerminalProfile, Server, Workspace
@@ -124,3 +126,117 @@ class WorkspaceOpeningTests(unittest.TestCase):
 
         self.assertFalse(accepted)
         self.assertEqual(host.toast, "Limit 32; found 33")
+
+    def test_local_workspace_root_uses_saved_available_directory(self) -> None:
+        profile = LocalTerminalProfile(id="shell", name="Shell")
+        host = SimpleNamespace(
+            store=SimpleNamespace(data=SimpleNamespace(local_terminals=[profile])),
+            opened=None,
+            available_workspace_working_directory=(
+                TerminalSessionsMixin.available_workspace_working_directory
+            ),
+        )
+
+        def open_local(selected, **kwargs):
+            host.opened = (selected, kwargs)
+            return "session"
+
+        host.open_local_terminal_profile = open_local
+        with tempfile.TemporaryDirectory() as directory:
+            session = TerminalSessionsMixin.open_workspace_root(
+                host,
+                {
+                    "type": "pane",
+                    "connection_type": "local",
+                    "connection_id": "shell",
+                    "working_directory": directory,
+                },
+            )
+
+        self.assertEqual(session, "session")
+        self.assertIs(host.opened[0], profile)
+        self.assertEqual(host.opened[1]["working_directory_override"], directory)
+
+    def test_missing_workspace_directory_falls_back_to_profile_default(self) -> None:
+        profile = LocalTerminalProfile(id="shell", name="Shell")
+        host = SimpleNamespace(
+            store=SimpleNamespace(data=SimpleNamespace(local_terminals=[profile])),
+            opened=None,
+            available_workspace_working_directory=(
+                TerminalSessionsMixin.available_workspace_working_directory
+            ),
+        )
+
+        def open_local(selected, **kwargs):
+            host.opened = (selected, kwargs)
+            return "session"
+
+        host.open_local_terminal_profile = open_local
+        missing = str(Path(tempfile.gettempdir()) / "termia-missing-workspace-directory")
+        TerminalSessionsMixin.open_workspace_root(
+            host,
+            {
+                "type": "pane",
+                "connection_type": "local",
+                "connection_id": "shell",
+                "working_directory": missing,
+            },
+        )
+
+        self.assertEqual(host.opened[1], {"split_layout": "none"})
+
+    def test_local_split_uses_its_own_saved_directory(self) -> None:
+        profile = LocalTerminalProfile(id="shell", name="Shell")
+        host = SimpleNamespace(
+            store=SimpleNamespace(data=SimpleNamespace(local_terminals=[profile])),
+            started=None,
+            available_workspace_working_directory=(
+                TerminalSessionsMixin.available_workspace_working_directory
+            ),
+        )
+
+        def start_local(session, terminal, source_terminal, **kwargs):
+            host.started = (session, terminal, source_terminal, kwargs)
+
+        host.start_local_split_terminal = start_local
+        with tempfile.TemporaryDirectory() as directory:
+            started = TerminalSessionsMixin.start_workspace_pane(
+                host,
+                "session",
+                "terminal",
+                "source",
+                {
+                    "type": "pane",
+                    "connection_type": "local",
+                    "connection_id": "shell",
+                    "working_directory": directory,
+                },
+            )
+
+        self.assertTrue(started)
+        self.assertEqual(host.started[3]["working_directory_override"], directory)
+
+    def test_restores_saved_custom_tab_title(self) -> None:
+        pane_state = SimpleNamespace(title="Shell")
+        session = SimpleNamespace(
+            title="Shell",
+            title_locked=False,
+            terminal=object(),
+            pane_for_terminal=lambda _terminal: pane_state,
+        )
+        host = SimpleNamespace(
+            updated=None,
+            synced=False,
+            update_session_tab_title=lambda current, title: setattr(
+                host, "updated", (current, title)
+            ),
+            sync_window_title_with_visible_session=lambda: setattr(host, "synced", True),
+        )
+
+        TerminalSessionsMixin.restore_workspace_tab_title(host, session, " Project shell ")
+
+        self.assertEqual(session.title, "Project shell")
+        self.assertTrue(session.title_locked)
+        self.assertEqual(pane_state.title, "Project shell")
+        self.assertEqual(host.updated, (session, "Project shell"))
+        self.assertTrue(host.synced)


### PR DESCRIPTION
Closes #214

## Summary
- Preserve custom tab titles in saved workspaces.
- Capture and restore an independent working directory for every local terminal pane, including splits.
- Fall back to the profile or default startup directory when a saved local path is unavailable.
- Never capture remote SSH working directories or terminal output.
- Keep automatic session snapshots minimal and compatible with legacy workspace data.
- Update English, Spanish, and Catalan documentation and regression coverage.

## Validation
- `PYTHONPATH=src python3 -m unittest discover -s tests -q` (142 tests)
- `python3 scripts/compile_translations.py --check`
- `python3 -m py_compile run_termia.py scripts/compile_translations.py src/termia/*.py tests/*.py`
- `git diff --check`
- Manual validation completed with independent local split directories, custom tab title, unavailable-directory fallback, and an SSH pane.