### PR TITLE
Avoid false connection failures during shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ Changes merged after `0.5.0-beta.3` (released 2026-07-30).
 
 ### Fixed
 
+- Treat managed terminal exits during application shutdown as intentional,
+  suppress reconnect notifications, and avoid duplicate forced termination
+  requests (`#233`).
 - Inspect SSH known-host files asynchronously so connection and SCP startup
   cannot block the GTK interface while `ssh-keygen -F` runs (`#230`).
 - Bind session-specific dialogs, confirmations, terminal preferences, and SCP

--- a/src/termia/app.py
+++ b/src/termia/app.py
@@ -399,6 +399,7 @@ class TermiaWindow(
         self.save_session_snapshot_before_close()
         self.save_history_before_close()
         self.save_statistics_before_close()
+        self.prepare_terminal_sessions_for_shutdown()
         self.terminate_open_terminal_processes()
         GLib.timeout_add(500, self.finish_main_window_shutdown)
 

--- a/src/termia/terminal_sessions.py
+++ b/src/termia/terminal_sessions.py
@@ -328,6 +328,8 @@ class TerminalSessionsMixin:
         )
         self.store.record_history_end(session, result)
         pane.connected = False
+        if getattr(self, "shutdown_in_progress", False):
+            return
         pane.disconnect_button.set_sensitive(False)
         if not pane.disconnect_requested and self.child_status_successful(_status) and session.active_terminal_ids:
             self.remove_terminal_pane_if_split(terminal, session)
@@ -1710,13 +1712,16 @@ class TerminalSessionsMixin:
             )
             self.store.record_history_end(pane, result)
             pane.connected = False
+        self.save_statistics_now()
+        if getattr(self, "shutdown_in_progress", False):
+            return
+        if pane is not None:
             pane.disconnect_button.set_sensitive(False)
             pane.status_label.set_label(
                 self.t("session_disconnected_status").format(title=pane.title)
                 if pane.disconnect_requested
                 else self.t("session_closed_status").format(title=pane.title)
             )
-        self.save_statistics_now()
         if (
             pane is not None
             and not pane.disconnect_requested
@@ -2010,13 +2015,26 @@ class TerminalSessionsMixin:
             signal=signum.name,
             accepted=terminated,
         )
-        if terminated and not force:
+        if terminated and not force and not getattr(self, "shutdown_in_progress", False):
             GLib.timeout_add(500, self.force_terminate_terminal_process, process)
         return terminated
 
     def force_terminate_terminal_process(self, process: TerminalProcess) -> bool:
         self.terminate_terminal_process(process, force=True)
         return GLib.SOURCE_REMOVE
+
+    def prepare_terminal_sessions_for_shutdown(self) -> None:
+        for session in self.session_registry.sessions():
+            session.disconnect_requested = True
+            session.pending_reconnect = False
+            for pane in session.panes.values():
+                pane.disconnect_requested = True
+                pane.pending_reconnect = False
+            log_event(
+                "session.shutdown_prepared",
+                session_id=session.id,
+                panes=len(session.panes),
+            )
 
     def terminate_open_terminal_processes(self, *, force: bool = False) -> None:
         for session in self.session_registry.sessions():
@@ -2188,6 +2206,8 @@ class TerminalSessionsMixin:
         )
         self.store.record_history_end(session, result)
         pane.connected = False
+        if getattr(self, "shutdown_in_progress", False):
+            return
         pane.disconnect_button.set_sensitive(False)
         if not pane.disconnect_requested and self.child_status_successful(_status) and session.active_terminal_ids:
             self.remove_terminal_pane_if_split(terminal, session)

--- a/tests/test_terminal_processes.py
+++ b/tests/test_terminal_processes.py
@@ -1,7 +1,7 @@
 import signal
 import unittest
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from termia.terminal_processes import TerminalProcess, signal_terminal_process, spawn_terminal_process
 from termia.terminal_sessions import TerminalSessionsMixin
@@ -93,3 +93,139 @@ class TerminalProcessTests(unittest.TestCase):
                 (split_process, True),
             ],
         )
+
+    def test_shutdown_marks_every_session_and_pane_as_intentional(self) -> None:
+        root_pane = SimpleNamespace(disconnect_requested=False, pending_reconnect=True)
+        split_pane = SimpleNamespace(disconnect_requested=False, pending_reconnect=True)
+        session = SimpleNamespace(
+            id="session",
+            disconnect_requested=False,
+            pending_reconnect=True,
+            panes={"root": root_pane, "split": split_pane},
+        )
+        host = TerminalSessionsMixin()
+        host.session_registry = SessionRegistry([session])
+
+        host.prepare_terminal_sessions_for_shutdown()
+
+        self.assertTrue(session.disconnect_requested)
+        self.assertFalse(session.pending_reconnect)
+        self.assertTrue(root_pane.disconnect_requested)
+        self.assertFalse(root_pane.pending_reconnect)
+        self.assertTrue(split_pane.disconnect_requested)
+        self.assertFalse(split_pane.pending_reconnect)
+
+    @patch("termia.terminal_sessions.GLib.timeout_add")
+    @patch("termia.terminal_sessions.signal_terminal_process", return_value=True)
+    def test_shutdown_uses_only_the_global_forced_termination_pass(self, signal_process, timeout_add) -> None:
+        process = TerminalProcess(pid=42, process_group_id=99, session_id=500, start_time="42")
+        host = TerminalSessionsMixin()
+        host.shutdown_in_progress = True
+
+        self.assertTrue(host.terminate_terminal_process(process))
+
+        signal_process.assert_called_once_with(process, signal.SIGTERM)
+        timeout_add.assert_not_called()
+
+    def test_ssh_exit_during_shutdown_does_not_reconnect_or_notify(self) -> None:
+        terminal = object()
+        pane = SimpleNamespace(
+            id="pane",
+            connected=True,
+            disconnect_requested=False,
+            pending_reconnect=True,
+            disconnect_button=Mock(),
+        )
+        session = SimpleNamespace(
+            id="session",
+            terminal=terminal,
+            disconnect_requested=False,
+            pending_reconnect=True,
+            panes={id(terminal): pane},
+        )
+
+        class Host(TerminalSessionsMixin):
+            def __init__(self) -> None:
+                self.shutdown_in_progress = True
+                self.session_registry = SessionRegistry([session])
+                self.store = SimpleNamespace(record_history_end=Mock())
+                self.toast_label = Mock()
+                self.reconnect_requested = False
+
+            def mark_terminal_inactive(self, _terminal, _session) -> None:
+                pass
+
+            def pane_state(self, _session, _terminal):
+                return pane
+
+            def record_session_duration(self, _session) -> None:
+                pass
+
+            def save_statistics_now(self) -> None:
+                pass
+
+            def mark_session_for_reconnect(self, *_args) -> None:
+                self.reconnect_requested = True
+
+        host = Host()
+        host.prepare_terminal_sessions_for_shutdown()
+        host.on_terminal_exited(
+            terminal,
+            65280,
+            SimpleNamespace(name="Example"),
+            session,
+        )
+
+        host.store.record_history_end.assert_called_once_with(session, "disconnected")
+        self.assertFalse(host.reconnect_requested)
+        host.toast_label.set_label.assert_not_called()
+
+    def test_split_exit_during_shutdown_does_not_reconnect_or_touch_widgets(self) -> None:
+        terminal = object()
+        pane = SimpleNamespace(
+            id="split-pane",
+            terminal=terminal,
+            server_id="server",
+            connected=True,
+            disconnect_requested=False,
+            pending_reconnect=True,
+            disconnect_button=Mock(),
+            status_label=Mock(),
+        )
+        session = SimpleNamespace(
+            id="session",
+            disconnect_requested=False,
+            pending_reconnect=True,
+            panes={id(terminal): pane},
+            pane_for_terminal=lambda current: pane if current is terminal else None,
+            split_child_pids={id(terminal): 42},
+            split_processes={id(terminal): object()},
+        )
+
+        class Host(TerminalSessionsMixin):
+            def __init__(self) -> None:
+                self.shutdown_in_progress = True
+                self.session_registry = SessionRegistry([session])
+                self.store = SimpleNamespace(record_history_end=Mock())
+                self.reconnect_requested = False
+
+            def mark_terminal_inactive(self, _terminal, _session) -> None:
+                pass
+
+            def record_pane_duration(self, _pane) -> None:
+                pass
+
+            def save_statistics_now(self) -> None:
+                pass
+
+            def mark_pane_for_reconnect(self, *_args) -> None:
+                self.reconnect_requested = True
+
+        host = Host()
+        host.prepare_terminal_sessions_for_shutdown()
+        host.on_split_terminal_exited(terminal, 65280, session)
+
+        host.store.record_history_end.assert_called_once_with(pane, "disconnected")
+        self.assertFalse(host.reconnect_requested)
+        pane.disconnect_button.set_sensitive.assert_not_called()
+        pane.status_label.set_label.assert_not_called()


### PR DESCRIPTION
## Summary

- mark every managed session and pane as intentionally closing before process termination
- suppress reconnect, failure notifications, focus changes, and widget updates during application shutdown
- use one global bounded `SIGTERM`/`SIGKILL` shutdown path instead of scheduling duplicate forced termination requests
- preserve the existing individual disconnect cleanup behavior and PID-reuse safeguards

## Validation

- `PYTHONPATH=src python3 -m unittest discover -s tests` (177 tests)
- `python3 -m py_compile run_termia.py scripts/compile_translations.py src/termia/*.py tests/*.py`
- manually closed a six-session, multi-pane workspace
- verified shutdown exits are `result=disconnected`, no `session.reconnect_pending` follows shutdown, and each PID receives at most one `SIGKILL` request

Closes #233