### PR TITLE
Synchronize detached window titles when renaming tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Changes merged after `0.5.0-beta.3` (released 2026-07-30).
 
 ### Fixed
 
+- Keep a detached window's native and header titles synchronized when its tab
+  is renamed, and bind the rename dialog input to that window (`#224`).
 - Transfer focus safely before collapsing nested split layouts so closing a
   pane does not leave stale `GtkPaned` focus state (`#219`).
 - Prevent Enter in the server filter from reopening a stale selection that is

--- a/src/termia/tabs.py
+++ b/src/termia/tabs.py
@@ -498,7 +498,11 @@ class TabsMixin:
 
     def show_rename_tab_dialog(self, popover: Gtk.Popover, session: TerminalSession) -> None:
         popover.popdown()
-        dialog = Gtk.Dialog(title=self.t("rename_tab"), transient_for=self, modal=True)
+        dialog = Gtk.Dialog(
+            title=self.t("rename_tab"),
+            transient_for=self.window_for_session(session),
+            modal=True,
+        )
         dialog.set_resizable(False)
         self.add_dialog_action_buttons(dialog, self.t("save"))
         entry = Gtk.Entry(text=session.title)
@@ -510,6 +514,10 @@ class TabsMixin:
         dialog.get_content_area().append(entry)
         dialog.connect("response", self.on_rename_tab_response, entry, session)
         dialog.present()
+        entry.grab_focus()
+
+    def window_for_session(self, session: TerminalSession) -> Gtk.Window:
+        return session.detached_window or self
 
     def on_rename_tab_response(
         self, dialog: Gtk.Dialog, response: Gtk.ResponseType, entry: Gtk.Entry, session: TerminalSession
@@ -519,8 +527,21 @@ class TabsMixin:
             session.title = title
             session.title_locked = True
             self.update_session_tab_title(session, title)
+            self.update_detached_window_title(session, title)
             self.sync_window_title_with_visible_session()
         dialog.destroy()
+
+    def update_detached_window_title(self, session: TerminalSession, title: str) -> None:
+        window = session.detached_window
+        if window is None:
+            return
+        window.set_title(title)
+        titlebar = window.get_titlebar()
+        if not isinstance(titlebar, Gtk.HeaderBar):
+            return
+        title_widget = titlebar.get_title_widget()
+        if isinstance(title_widget, Gtk.Label):
+            title_widget.set_label(title)
 
     def on_request_close_tab(self, _button: Gtk.Button, session_id: str, page: Gtk.Widget) -> None:
         self.request_close_tab(session_id, page)

--- a/tests/test_tabs.py
+++ b/tests/test_tabs.py
@@ -21,6 +21,7 @@ class FakeWindow:
         self.child = None
         self.presented = False
         self.titlebar = None
+        self.title = kwargs.get("title", "")
 
     def set_handle_menubar_accel(self, _enabled: bool) -> None:
         pass
@@ -30,6 +31,12 @@ class FakeWindow:
 
     def set_titlebar(self, titlebar) -> None:
         self.titlebar = titlebar
+
+    def get_titlebar(self):
+        return self.titlebar
+
+    def set_title(self, title: str) -> None:
+        self.title = title
 
     def set_child(self, child) -> None:
         self.child = child
@@ -43,10 +50,21 @@ class FakeWindow:
 
 class FakeHeaderBar:
     def __init__(self) -> None:
-        pass
+        self.title_widget = None
 
-    def set_title_widget(self, _widget) -> None:
-        pass
+    def set_title_widget(self, widget) -> None:
+        self.title_widget = widget
+
+    def get_title_widget(self):
+        return self.title_widget
+
+
+class FakeLabel:
+    def __init__(self, *, label: str) -> None:
+        self.label = label
+
+    def set_label(self, label: str) -> None:
+        self.label = label
 
 
 class FakeTab:
@@ -68,6 +86,19 @@ class FakeTabBar:
 
 
 class DetachTabTests(unittest.TestCase):
+    def test_dialog_owner_uses_detached_window_when_available(self) -> None:
+        detached_window = object()
+        session = SimpleNamespace(detached_window=detached_window)
+        host = TabsMixin()
+
+        self.assertIs(host.window_for_session(session), detached_window)
+
+    def test_dialog_owner_uses_main_window_for_attached_session(self) -> None:
+        session = SimpleNamespace(detached_window=None)
+        host = TabsMixin()
+
+        self.assertIs(host.window_for_session(session), host)
+
     def test_detach_tab_keeps_previous_order_for_focus_selection(self) -> None:
         session = SimpleNamespace(
             id="detached",
@@ -111,7 +142,7 @@ class DetachTabTests(unittest.TestCase):
         with (
             patch("termia.tabs.Gtk.Window", FakeWindow),
             patch("termia.tabs.Gtk.HeaderBar", FakeHeaderBar),
-            patch("termia.tabs.Gtk.Label", lambda **_kwargs: object()),
+            patch("termia.tabs.Gtk.Label", FakeLabel),
         ):
             host.detach_tab(popover, session)
 
@@ -122,7 +153,49 @@ class DetachTabTests(unittest.TestCase):
         self.assertIs(session.detached_window.properties["application"], host.application)
         self.assertNotIn("transient_for", session.detached_window.properties)
         self.assertIsInstance(session.detached_window.titlebar, FakeHeaderBar)
+        self.assertEqual(session.detached_window.titlebar.title_widget.label, session.title)
         self.assertTrue(session.detached_window.presented)
+
+    def test_renaming_detached_tab_updates_window_and_header_titles(self) -> None:
+        window = FakeWindow(title="Old title")
+        header = FakeHeaderBar()
+        header.set_title_widget(FakeLabel(label="Old title"))
+        window.set_titlebar(header)
+        session = SimpleNamespace(
+            title="Old title",
+            title_locked=False,
+            detached_window=window,
+        )
+        dialog = SimpleNamespace(destroy=lambda: setattr(dialog, "destroyed", True))
+        entry = SimpleNamespace(get_text=lambda: "New title")
+
+        class Host(TabsMixin):
+            def __init__(self) -> None:
+                self.updated = None
+                self.synced = False
+
+            def update_session_tab_title(self, current_session, title) -> None:
+                self.updated = (current_session, title)
+
+            def sync_window_title_with_visible_session(self) -> None:
+                self.synced = True
+
+        from gi.repository import Gtk
+
+        host = Host()
+        with (
+            patch("termia.tabs.Gtk.HeaderBar", FakeHeaderBar),
+            patch("termia.tabs.Gtk.Label", FakeLabel),
+        ):
+            host.on_rename_tab_response(dialog, Gtk.ResponseType.OK, entry, session)
+
+        self.assertEqual(session.title, "New title")
+        self.assertTrue(session.title_locked)
+        self.assertEqual(host.updated, (session, "New title"))
+        self.assertEqual(window.title, "New title")
+        self.assertEqual(header.title_widget.label, "New title")
+        self.assertTrue(host.synced)
+        self.assertTrue(dialog.destroyed)
 
 
 class DuplicateTabTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

- synchronize a renamed detached tab with both its native window title and header label
- bind the rename dialog to the detached window that initiated it
- focus the rename entry explicitly so composed characters cannot leak into terminals in the main window

## Tests

- `python3 -m py_compile src/termia/tabs.py tests/test_tabs.py`
- `PYTHONPATH=src python3 -m unittest tests.test_tabs`
- `PYTHONPATH=src python3 -m unittest discover -s tests`
- `python3 -m py_compile run_termia.py scripts/compile_translations.py src/termia/*.py tests/*.py`
- `bash -n scripts/*.sh`
- manual validation with repeated detached-tab renames containing accented and composed characters

Closes #224
