### PR TITLE
Avoid blocking GTK during SSH known-host inspection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Changes merged after `0.5.0-beta.3` (released 2026-07-30).
 
 ### Fixed
 
+- Inspect SSH known-host files asynchronously so connection and SCP startup
+  cannot block the GTK interface while `ssh-keygen -F` runs (`#230`).
 - Bind session-specific dialogs, confirmations, terminal preferences, and SCP
   flows to the detached window that initiated them (`#226`).
 - Keep a detached window's native and header titles synchronized when its tab

--- a/docs/REGRESSION_CHECKS.md
+++ b/docs/REGRESSION_CHECKS.md
@@ -58,6 +58,8 @@ Protected behavior does not mean the code cannot change. It means regressions sh
 - Local terminal prompt customization must apply to newly opened and duplicated local terminals.
 - SSH sessions must not send arbitrary commands automatically to remote servers.
 - SSH fingerprint prompts must remain visible and interactive in the terminal.
+- Starting a password-backed SSH connection or SCP transfer must leave the
+  interface responsive while the SSH known-host lookup completes.
 - Failed SSH connections must leave the tab usable and show the reconnect prompt.
 - The reconnect prompt must be readable on both light and dark terminal backgrounds.
 - Pressing Enter on a failed SSH tab must reconnect to the same server.

--- a/src/termia/file_transfer.py
+++ b/src/termia/file_transfer.py
@@ -51,13 +51,13 @@ class FileTransferController:
         translate: Callable[[str], str],
         toast_label: Gtk.Label,
         add_dialog_action_button: Callable[..., Gtk.Button],
-        has_known_host_key: Callable[[str, int], bool],
+        inspect_known_host: Callable[[str, int, Callable[[bool], None]], None],
     ) -> None:
         self.parent = parent
         self.t = translate
         self.toast_label = toast_label
         self.add_dialog_action_button = add_dialog_action_button
-        self.has_known_host_key = has_known_host_key
+        self.inspect_known_host = inspect_known_host
 
     def open_file_selection(self, server: Server) -> None:
         dialog = Gtk.FileDialog(title=self.t("send_files_to_server"))
@@ -92,7 +92,21 @@ class FileTransferController:
         if ssh_path is None or scp_path is None:
             self.toast_label.set_label(self.t("send_files_to_server_missing"))
             return
-        if not self.has_known_host_key(server.host, server.port):
+        self.inspect_known_host(
+            server.host,
+            server.port,
+            lambda known: self._start_upload_after_known_host_check(server, local_paths, ssh_path, scp_path, known),
+        )
+
+    def _start_upload_after_known_host_check(
+        self,
+        server: Server,
+        local_paths: list[Path],
+        ssh_path: str,
+        scp_path: str,
+        known_host: bool,
+    ) -> None:
+        if not known_host:
             self.toast_label.set_label(self.t("send_files_to_server_fingerprint"))
             return
 

--- a/src/termia/known_hosts.py
+++ b/src/termia/known_hosts.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: 2026 Jordi Pons
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Asynchronous SSH known-host inspection."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from pathlib import Path
+
+import gi
+
+gi.require_version("Gio", "2.0")
+from gi.repository import Gio, GLib
+
+
+def known_host_lookup_commands(
+    host: str,
+    port: int,
+    ssh_keygen: str,
+    known_hosts_files: Iterable[Path],
+) -> list[list[str]]:
+    lookup_host = f"[{host}]:{port}" if port != 22 else host
+    return [
+        [ssh_keygen, "-F", lookup_host, "-f", str(path)]
+        for path in known_hosts_files
+        if path.exists()
+    ]
+
+
+def inspect_known_host_async(
+    host: str,
+    port: int,
+    callback: Callable[[bool], None],
+    *,
+    known_hosts_files: Iterable[Path] | None = None,
+) -> None:
+    """Report whether *host* is known without blocking the GTK main loop."""
+    ssh_keygen = GLib.find_program_in_path("ssh-keygen")
+    if ssh_keygen is None:
+        GLib.idle_add(callback, False)
+        return
+
+    paths = known_hosts_files
+    if paths is None:
+        paths = (Path.home() / ".ssh" / "known_hosts", Path.home() / ".ssh" / "known_hosts2")
+    commands = iter(known_host_lookup_commands(host, port, ssh_keygen, paths))
+
+    def run_next() -> None:
+        try:
+            command = next(commands)
+        except StopIteration:
+            callback(False)
+            return
+        try:
+            launcher = Gio.SubprocessLauncher.new(
+                Gio.SubprocessFlags.STDOUT_SILENCE | Gio.SubprocessFlags.STDERR_SILENCE
+            )
+            process = launcher.spawnv(command)
+        except GLib.Error:
+            run_next()
+            return
+
+        def on_finished(current: Gio.Subprocess, result: Gio.AsyncResult) -> None:
+            try:
+                current.wait_finish(result)
+            except GLib.Error:
+                run_next()
+                return
+            if current.get_successful():
+                callback(True)
+                return
+            run_next()
+
+        process.wait_async(None, on_finished)
+
+    run_next()

--- a/src/termia/terminal_sessions.py
+++ b/src/termia/terminal_sessions.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import os
 import signal
-import subprocess
 import shlex
 import time
 from pathlib import Path
@@ -24,6 +23,7 @@ from gi.repository import Gdk, Gio, GLib, Gtk, Pango, Vte
 from .connection_utils import find_local_terminal_profile, find_server
 from .file_transfer import FileTransferController
 from .keybindings import is_unmodified_function_key, keybinding_matches
+from .known_hosts import inspect_known_host_async
 from .models import LocalTerminalProfile, Server, Workspace
 from .session_commands import build_ssh_command
 from .split_panes import SplitPaneController, directional_pane_neighbor
@@ -621,9 +621,35 @@ class TerminalSessionsMixin:
             self.mark_session_for_reconnect(session, server, message)
             return
 
+        if server.password:
+            inspect_known_host_async(
+                server.host,
+                server.port,
+                lambda known: self.finish_start_ssh_session(server, session, split_layout, ssh_path, known),
+            )
+            return
+        self.finish_start_ssh_session(server, session, split_layout, ssh_path, False)
+
+    def finish_start_ssh_session(
+        self,
+        server: Server,
+        session: TerminalSession,
+        split_layout: str,
+        ssh_path: str,
+        known_host: bool,
+    ) -> None:
+        root_pane = session.pane_for_terminal(session.terminal)
+        if (
+            self.session_registry.get(session.id) is not session
+            or session.disconnect_requested
+            or root_pane is None
+            or root_pane.disconnect_requested
+        ):
+            return
+        terminal = session.terminal
         envv = build_terminal_environment(self.store.data.terminal.ls_colors, server.password)
-        use_sshpass = bool(server.password)
-        if server.password and not self.has_known_host_key(server.host, server.port):
+        use_sshpass = bool(server.password and known_host)
+        if server.password and not known_host:
             use_sshpass = False
             message = self.t("ssh_fingerprint_manual")
             terminal.feed(f"{message}\r\n\r\n".encode())
@@ -781,25 +807,6 @@ class TerminalSessionsMixin:
             return os.WIFEXITED(status) and os.WEXITSTATUS(status) == 0
         except ValueError:
             return False
-
-    def has_known_host_key(self, host: str, port: int) -> bool:
-        ssh_keygen = GLib.find_program_in_path("ssh-keygen")
-        if ssh_keygen is None:
-            return False
-        lookup_host = f"[{host}]:{port}" if port != 22 else host
-        known_hosts_files = [Path.home() / ".ssh" / "known_hosts", Path.home() / ".ssh" / "known_hosts2"]
-        for known_hosts in known_hosts_files:
-            if not known_hosts.exists():
-                continue
-            result = subprocess.run(
-                [ssh_keygen, "-F", lookup_host, "-f", str(known_hosts)],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-                check=False,
-            )
-            if result.returncode == 0:
-                return True
-        return False
 
     def schedule_statistics_save(self) -> None:
         if self.store.data.app.statistics_enabled and self.stats_save_id is None:
@@ -1584,9 +1591,41 @@ class TerminalSessionsMixin:
             self.mark_pane_for_reconnect(session, pane, message)
             return
 
+        if server.password:
+            inspect_known_host_async(
+                server.host,
+                server.port,
+                lambda known: self.finish_start_ssh_split_terminal(
+                    session,
+                    terminal,
+                    server,
+                    announce,
+                    ssh_path,
+                    known,
+                ),
+            )
+            return
+        self.finish_start_ssh_split_terminal(session, terminal, server, announce, ssh_path, False)
+
+    def finish_start_ssh_split_terminal(
+        self,
+        session: TerminalSession,
+        terminal: Vte.Terminal,
+        server: Server,
+        announce: bool,
+        ssh_path: str,
+        known_host: bool,
+    ) -> None:
+        pane = session.pane_for_terminal(terminal)
+        if (
+            self.session_registry.get(session.id) is not session
+            or pane is None
+            or pane.disconnect_requested
+        ):
+            return
         envv = build_terminal_environment(self.store.data.terminal.ls_colors, server.password)
-        use_sshpass = bool(server.password)
-        if server.password and not self.has_known_host_key(server.host, server.port):
+        use_sshpass = bool(server.password and known_host)
+        if server.password and not known_host:
             use_sshpass = False
             message = self.t("ssh_fingerprint_manual")
             terminal.feed(f"{message}\r\n\r\n".encode())
@@ -1881,7 +1920,7 @@ class TerminalSessionsMixin:
             self.t,
             self.toast_label,
             self.add_dialog_action_button,
-            self.has_known_host_key,
+            inspect_known_host_async,
         ).open_file_selection(server)
 
     def local_directory_title(self, path: Path) -> str:

--- a/tests/test_file_transfer.py
+++ b/tests/test_file_transfer.py
@@ -1,8 +1,9 @@
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import Mock, patch
 
-from termia.file_transfer import DESTINATION, build_scp_commands
+from termia.file_transfer import DESTINATION, FileTransferController, build_scp_commands
 from termia.models import Server
 
 
@@ -50,3 +51,25 @@ class FileTransferTests(unittest.TestCase):
         self.assertEqual(ssh_command[:2], ["/usr/bin/sshpass", "-e"])
         self.assertEqual(scp_command[:2], ["/usr/bin/sshpass", "-e"])
         self.assertIn("file;touch compromised", scp_command)
+
+    def test_defers_upload_until_known_host_check_finishes(self) -> None:
+        inspect_known_host = Mock()
+        toast = Mock()
+        controller = FileTransferController(object(), lambda key: key, toast, Mock(), inspect_known_host)
+        controller.show_transfer_dialog = Mock()
+
+        with patch(
+            "termia.file_transfer.GLib.find_program_in_path",
+            side_effect=lambda program: f"/usr/bin/{program}",
+        ):
+            controller.start_upload(
+                Server(id="server-1", name="Web", host="example.test", user="admin"),
+                [Path("report.txt")],
+            )
+
+        inspect_known_host.assert_called_once()
+        controller.show_transfer_dialog.assert_not_called()
+        callback = inspect_known_host.call_args.args[2]
+        callback(False)
+        toast.set_label.assert_called_once_with("send_files_to_server_fingerprint")
+        controller.show_transfer_dialog.assert_not_called()

--- a/tests/test_known_hosts.py
+++ b/tests/test_known_hosts.py
@@ -1,0 +1,111 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from termia.known_hosts import inspect_known_host_async, known_host_lookup_commands
+
+
+class FakeProcess:
+    def __init__(self, successful: bool) -> None:
+        self.successful = successful
+
+    def wait_async(self, _cancellable, callback) -> None:
+        callback(self, object())
+
+    def wait_finish(self, _result) -> bool:
+        return True
+
+    def get_successful(self) -> bool:
+        return self.successful
+
+
+class FakeLauncher:
+    def __init__(self, results: list[bool], commands: list[list[str]]) -> None:
+        self.results = results
+        self.commands = commands
+
+    def spawnv(self, command: list[str]) -> FakeProcess:
+        self.commands.append(command)
+        return FakeProcess(self.results.pop(0))
+
+
+class KnownHostsTests(unittest.TestCase):
+    def test_builds_lookups_only_for_existing_files(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            existing = Path(directory) / "known_hosts"
+            existing.touch()
+            missing = Path(directory) / "known_hosts2"
+
+            commands = known_host_lookup_commands(
+                "example.test",
+                2200,
+                "/usr/bin/ssh-keygen",
+                [existing, missing],
+            )
+
+        self.assertEqual(
+            commands,
+            [["/usr/bin/ssh-keygen", "-F", "[example.test]:2200", "-f", str(existing)]],
+        )
+
+    def test_checks_files_sequentially_until_host_is_found(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            first = Path(directory) / "known_hosts"
+            second = Path(directory) / "known_hosts2"
+            first.touch()
+            second.touch()
+            commands: list[list[str]] = []
+            launcher = FakeLauncher([False, True], commands)
+            results: list[bool] = []
+
+            with (
+                patch("termia.known_hosts.GLib.find_program_in_path", return_value="/usr/bin/ssh-keygen"),
+                patch("termia.known_hosts.Gio.SubprocessLauncher.new", return_value=launcher),
+            ):
+                inspect_known_host_async(
+                    "example.test",
+                    22,
+                    results.append,
+                    known_hosts_files=[first, second],
+                )
+
+        self.assertEqual(results, [True])
+        self.assertEqual(len(commands), 2)
+        self.assertEqual(commands[0][2], "example.test")
+
+    def test_reports_unknown_after_all_files_fail(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            known_hosts = Path(directory) / "known_hosts"
+            known_hosts.touch()
+            launcher = FakeLauncher([False], [])
+            results: list[bool] = []
+
+            with (
+                patch("termia.known_hosts.GLib.find_program_in_path", return_value="/usr/bin/ssh-keygen"),
+                patch("termia.known_hosts.Gio.SubprocessLauncher.new", return_value=launcher),
+            ):
+                inspect_known_host_async(
+                    "example.test",
+                    22,
+                    results.append,
+                    known_hosts_files=[known_hosts],
+                )
+
+        self.assertEqual(results, [False])
+
+    def test_defers_unknown_result_when_ssh_keygen_is_missing(self) -> None:
+        callback = unittest.mock.Mock()
+
+        with (
+            patch("termia.known_hosts.GLib.find_program_in_path", return_value=None),
+            patch("termia.known_hosts.GLib.idle_add") as idle_add,
+        ):
+            inspect_known_host_async("example.test", 22, callback)
+
+        idle_add.assert_called_once_with(callback, False)
+        callback.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_terminal_panes.py
+++ b/tests/test_terminal_panes.py
@@ -128,7 +128,6 @@ class TerminalPaneStateTests(unittest.TestCase):
             def __init__(self) -> None:
                 self.toast_label = object()
                 self.add_dialog_action_button = object()
-                self.has_known_host_key = object()
 
             def window_for_session(self, current_session):
                 self.assert_session = current_session
@@ -148,7 +147,7 @@ class TerminalPaneStateTests(unittest.TestCase):
             host.t,
             host.toast_label,
             host.add_dialog_action_button,
-            host.has_known_host_key,
+            unittest.mock.ANY,
         )
         controller.return_value.open_file_selection.assert_called_once_with(server)
 


### PR DESCRIPTION
## Summary

- inspect SSH known-host files through asynchronous Gio subprocesses
- defer password-backed SSH, split, and SCP startup until inspection completes
- prevent delayed callbacks from starting processes for closed sessions or panes
- add focused tests and regression coverage

## Validation

- `PYTHONPATH=src python3 -m unittest discover -s tests` (173 tests)
- `python3 -m py_compile run_termia.py scripts/compile_translations.py src/termia/*.py tests/*.py`
- manually verified regular SSH, split, SCP, responsive UI, and closing a tab during a delayed lookup

Closes #230