### PR TITLE
Make debug logging actionable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ Changes merged after `0.5.0-beta.3` (released 2026-07-30).
 
 ### Changed
 
+- Make debug logging focus on privacy-safe Termia lifecycle events, retain
+  actionable GTK warnings, and capture Python stacks on fatal signals (`#221`).
 - Unify Terminal appearance and local Prompt preferences in one dialog with a
   compact shared live preview, while preserving running shell environments (`#205`).
 - Streamline repository maintenance guidance and validation output while

--- a/README.md
+++ b/README.md
@@ -88,16 +88,17 @@ The option copies connections, settings, connection history, statistics, and
 the debug log into the test profile. Changes made there never modify your usual
 Termia data.
 
-For diagnostic information about GTK rendering, VTE sessions, storage locks,
-encryption, and read-only startup, enable `Debug mode` in General preferences. It
-can also be enabled for one run with:
+For diagnostic information about tabs, splits, VTE process lifecycles, GTK
+warnings, storage locks, encryption, and read-only startup, enable `Debug mode`
+in General preferences. It can also be enabled for one run with:
 
 ```bash
 python3 run_termia.py --debug
 ```
 
-Debug output is written to `~/.local/state/termia/debug.log`. It does not log
-passwords or connection contents.
+Debug output is written to `~/.local/state/termia/debug.log`. Fatal signals also
+write the active Python stacks there when possible. It does not log passwords,
+commands, terminal contents, connection endpoints, or private paths.
 
 The launcher is installed at
 `~/.local/share/applications/local.termia.desktop` and its icon under

--- a/docs/README.ca.md
+++ b/docs/README.ca.md
@@ -77,16 +77,19 @@ L'opció copia les connexions, ajustos, historial de connexions, estadístiques 
 el registre de depuració al perfil de proves. Els canvis fets allà mai no
 modifiquen les dades habituals de Termia.
 
-Per obtenir informació de diagnòstic sobre GTK, VTE, els bloquejos
-d'emmagatzematge, el xifratge i l'inici en mode només lectura, activa `Mode
-debug` a les preferències Generals. També pots activar-lo per a una execució amb:
+Per obtenir informació de diagnòstic sobre pestanyes, splits, processos VTE,
+avisos de GTK, bloquejos d'emmagatzematge, xifratge i inici en mode només lectura,
+activa `Mode debug` a les preferències Generals. També pots activar-lo per a una
+execució amb:
 
 ```bash
 python3 run_termia.py --debug
 ```
 
-La informació es desa a `~/.local/state/termia/debug.log`. No registra
-contrasenyes ni el contingut de les connexions.
+La informació es desa a `~/.local/state/termia/debug.log`. Quan és possible, els
+senyals fatals també hi escriuen les piles Python actives. No registra
+contrasenyes, ordres, contingut del terminal, destinacions de connexió ni rutes
+privades.
 
 Elimina únicament el llançador d'escriptori, sense esborrar ajustos, connexions,
 estadístiques ni paquets del sistema:

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -77,16 +77,19 @@ La opción copia las conexiones, ajustes, historial de conexiones, estadísticas
 el registro de depuración en el perfil de pruebas. Los cambios realizados allí
 nunca modifican los datos habituales de Termia.
 
-Para obtener información de diagnóstico sobre GTK, VTE, los bloqueos de
-almacenamiento, el cifrado y el arranque en modo solo lectura, activa `Modo
-debug` en las preferencias Generales. También puedes activarlo para una ejecución con:
+Para obtener información de diagnóstico sobre pestañas, splits, procesos VTE,
+avisos de GTK, bloqueos de almacenamiento, cifrado y arranque en modo solo
+lectura, activa `Modo debug` en las preferencias Generales. También puedes
+activarlo para una ejecución con:
 
 ```bash
 python3 run_termia.py --debug
 ```
 
-La información se guarda en `~/.local/state/termia/debug.log`. No registra
-contraseñas ni el contenido de las conexiones.
+La información se guarda en `~/.local/state/termia/debug.log`. Cuando es posible,
+las señales fatales también escriben allí las pilas Python activas. No registra
+contraseñas, comandos, contenido del terminal, destinos de conexión ni rutas
+privadas.
 
 Elimina únicamente el lanzador de escritorio, sin borrar ajustes, conexiones,
 estadísticas ni paquetes del sistema:

--- a/src/termia/app.py
+++ b/src/termia/app.py
@@ -2,7 +2,6 @@
 # SPDX-FileCopyrightText: 2026 Jordi Pons
 # SPDX-License-Identifier: GPL-3.0-or-later
 import argparse
-import logging
 import signal
 
 import gi
@@ -18,14 +17,12 @@ from .connection_dialogs import ConnectionDialogsMixin
 from .constants import (
     APP_ID,
     DATA_FILE,
-    DEBUG_LOG_FILE,
-    HISTORY_FILE,
     INSTANCE_LOCK_FILE,
     SETTINGS_FILE,
     SESSION_SNAPSHOT_FILE,
     STATE_DIR,
 )
-from .debug import configure_debug_logging, log_startup_context, log_store_state
+from .debug import configure_debug_logging, log_event, log_startup_context, log_store_state
 from .i18n import translate_key
 from .keybindings import keybinding_matches
 from .main_menu import MainMenuMixin
@@ -127,7 +124,7 @@ class TermiaWindow(
             state_dir=STATE_DIR,
         )
         log_store_state(self.store)
-        logging.getLogger("termia").debug("debug_log_file=%s history_path=%s", DEBUG_LOG_FILE, HISTORY_FILE)
+        log_event("application.window_created", read_only=self.store.read_only)
         if self.store.read_only:
             self.set_title(f"Termia ({self.t('read_only_badge')})")
         self.apply_app_theme()
@@ -397,6 +394,7 @@ class TermiaWindow(
         if self.shutdown_in_progress:
             return
         self.shutdown_in_progress = True
+        log_event("application.shutdown_started", sessions=len(self.session_registry.sessions()))
         self.save_session_snapshot_before_close()
         self.save_history_before_close()
         self.save_statistics_before_close()
@@ -417,6 +415,7 @@ class TermiaWindow(
 
     def finish_main_window_shutdown(self) -> bool:
         self.terminate_open_terminal_processes(force=True)
+        log_event("application.shutdown_finished")
         application = self.get_application()
         if application is not None:
             application.quit()
@@ -861,6 +860,7 @@ class TermiaApp(Gtk.Application):
         created = window is None
         if window is None:
             window = TermiaWindow(self)
+        log_event("application.activated", window_created=created)
         window.present()
         if created:
             window.focus_startup_control()

--- a/src/termia/debug.py
+++ b/src/termia/debug.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
+import faulthandler
 import logging
 import os
 from pathlib import Path
@@ -15,6 +16,13 @@ from .constants import DEBUG_LOG_FILE
 
 LOGGER = logging.getLogger("termia")
 _GLIB_WRITER_CONFIGURED = False
+_FAULT_HANDLER_CONFIGURED = False
+
+
+def log_event(event: str, **fields: object) -> None:
+    """Write a privacy-safe, machine-searchable application lifecycle event."""
+    details = " ".join(f"{key}={value}" for key, value in sorted(fields.items()) if value is not None)
+    LOGGER.debug("event=%s%s", event, f" {details}" if details else "")
 
 
 def _write_glib_log(
@@ -38,14 +46,17 @@ def _write_glib_log(
     except (TypeError, ValueError, UnicodeError) as exc:
         LOGGER.warning("Could not format GLib diagnostic: %s", exc)
         return GLib.LogWriterOutput.HANDLED
-    if message:
+    if message and level >= logging.WARNING:
         LOGGER.log(level, "%s", message)
     return GLib.LogWriterOutput.HANDLED
 
 
 def configure_debug_logging(enabled: bool) -> None:
-    global _GLIB_WRITER_CONFIGURED
+    global _FAULT_HANDLER_CONFIGURED, _GLIB_WRITER_CONFIGURED
     if not enabled:
+        if _FAULT_HANDLER_CONFIGURED and faulthandler.is_enabled():
+            faulthandler.disable()
+        _FAULT_HANDLER_CONFIGURED = False
         LOGGER.disabled = True
         for handler in LOGGER.handlers[:]:
             LOGGER.removeHandler(handler)
@@ -54,8 +65,6 @@ def configure_debug_logging(enabled: bool) -> None:
     LOGGER.disabled = False
     if LOGGER.handlers:
         return
-    os.environ.setdefault("G_MESSAGES_DEBUG", "all")
-    os.environ.setdefault("PYTHONFAULTHANDLER", "1")
     LOGGER.setLevel(logging.DEBUG)
     LOGGER.propagate = False
     formatter = logging.Formatter("%(asctime)s %(levelname)s %(message)s")
@@ -64,6 +73,8 @@ def configure_debug_logging(enabled: bool) -> None:
         file_handler = logging.FileHandler(DEBUG_LOG_FILE, encoding="utf-8")
         file_handler.setFormatter(formatter)
         LOGGER.addHandler(file_handler)
+        faulthandler.enable(file=file_handler.stream, all_threads=True)
+        _FAULT_HANDLER_CONFIGURED = True
         if not _GLIB_WRITER_CONFIGURED:
             GLib.log_set_writer_func(_write_glib_log, None)
             _GLIB_WRITER_CONFIGURED = True
@@ -73,10 +84,15 @@ def configure_debug_logging(enabled: bool) -> None:
 
 
 def log_startup_context(*, lock_path: Path, data_path: Path, settings_path: Path, state_dir: Path) -> None:
-    LOGGER.debug("PID=%s PPID=%s", os.getpid(), os.getppid())
-    LOGGER.debug("XDG_SESSION_TYPE=%s", os.environ.get("XDG_SESSION_TYPE", ""))
-    LOGGER.debug("GDK_BACKEND=%s GSK_RENDERER=%s", os.environ.get("GDK_BACKEND", ""), os.environ.get("GSK_RENDERER", ""))
-    LOGGER.debug("lock_path=%s data_path=%s settings_path=%s state_dir=%s", lock_path, data_path, settings_path, state_dir)
+    log_event(
+        "application.started",
+        pid=os.getpid(),
+        parent_pid=os.getppid(),
+        session_type=os.environ.get("XDG_SESSION_TYPE", "unknown"),
+        gdk_backend=os.environ.get("GDK_BACKEND", "default"),
+        gsk_renderer=os.environ.get("GSK_RENDERER", "default"),
+        locations_configured=all((lock_path, data_path, settings_path, state_dir)),
+    )
 
 
 def log_lock_failure(path: Path, reason: str) -> None:

--- a/src/termia/tabs.py
+++ b/src/termia/tabs.py
@@ -10,6 +10,7 @@ gi.require_version("Gtk", "4.0")
 gi.require_version("Pango", "1.0")
 from gi.repository import Gdk, GLib, Graphene, Gtk, Pango
 
+from .debug import log_event
 from .ui_state import TerminalSession
 
 
@@ -22,6 +23,7 @@ class TabsMixin:
         self.update_session_tab_bar_visibility()
         self.set_active_session(session.id)
         self.sync_window_title_with_visible_session()
+        log_event("tab.attached", session_id=session.id)
 
     @staticmethod
     def tab_reveal_scroll_value(
@@ -73,6 +75,7 @@ class TabsMixin:
         self.update_session_tab_states()
         self.schedule_active_tab_reveal()
         session.terminal.grab_focus()
+        log_event("tab.selected", session_id=session.id)
 
     def update_session_tab_states(self) -> None:
         visible_page = self.terminal_stack.get_visible_child()
@@ -483,12 +486,14 @@ class TabsMixin:
         self.sync_window_title_with_visible_session()
         window.connect("close-request", self.on_detached_window_close, session)
         window.present()
+        log_event("tab.detached", session_id=session.id)
 
     def on_detached_window_close(self, window: Gtk.Window, session: TerminalSession) -> bool:
         window.set_child(None)
         session.detached_window = None
         if self.session_registry.contains(session.id):
             self.add_session_to_main_view(session)
+            log_event("tab.reattached", session_id=session.id)
         return False
 
     def show_rename_tab_dialog(self, popover: Gtk.Popover, session: TerminalSession) -> None:
@@ -557,3 +562,4 @@ class TabsMixin:
         self.update_session_tab_bar_visibility()
         self.focus_available_session_after_close(session_id, previous_order)
         self.sync_window_title_with_visible_session()
+        log_event("tab.closed", session_id=session_id, remaining_tabs=len(self.session_registry.sessions()))

--- a/src/termia/terminal_sessions.py
+++ b/src/termia/terminal_sessions.py
@@ -49,6 +49,7 @@ from .workspace_layout import (
     workspace_tab_layouts,
     workspace_total_pane_count,
 )
+from .debug import log_event
 
 
 INITIAL_LOCAL_COMMAND_DELAY_MS = 300
@@ -228,6 +229,12 @@ class TerminalSessionsMixin:
             local_profile_id=local_profile_id,
         )
         session.active_terminal_ids.add(id(terminal))
+        log_event(
+            "session.created",
+            session_id=session.id,
+            pane_id=session.id,
+            kind="ssh" if server_id is not None else "local",
+        )
         return session, focus_button
 
     def open_process_terminal_tab(
@@ -282,6 +289,13 @@ class TerminalSessionsMixin:
             return session
         session.child_process = child_process
         session.child_pid = child_process.pid
+        log_event(
+            "process.started",
+            session_id=session.id,
+            pane_id=session.id,
+            kind="local",
+            pid=child_process.pid,
+        )
         self.sync_root_pane_state(session)
         self.update_local_session_directory_title(session)
         session.timeout_id = GLib.timeout_add_seconds(1, self.update_session_timer, session)
@@ -303,6 +317,14 @@ class TerminalSessionsMixin:
         self.save_statistics_now()
         result = "disconnected" if pane.disconnect_requested else (
             "closed" if self.child_status_successful(_status) else "failed"
+        )
+        log_event(
+            "process.exited",
+            session_id=session.id,
+            pane_id=pane.id,
+            kind="local",
+            status=_status,
+            result=result,
         )
         self.store.record_history_end(session, result)
         pane.connected = False
@@ -370,6 +392,7 @@ class TerminalSessionsMixin:
 
     def open_workspace(self, workspace: Workspace) -> None:
         pane_count = workspace_total_pane_count(workspace.tabs)
+        log_event("workspace.open_requested", workspace_id=workspace.id, panes=pane_count)
         if pane_count > MAX_WORKSPACE_PANES:
             self.toast_label.set_label(
                 self.t("workspace_pane_limit_exceeded").format(
@@ -416,6 +439,12 @@ class TerminalSessionsMixin:
                     skipped=skipped_tabs,
                 )
             )
+        log_event(
+            "workspace.open_finished",
+            workspace_id=workspace.id,
+            opened_tabs=opened_tabs,
+            skipped_tabs=skipped_tabs,
+        )
 
     def restore_session_snapshot(self, tabs: list[dict[str, object]]) -> None:
         """Reopen the last session from safe connection references."""
@@ -625,6 +654,13 @@ class TerminalSessionsMixin:
 
         session.child_process = child_process
         session.child_pid = child_process.pid
+        log_event(
+            "process.started",
+            session_id=session.id,
+            pane_id=session.id,
+            kind="ssh",
+            pid=child_process.pid,
+        )
         self.sync_root_pane_state(session)
         session.timeout_id = GLib.timeout_add_seconds(1, self.update_session_timer, session)
         terminal.connect("child-exited", self.on_terminal_exited, server, session)
@@ -642,6 +678,7 @@ class TerminalSessionsMixin:
         prompt = f"  {self.t('reconnect_prompt')}  "
         session.terminal.feed(f"\r\n\x1b[1;30;48;2;255;213;79m{prompt}\x1b[0m\r\n".encode())
         self.update_session_tab_title(session, self.t("tab_error_title").format(title=session.title))
+        log_event("session.reconnect_pending", session_id=session.id, pane_id=session.id, kind="ssh")
 
     def reconnect_session(self, session: TerminalSession) -> None:
         if not session.pending_reconnect or session.server_id is None:
@@ -682,6 +719,12 @@ class TerminalSessionsMixin:
         prompt = f"  {self.t('reconnect_prompt')}  "
         pane.terminal.feed(f"\r\n\x1b[1;30;48;2;255;213;79m{prompt}\x1b[0m\r\n".encode())
         self.toast_label.set_label(toast)
+        log_event(
+            "session.reconnect_pending",
+            session_id=session.id,
+            pane_id=pane.id,
+            kind="ssh" if pane.server_id is not None else "local",
+        )
 
     def show_pane_reconnect_controls(self, pane: TerminalPane) -> None:
         pane.status_bar.set_visible(True)
@@ -854,6 +897,7 @@ class TerminalSessionsMixin:
         pane = session.pane_for_terminal(terminal)
         if pane is not None:
             pane.status_bar.add_css_class("active")
+            log_event("split.focused", session_id=session.id, pane_id=pane.id)
 
     def on_terminal_key_pressed(
         self,
@@ -1048,11 +1092,21 @@ class TerminalSessionsMixin:
         if len(session.panes) >= MAX_TERMINAL_PANES:
             self.toast_label.set_label(self.t("split_pane_limit").format(limit=MAX_TERMINAL_PANES))
             return None
-        return SplitPaneController(
+        new_terminal = SplitPaneController(
             self.create_split_terminal,
             self.terminal_pane_container,
             self.replace_terminal_pane,
         ).split_terminal(session, terminal, direction)
+        if new_terminal is not None:
+            pane = session.pane_for_terminal(new_terminal)
+            log_event(
+                "split.created",
+                session_id=session.id,
+                pane_id=pane.id if pane is not None else None,
+                direction=direction,
+                pane_count=len(session.panes),
+            )
+        return new_terminal
 
     def terminal_pane_container(
         self,
@@ -1479,6 +1533,13 @@ class TerminalSessionsMixin:
             return
         pane.child_pid = child_process.pid
         pane.child_process = child_process
+        log_event(
+            "process.started",
+            session_id=session.id,
+            pane_id=pane.id,
+            kind="local",
+            pid=child_process.pid,
+        )
         pane.status_label.set_label(f"{pane.title} · PID {child_process.pid}")
         pane.timeout_id = GLib.timeout_add_seconds(1, self.update_pane_timer, session, terminal)
         session.split_child_pids[id(terminal)] = child_process.pid
@@ -1560,6 +1621,13 @@ class TerminalSessionsMixin:
             return
         pane.child_pid = child_process.pid
         pane.child_process = child_process
+        log_event(
+            "process.started",
+            session_id=session.id,
+            pane_id=pane.id,
+            kind="ssh",
+            pid=child_process.pid,
+        )
         pane.status_label.set_label(f"{server.name} · PID {child_process.pid}")
         pane.timeout_id = GLib.timeout_add_seconds(1, self.update_pane_timer, session, terminal)
         session.split_child_pids[id(terminal)] = child_process.pid
@@ -1592,6 +1660,14 @@ class TerminalSessionsMixin:
             self.record_pane_duration(pane)
             result = "disconnected" if pane.disconnect_requested else (
                 "closed" if self.child_status_successful(_status) else "failed"
+            )
+            log_event(
+                "process.exited",
+                session_id=session.id,
+                pane_id=pane.id,
+                kind="ssh" if pane.server_id is not None else "local",
+                status=_status,
+                result=result,
             )
             self.store.record_history_end(pane, result)
             pane.connected = False
@@ -1644,6 +1720,12 @@ class TerminalSessionsMixin:
         self.clear_split_focus_before_replacement(parent)
         self.replace_split_container(parent, sibling)
         session.panes.pop(id(terminal), None)
+        log_event(
+            "split.removed",
+            session_id=session.id,
+            pane_id=pane.id,
+            remaining_panes=len(session.panes),
+        )
         if self.should_close_tab_after_terminal_exit(session):
             self.close_tab(session.id, session.page, disconnect=False)
             return GLib.SOURCE_REMOVE
@@ -1870,6 +1952,12 @@ class TerminalSessionsMixin:
     def terminate_terminal_process(self, process: TerminalProcess, *, force: bool = False) -> bool:
         signum = signal.SIGKILL if force else signal.SIGTERM
         terminated = signal_terminal_process(process, signum)
+        log_event(
+            "process.termination_requested",
+            pid=process.pid,
+            signal=signum.name,
+            accepted=terminated,
+        )
         if terminated and not force:
             GLib.timeout_add(500, self.force_terminate_terminal_process, process)
         return terminated
@@ -1940,6 +2028,7 @@ class TerminalSessionsMixin:
                 self.close_pending_reconnect_pane(session, terminal)
             return
         pane.disconnect_requested = True
+        log_event("split.disconnect_requested", session_id=session.id, pane_id=pane.id)
         process = pane.child_process
         if process is not None and not self.terminate_terminal_process(process):
             message = self.t("sigterm_failed")
@@ -1966,6 +2055,7 @@ class TerminalSessionsMixin:
         if not session.connected:
             return
         session.disconnect_requested = True
+        log_event("session.disconnect_requested", session_id=session.id, panes=len(session.panes))
         for pane in session.panes.values():
             pane.disconnect_requested = True
         if session.child_process is not None and not self.terminate_terminal_process(session.child_process):
@@ -2026,6 +2116,14 @@ class TerminalSessionsMixin:
         self.save_statistics_now()
         result = "disconnected" if pane.disconnect_requested else (
             "closed" if self.child_status_successful(_status) else "failed"
+        )
+        log_event(
+            "process.exited",
+            session_id=session.id,
+            pane_id=pane.id,
+            kind="ssh",
+            status=_status,
+            result=result,
         )
         self.store.record_history_end(session, result)
         pane.connected = False

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -2,6 +2,7 @@ import tempfile
 import unittest
 import logging
 import os
+import faulthandler
 from pathlib import Path
 from unittest.mock import patch
 
@@ -34,7 +35,7 @@ class DebugLoggingTests(unittest.TestCase):
                 )
             )
 
-    def test_glib_diagnostics_use_the_debug_file(self) -> None:
+    def test_glib_debug_noise_is_filtered_from_debug_file(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             log_path = Path(directory) / "debug.log"
             with patch.object(debug, "DEBUG_LOG_FILE", log_path):
@@ -49,9 +50,49 @@ class DebugLoggingTests(unittest.TestCase):
                 )
 
             contents = log_path.read_text(encoding="utf-8")
-            self.assertIn("GtkTest", contents)
-            self.assertIn("GTK diagnostic", contents)
+            self.assertNotIn("GtkTest", contents)
+            self.assertNotIn("GTK diagnostic", contents)
             self.assertNotRegex(contents, r"DEBUG \[\d+\] \d+")
+
+    def test_glib_warnings_remain_available_in_debug_file(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            log_path = Path(directory) / "debug.log"
+            with patch.object(debug, "DEBUG_LOG_FILE", log_path):
+                debug.configure_debug_logging(True)
+                GLib.log_variant(
+                    "GtkTest",
+                    GLib.LogLevelFlags.LEVEL_WARNING,
+                    GLib.Variant("a{sv}", {"MESSAGE": GLib.Variant("s", "Actionable warning")}),
+                )
+
+            contents = log_path.read_text(encoding="utf-8")
+            self.assertIn("GtkTest", contents)
+            self.assertIn("Actionable warning", contents)
+
+    def test_application_events_are_structured_and_omit_none_fields(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            log_path = Path(directory) / "debug.log"
+            with patch.object(debug, "DEBUG_LOG_FILE", log_path):
+                debug.configure_debug_logging(True)
+                debug.log_event("split.created", session_id="session-1", pane_id=None, pane_count=3)
+
+            contents = log_path.read_text(encoding="utf-8")
+            self.assertIn("event=split.created pane_count=3 session_id=session-1", contents)
+            self.assertNotIn("pane_id", contents)
+
+    def test_faulthandler_writes_python_stack_to_debug_file(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            log_path = Path(directory) / "debug.log"
+            with patch.object(debug, "DEBUG_LOG_FILE", log_path):
+                debug.configure_debug_logging(True)
+                self.assertTrue(faulthandler.is_enabled())
+                handler = next(handler for handler in debug.LOGGER.handlers if isinstance(handler, logging.FileHandler))
+                faulthandler.dump_traceback(file=handler.stream, all_threads=True)
+                handler.flush()
+
+            contents = log_path.read_text(encoding="utf-8")
+            self.assertIn("Current thread", contents)
+            self.assertIn("test_faulthandler_writes_python_stack_to_debug_file", contents)
 
     def test_debug_logging_does_not_enable_gsk_renderer_output(self) -> None:
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
## Summary

- replace noisy low-level GTK/GLib debug output with structured, privacy-safe Termia lifecycle events
- retain actionable GTK/GLib warnings and errors
- capture active Python stacks in `debug.log` on fatal signals when possible
- document the diagnostic scope and privacy guarantees in all README languages

## Tests

- `python3 -m py_compile src/termia/debug.py src/termia/app.py src/termia/tabs.py src/termia/terminal_sessions.py tests/test_debug.py`
- `PYTHONPATH=src python3 -m unittest tests.test_debug tests.test_tabs tests.test_terminal_panes`
- `PYTHONPATH=src python3 -m unittest discover -s tests`
- `python3 -m py_compile run_termia.py scripts/compile_translations.py src/termia/*.py tests/*.py`
- `bash -n scripts/*.sh`
- manual validation of tab, split, process, workspace and shutdown events without GTK snapshot or `g_unix_open_pipe` noise

Closes #221
