### PR TITLE
Fix split pane removal focus handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Changes merged after `0.5.0-beta.3` (released 2026-07-30).
 
 ### Fixed
 
+- Transfer focus safely before collapsing nested split layouts so closing a
+  pane does not leave stale `GtkPaned` focus state (`#219`).
 - Prevent Enter in the server filter from reopening a stale selection that is
   absent from the current search results (`#216`).
 - Create detached sessions as normal application windows instead of transient

--- a/src/termia/terminal_sessions.py
+++ b/src/termia/terminal_sessions.py
@@ -1640,14 +1640,43 @@ class TerminalSessionsMixin:
         )
         if sibling is None:
             return GLib.SOURCE_REMOVE
+        focus_target = self.active_terminal_in_split_subtree(session, sibling)
+        self.clear_split_focus_before_replacement(parent)
         self.replace_split_container(parent, sibling)
         session.panes.pop(id(terminal), None)
         if self.should_close_tab_after_terminal_exit(session):
             self.close_tab(session.id, session.page, disconnect=False)
             return GLib.SOURCE_REMOVE
-        active_panes = session.active_panes()
-        if active_panes:
-            active_panes[-1].terminal.grab_focus()
+        if focus_target is None:
+            active_panes = session.active_panes()
+            focus_target = active_panes[-1].terminal if active_panes else None
+        if focus_target is not None:
+            GLib.idle_add(self.restore_terminal_focus, focus_target)
+        return GLib.SOURCE_REMOVE
+
+    def active_terminal_in_split_subtree(
+        self,
+        session: TerminalSession,
+        subtree: Gtk.Widget,
+    ) -> Vte.Terminal | None:
+        for pane in session.active_panes():
+            widget: Gtk.Widget | None = pane.container
+            while widget is not None:
+                if widget is subtree:
+                    return pane.terminal
+                widget = widget.get_parent()
+        return None
+
+    def clear_split_focus_before_replacement(self, paned: Gtk.Paned) -> None:
+        root = paned.get_root()
+        get_focus = getattr(root, "get_focus", None)
+        set_focus = getattr(root, "set_focus", None)
+        focused = get_focus() if callable(get_focus) else None
+        if focused is not None and callable(set_focus):
+            set_focus(None)
+
+    def restore_terminal_focus(self, terminal: Vte.Terminal) -> bool:
+        terminal.grab_focus()
         return GLib.SOURCE_REMOVE
 
     def remove_terminal_pane_if_split(self, terminal: Vte.Terminal, session: TerminalSession) -> None:

--- a/tests/test_terminal_panes.py
+++ b/tests/test_terminal_panes.py
@@ -42,6 +42,14 @@ class FakeControl:
         return self.visible
 
 
+class FakeWidget:
+    def __init__(self, parent=None) -> None:
+        self.parent = parent
+
+    def get_parent(self):
+        return self.parent
+
+
 def make_pane(
     terminal,
     pane_id: str,
@@ -87,6 +95,49 @@ def make_session(root_terminal, root_pane: TerminalPane) -> TerminalSession:
 
 
 class TerminalPaneStateTests(unittest.TestCase):
+    def test_split_removal_selects_focus_target_from_surviving_nested_subtree(self) -> None:
+        root_terminal = FakeTerminal()
+        nested_terminal = FakeTerminal()
+        other_terminal = FakeTerminal()
+        surviving_subtree = FakeWidget()
+        nested_container = FakeWidget(surviving_subtree)
+        other_container = FakeWidget(FakeWidget())
+        root = make_pane(root_terminal, "root")
+        nested = make_pane(nested_terminal, "nested")
+        other = make_pane(other_terminal, "other")
+        root.container = FakeWidget()
+        nested.container = nested_container
+        other.container = other_container
+        session = make_session(root_terminal, root)
+        session.panes[id(nested_terminal)] = nested
+        session.panes[id(other_terminal)] = other
+        session.active_terminal_ids.update((id(nested_terminal), id(other_terminal)))
+
+        target = TerminalSessionsMixin().active_terminal_in_split_subtree(session, surviving_subtree)
+
+        self.assertIs(target, nested_terminal)
+
+    def test_restoring_split_focus_is_deferred_callback_safe(self) -> None:
+        terminal = FakeTerminal()
+
+        result = TerminalSessionsMixin().restore_terminal_focus(terminal)
+
+        self.assertTrue(terminal.focused)
+        from gi.repository import GLib
+
+        self.assertEqual(result, GLib.SOURCE_REMOVE)
+
+    def test_split_replacement_clears_existing_window_focus(self) -> None:
+        focused = object()
+        root = Mock()
+        root.get_focus.return_value = focused
+        paned = Mock()
+        paned.get_root.return_value = root
+
+        TerminalSessionsMixin().clear_split_focus_before_replacement(paned)
+
+        root.set_focus.assert_called_once_with(None)
+
     def test_split_focus_grabs_selected_neighbor(self) -> None:
         root_terminal = FakeTerminal()
         split_terminal = FakeTerminal()


### PR DESCRIPTION
## Summary

- transfer focus away from a `GtkPaned` before collapsing a closed split
- select a surviving terminal from nested split layouts and restore its focus after GTK rebuilds the tree
- cover nested-subtree focus selection and deferred focus restoration

## Tests

- `python3 -m py_compile src/termia/terminal_sessions.py`
- `PYTHONPATH=src python3 -m unittest tests.test_terminal_panes`
- `PYTHONPATH=src python3 -m unittest discover -s tests`
- `python3 -m py_compile run_termia.py scripts/compile_translations.py src/termia/*.py tests/*.py`
- `bash -n scripts/*.sh`
- manual validation with three or more mixed nested splits, closing panes via `exit` without GTK focus warnings

Closes #219
