### PR TITLE
Prevent stale search activation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Changes merged after `0.5.0-beta.3` (released 2026-07-30).
 
 ### Fixed
 
+- Prevent Enter in the server filter from reopening a stale selection that is
+  absent from the current search results (`#216`).
 - Create detached sessions as normal application windows instead of transient
   windows so GTK exposes native minimize, maximize, and close controls while
   preserving tab restoration on close (`#209`).

--- a/docs/REGRESSION_CHECKS.md
+++ b/docs/REGRESSION_CHECKS.md
@@ -199,6 +199,10 @@ Protected behavior does not mean the code cannot change. It means regressions sh
 
 Before merging changes that touch UI, terminals, tabs, or configuration, verify:
 
+- Filter for one server and open it with Enter. Type a different query and
+  immediately press Enter; only the first server in the current results may
+  open. Repeat with a query that has no matches and confirm nothing opens.
+
 - Open Termia and confirm a local terminal opens if the preference is enabled.
 - Open two local terminals and reorder their tabs with the mouse.
 - At 1280, 1366, 1920, and 2560 logical pixels, open enough tabs to overflow

--- a/src/termia/sidebar.py
+++ b/src/termia/sidebar.py
@@ -292,6 +292,9 @@ class SidebarMixin:
         )
         self.sidebar_projection = projection
         self.visible_tree_rows = projection.rows
+        if self.selected is not None and self.get_visible_tree_row_index(self.selected) is None:
+            self.selected = None
+            self.selected_tree_widget = None
         if projection.workspaces:
             self.server_list.append(self.build_workspaces_widget(projection.workspaces, query))
         if projection.local_terminal_profiles:
@@ -707,7 +710,10 @@ class SidebarMixin:
         return self.select_visible_tree_row(target_index)
 
     def activate_selected_tree_row(self) -> bool:
-        if self.selected is None:
+        if self.selected is None or self.get_visible_tree_row_index(self.selected) is None:
+            if not self.select_visible_tree_row(0):
+                return False
+        if self.selected is None or self.get_visible_tree_row_index(self.selected) is None:
             return False
         if self.selected.kind == "local_terminal":
             profile = find_local_terminal_profile(self.store.data.local_terminals, self.selected.item_id)

--- a/tests/test_sidebar_navigation.py
+++ b/tests/test_sidebar_navigation.py
@@ -1,0 +1,82 @@
+import unittest
+from types import SimpleNamespace
+
+from termia.models import Server
+from termia.sidebar import SidebarMixin
+from termia.sidebar_projection import SidebarRow
+
+
+class FakeWidget:
+    def __init__(self) -> None:
+        self.focused = False
+        self.classes: set[str] = set()
+
+    def add_css_class(self, name: str) -> None:
+        self.classes.add(name)
+
+    def remove_css_class(self, name: str) -> None:
+        self.classes.discard(name)
+
+    def grab_focus(self) -> None:
+        self.focused = True
+
+
+class SidebarNavigationTests(unittest.TestCase):
+    def build_host(self, rows: list[SidebarRow]):
+        server = Server(id="current", name="Current", host="current.test", user="user")
+
+        class Host(SidebarMixin):
+            def __init__(self) -> None:
+                self.visible_tree_rows = rows
+                self.tree_widgets = {
+                    (row.kind, row.item_id): FakeWidget() for row in rows
+                }
+                self.selected = None
+                self.selected_tree_widget = None
+                self.store = SimpleNamespace(data=SimpleNamespace(servers=[server]))
+                self.opened = None
+
+            def cancel_sidebar_scroll_restore(self) -> None:
+                pass
+
+            def select_tree_row(self, row, widget, preserve_scroll=True) -> None:
+                self.selected = row
+                self.selected_tree_widget = widget
+                widget.add_css_class("selected")
+
+            def open_terminal_tab(self, selected_server) -> None:
+                self.opened = selected_server
+
+        return Host(), server
+
+    def test_enter_replaces_stale_selection_with_first_visible_result(self) -> None:
+        current = SidebarRow("server", "current", "Current")
+        host, server = self.build_host([current])
+        host.selected = SidebarRow("server", "previous", "Previous")
+
+        activated = host.activate_selected_tree_row()
+
+        self.assertTrue(activated)
+        self.assertEqual(host.selected, current)
+        self.assertIs(host.opened, server)
+
+    def test_enter_with_no_results_does_not_activate_stale_selection(self) -> None:
+        host, _server = self.build_host([])
+        host.selected = SidebarRow("server", "previous", "Previous")
+
+        activated = host.activate_selected_tree_row()
+
+        self.assertFalse(activated)
+        self.assertIsNone(host.opened)
+
+    def test_activation_rejects_selection_removed_during_result_resolution(self) -> None:
+        current = SidebarRow("server", "current", "Current")
+        host, _server = self.build_host([current])
+        host.selected = current
+        host.get_visible_tree_row_index = lambda _row: None
+        host.select_visible_tree_row = lambda _index: False
+
+        activated = host.activate_selected_tree_row()
+
+        self.assertFalse(activated)
+        self.assertIsNone(host.opened)


### PR DESCRIPTION
Closes #216

## Summary
- Clear a sidebar selection when it is absent from the current filtered rows.
- Resolve Enter against the current visible result set and select its first row when needed.
- Ignore Enter when the active search has no results.
- Add focused regression coverage for rapid query changes and stale selections.

## Validation
- `PYTHONPATH=src python3 -m unittest discover -s tests -q` (145 tests)
- `python3 scripts/compile_translations.py --check`
- `python3 -m py_compile run_termia.py scripts/compile_translations.py src/termia/*.py tests/*.py`
- `git diff --check`
- Manual validation completed for rapid search changes, no-match queries, arrow navigation, Enter activation, and mouse activation.