### PR TITLE
Add severity icons to in-app notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changes merged after `0.5.0-beta.3` (released 2026-07-30).
 
 ### Added
 
+- Add severity icons to in-app information, success, warning, and error notifications.
 - Add configurable `Ctrl+Arrow` keybindings for directional focus navigation
   between local and SSH split panes, with a scrollable shortcut editor (`#218`).
 - Preserve custom tab titles and per-pane local working directories in saved

--- a/src/termia/app.py
+++ b/src/termia/app.py
@@ -27,7 +27,7 @@ from .i18n import translate_key
 from .keybindings import keybinding_matches
 from .main_menu import MainMenuMixin
 from .main_menu_actions import MainMenuActions
-from .notifications import GroupedNotificationLabel
+from .notifications import NOTIFICATION_ICONS, GroupedNotificationLabel, NotificationSeverity
 from .preferences import PreferencesMixin
 from .session_registry import SessionRegistry
 from .session_snapshot import SessionSnapshotStore
@@ -93,6 +93,11 @@ class TermiaWindow(
             self.session_snapshot_store.clear()
         self.startup_restore_prompt_pending = False
         self.toast_messages: list[str] = []
+        self.toast_severity = NotificationSeverity.INFORMATION
+        self.toast_icon = Gtk.Image.new_from_icon_name(
+            NOTIFICATION_ICONS[NotificationSeverity.INFORMATION]
+        )
+        self.toast_icon.set_pixel_size(18)
         self.toast_label = GroupedNotificationLabel()
         self.toast_label.set_notification_handler(self.show_toast)
         self.toast_label.add_css_class("dim-label")
@@ -100,8 +105,6 @@ class TermiaWindow(
         self.toast_label.set_max_width_chars(80)
         self.toast_label.set_margin_top(10)
         self.toast_label.set_margin_bottom(10)
-        self.toast_label.set_margin_start(14)
-        self.toast_label.set_margin_end(14)
         self.toast_hide_id: int | None = None
         self.history_presenter = ConnectionHistoryPresenter(
             lambda: self.store.history_store.entries,
@@ -249,10 +252,16 @@ class TermiaWindow(
             self.on_open_local_terminal(None)
         return GLib.SOURCE_REMOVE
 
-    def show_toast(self, message: str) -> None:
+    def show_toast(
+        self,
+        message: str,
+        severity: NotificationSeverity = NotificationSeverity.INFORMATION,
+    ) -> None:
         if not message:
             return
         self.toast_messages.append(message)
+        self.toast_severity = max(self.toast_severity, severity)
+        self.toast_icon.set_from_icon_name(NOTIFICATION_ICONS[self.toast_severity])
         self.toast_label.set_grouped_text("\n".join(self.toast_messages))
         if not hasattr(self, "toast_revealer"):
             return
@@ -269,6 +278,10 @@ class TermiaWindow(
         self.toast_hide_id = None
         self.toast_revealer.set_reveal_child(False)
         self.toast_messages.clear()
+        self.toast_severity = NotificationSeverity.INFORMATION
+        self.toast_icon.set_from_icon_name(
+            NOTIFICATION_ICONS[NotificationSeverity.INFORMATION]
+        )
         self.toast_label.set_grouped_text("")
         return GLib.SOURCE_REMOVE
 
@@ -733,7 +746,12 @@ class TermiaWindow(
         toast_frame = Gtk.Frame()
         toast_frame.add_css_class("background")
         toast_frame.add_css_class("card")
-        toast_frame.set_child(self.toast_label)
+        toast_content = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=10)
+        toast_content.set_margin_start(14)
+        toast_content.set_margin_end(14)
+        toast_content.prepend(self.toast_icon)
+        toast_content.append(self.toast_label)
+        toast_frame.set_child(toast_content)
         toast_revealer.set_child(toast_frame)
         window_overlay.add_overlay(toast_revealer)
 

--- a/src/termia/config_actions.py
+++ b/src/termia/config_actions.py
@@ -155,7 +155,7 @@ class ConfigActionsMixin:
             try:
                 imported = load_store_data_from_json(Path(file.get_path()), self.store.data)
             except (OSError, ValueError, TypeError) as exc:
-                self.toast_label.set_label(self.t("import_config_failed").format(error=exc))
+                self.toast_label.set_error(self.t("import_config_failed").format(error=exc))
                 return
             self.store.data = imported
             self.store.save_connections()
@@ -177,10 +177,10 @@ class ConfigActionsMixin:
         try:
             payload = yaml.safe_load(Path(file.get_path()).read_text(encoding="utf-8")) or {}
         except (OSError, yaml.YAMLError) as exc:
-            self.toast_label.set_label(self.t("import_asbru_failed").format(error=exc))
+            self.toast_label.set_error(self.t("import_asbru_failed").format(error=exc))
             return
         if not isinstance(payload, dict):
-            self.toast_label.set_label(self.t("import_asbru_invalid"))
+            self.toast_label.set_error(self.t("import_asbru_invalid"))
             return
         if "__PAC__EXPORTED__PARTIAL_CONF" in payload:
             payload = payload["__PAC__EXPORTED__PARTIAL_CONF"]

--- a/src/termia/connection_dialogs.py
+++ b/src/termia/connection_dialogs.py
@@ -215,7 +215,7 @@ class ConnectionDialogsMixin:
 
         if response == Gtk.ResponseType.OK:
             if not name or not host or not user:
-                self.toast_label.set_label(self.t("server_required_fields"))
+                self.toast_label.set_warning(self.t("server_required_fields"))
                 for widget in (widgets["name"], widgets["host"], widgets["user"]):
                     if not widget.get_text().strip():
                         widget.grab_focus()
@@ -358,7 +358,7 @@ class ConnectionDialogsMixin:
 
         if response == Gtk.ResponseType.OK:
             if not name or not shell:
-                self.toast_label.set_label(self.t("local_terminal_required_fields"))
+                self.toast_label.set_warning(self.t("local_terminal_required_fields"))
                 for widget in (widgets["name"], widgets["shell"]):
                     if not widget.get_text().strip():
                         widget.grab_focus()
@@ -368,7 +368,7 @@ class ConnectionDialogsMixin:
                 if arguments:
                     shlex.split(arguments)
             except ValueError as exc:
-                self.toast_label.set_label(self.t("local_terminal_invalid_arguments").format(error=exc))
+                self.toast_label.set_error(self.t("local_terminal_invalid_arguments").format(error=exc))
                 widgets["arguments"].grab_focus()
                 return
             try:

--- a/src/termia/file_transfer.py
+++ b/src/termia/file_transfer.py
@@ -90,7 +90,7 @@ class FileTransferController:
         ssh_path = GLib.find_program_in_path("ssh")
         scp_path = GLib.find_program_in_path("scp")
         if ssh_path is None or scp_path is None:
-            self.toast_label.set_label(self.t("send_files_to_server_missing"))
+            self.toast_label.set_error(self.t("send_files_to_server_missing"))
             return
         self.inspect_known_host(
             server.host,
@@ -114,7 +114,7 @@ class FileTransferController:
         if server.password:
             sshpass_path = GLib.find_program_in_path("sshpass")
             if sshpass_path is None:
-                self.toast_label.set_label(self.t("sshpass_missing"))
+                self.toast_label.set_error(self.t("sshpass_missing"))
                 return
         ssh_command, scp_command = build_scp_commands(
             server,
@@ -279,7 +279,10 @@ class FileTransferController:
         state["status"].set_label(message)
         state["progress"].set_fraction(0.0 if failed else 1.0)
         state["cancel"].set_label(self.t("close"))
-        self.toast_label.set_label(message)
+        if failed:
+            self.toast_label.set_error(message)
+        else:
+            self.toast_label.set_success(message)
 
     def cleanup_dialog(self, state: dict[str, Any]) -> None:
         pulse_id = state.get("pulse_id")

--- a/src/termia/keybinding_preferences.py
+++ b/src/termia/keybinding_preferences.py
@@ -129,7 +129,7 @@ class KeybindingPreferencesMixin:
             keybindings = {action: row.get_accelerator() for action, row in rows}
             conflict = self.duplicate_keybinding(keybindings)
             if conflict:
-                self.toast_label.set_label(self.t("keybindings_conflict").format(shortcut=conflict))
+                self.toast_label.set_warning(self.t("keybindings_conflict").format(shortcut=conflict))
                 return
             try:
                 self.store.update_keybindings(keybindings)

--- a/src/termia/notifications.py
+++ b/src/termia/notifications.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from enum import IntEnum
 
 import gi
 
@@ -10,20 +11,50 @@ gi.require_version("Gtk", "4.0")
 from gi.repository import Gtk
 
 
+class NotificationSeverity(IntEnum):
+    INFORMATION = 0
+    SUCCESS = 1
+    WARNING = 2
+    ERROR = 3
+
+
+NOTIFICATION_ICONS = {
+    NotificationSeverity.INFORMATION: "dialog-information-symbolic",
+    NotificationSeverity.SUCCESS: "emblem-default-symbolic",
+    NotificationSeverity.WARNING: "dialog-warning-symbolic",
+    NotificationSeverity.ERROR: "dialog-error-symbolic",
+}
+
+
 class GroupedNotificationLabel(Gtk.Label):
     def __init__(self) -> None:
         super().__init__()
-        self._notification_handler: Callable[[str], None] | None = None
+        self._notification_handler: Callable[[str, NotificationSeverity], None] | None = None
         self._setting_grouped_text = False
 
-    def set_notification_handler(self, handler: Callable[[str], None]) -> None:
+    def set_notification_handler(
+        self,
+        handler: Callable[[str, NotificationSeverity], None],
+    ) -> None:
         self._notification_handler = handler
 
     def set_label(self, text: str) -> None:
+        self.set_notification(text, NotificationSeverity.INFORMATION)
+
+    def set_success(self, text: str) -> None:
+        self.set_notification(text, NotificationSeverity.SUCCESS)
+
+    def set_warning(self, text: str) -> None:
+        self.set_notification(text, NotificationSeverity.WARNING)
+
+    def set_error(self, text: str) -> None:
+        self.set_notification(text, NotificationSeverity.ERROR)
+
+    def set_notification(self, text: str, severity: NotificationSeverity) -> None:
         if self._notification_handler is None or self._setting_grouped_text:
             super().set_label(text)
             return
-        self._notification_handler(text)
+        self._notification_handler(text, severity)
 
     def set_grouped_text(self, text: str) -> None:
         self._setting_grouped_text = True

--- a/src/termia/terminal_sessions.py
+++ b/src/termia/terminal_sessions.py
@@ -72,7 +72,7 @@ class TerminalSessionsMixin:
         try:
             command = self.build_local_terminal_command(profile)
         except ValueError as exc:
-            self.toast_label.set_label(self.t("local_terminal_invalid_arguments").format(error=exc))
+            self.toast_label.set_error(self.t("local_terminal_invalid_arguments").format(error=exc))
             return None
         working_directory = (
             working_directory_override
@@ -285,7 +285,7 @@ class TerminalSessionsMixin:
             self.show_pane_reconnect_controls(self.pane_state(session, terminal))
             self.store.record_history_end(session, "failed", detail=exc.message)
             self.update_session_tab_title(session, self.t("tab_error_title").format(title=session.title))
-            self.toast_label.set_label(message)
+            self.toast_label.set_error(message)
             return session
         session.child_process = child_process
         session.child_pid = child_process.pid
@@ -353,7 +353,7 @@ class TerminalSessionsMixin:
         open_tabs = len(self.session_registry.sessions())
         if open_tabs + requested_tabs <= MAX_OPEN_TABS:
             return True
-        self.toast_label.set_label(
+        self.toast_label.set_warning(
             self.t("global_tab_limit_exceeded").format(
                 limit=MAX_OPEN_TABS,
                 open=open_tabs,
@@ -396,7 +396,7 @@ class TerminalSessionsMixin:
         pane_count = workspace_total_pane_count(workspace.tabs)
         log_event("workspace.open_requested", workspace_id=workspace.id, panes=pane_count)
         if pane_count > MAX_WORKSPACE_PANES:
-            self.toast_label.set_label(
+            self.toast_label.set_warning(
                 self.t("workspace_pane_limit_exceeded").format(
                     count=pane_count,
                     limit=MAX_WORKSPACE_PANES,
@@ -432,7 +432,9 @@ class TerminalSessionsMixin:
                 self.t("workspace_opened").format(name=workspace.name, count=opened_tabs)
             )
         else:
-            self.toast_label.set_label(self.t("workspace_no_available_tabs").format(name=workspace.name))
+            self.toast_label.set_warning(
+                self.t("workspace_no_available_tabs").format(name=workspace.name)
+            )
         if opened_tabs and skipped_tabs:
             self.toast_label.set_label(
                 self.t("workspace_opened_with_skipped_tabs").format(
@@ -702,7 +704,7 @@ class TerminalSessionsMixin:
         session.pending_reconnect = True
         self.sync_root_pane_state(session)
         self.show_pane_reconnect_controls(self.pane_state(session, session.terminal))
-        self.toast_label.set_label(toast)
+        self.toast_label.set_error(toast)
         prompt = f"  {self.t('reconnect_prompt')}  "
         session.terminal.feed(f"\r\n\x1b[1;30;48;2;255;213;79m{prompt}\x1b[0m\r\n".encode())
         self.update_session_tab_title(session, self.t("tab_error_title").format(title=session.title))
@@ -714,7 +716,7 @@ class TerminalSessionsMixin:
         server = find_server(self.store.data.servers, session.server_id)
         if server is None:
             session.pending_reconnect = False
-            self.toast_label.set_label(self.t("server_reconnect_missing"))
+            self.toast_label.set_error(self.t("server_reconnect_missing"))
             return
         session.pending_reconnect = False
         self.close_tab(session.id, session.page, disconnect=False)
@@ -746,7 +748,7 @@ class TerminalSessionsMixin:
         session.active_terminal_ids.discard(id(pane.terminal))
         prompt = f"  {self.t('reconnect_prompt')}  "
         pane.terminal.feed(f"\r\n\x1b[1;30;48;2;255;213;79m{prompt}\x1b[0m\r\n".encode())
-        self.toast_label.set_label(toast)
+        self.toast_label.set_error(toast)
         log_event(
             "session.reconnect_pending",
             session_id=session.id,
@@ -793,7 +795,7 @@ class TerminalSessionsMixin:
         )
         if pane.server_id is not None and server is None:
             pane.pending_reconnect = False
-            self.toast_label.set_label(self.t("server_reconnect_missing"))
+            self.toast_label.set_error(self.t("server_reconnect_missing"))
             return
         self.reset_pane_connection_attempt(pane)
         session.active_terminal_ids.add(id(terminal))
@@ -1084,7 +1086,7 @@ class TerminalSessionsMixin:
         pane = self.pane_state(session, target)
         server = find_server(self.store.data.servers, pane.server_id) if pane.server_id is not None else None
         if not pane.connected or server is None or not server.password:
-            self.toast_label.set_label(self.t("send_password_unavailable"))
+            self.toast_label.set_warning(self.t("send_password_unavailable"))
             return
         payload = server.password.encode()
         if self.store.data.app.send_password_enter:
@@ -1099,7 +1101,7 @@ class TerminalSessionsMixin:
         direction: str,
     ) -> Vte.Terminal | None:
         if len(session.panes) >= MAX_TERMINAL_PANES:
-            self.toast_label.set_label(self.t("split_pane_limit").format(limit=MAX_TERMINAL_PANES))
+            self.toast_label.set_warning(self.t("split_pane_limit").format(limit=MAX_TERMINAL_PANES))
             return None
         new_terminal = SplitPaneController(
             self.create_split_terminal,
@@ -1205,7 +1207,7 @@ class TerminalSessionsMixin:
     ) -> None:
         popover.popdown()
         if len(session.panes) >= MAX_TERMINAL_PANES:
-            self.toast_label.set_label(self.t("split_pane_limit").format(limit=MAX_TERMINAL_PANES))
+            self.toast_label.set_warning(self.t("split_pane_limit").format(limit=MAX_TERMINAL_PANES))
             return
         if not self.store.data.servers and not self.store.data.local_terminals:
             self.toast_label.set_label(self.t("split_connection_none_available"))
@@ -1631,7 +1633,7 @@ class TerminalSessionsMixin:
             use_sshpass = False
             message = self.t("ssh_fingerprint_manual")
             terminal.feed(f"{message}\r\n\r\n".encode())
-            self.toast_label.set_label(message)
+            self.toast_label.set_warning(message)
         if use_sshpass:
             sshpass_path = GLib.find_program_in_path("sshpass")
             if sshpass_path is None:
@@ -2103,7 +2105,7 @@ class TerminalSessionsMixin:
         if process is not None and not self.terminate_terminal_process(process):
             message = self.t("sigterm_failed")
             terminal.feed(f"{message}\r\n".encode())
-            self.toast_label.set_label(message)
+            self.toast_label.set_error(message)
             pane.disconnect_requested = False
             return
         pane.disconnect_button.set_sensitive(False)
@@ -2131,7 +2133,7 @@ class TerminalSessionsMixin:
         if session.child_process is not None and not self.terminate_terminal_process(session.child_process):
             message = self.t("sigterm_failed")
             session.terminal.feed(f"{message}\r\n".encode())
-            self.toast_label.set_label(message)
+            self.toast_label.set_error(message)
             return
         self.terminate_split_processes(session)
         self.record_session_duration(session)

--- a/tests/test_app_toasts.py
+++ b/tests/test_app_toasts.py
@@ -3,7 +3,7 @@ from types import MethodType, SimpleNamespace
 from unittest.mock import Mock, patch
 
 from termia.app import TOAST_VISIBLE_SECONDS, TermiaWindow
-from termia.notifications import GroupedNotificationLabel
+from termia.notifications import NOTIFICATION_ICONS, GroupedNotificationLabel, NotificationSeverity
 
 
 class AppToastTests(unittest.TestCase):
@@ -12,6 +12,8 @@ class AppToastTests(unittest.TestCase):
             toast_hide_id=hide_id,
             toast_revealer=Mock(),
             toast_messages=[],
+            toast_severity=NotificationSeverity.INFORMATION,
+            toast_icon=Mock(),
             toast_label=Mock(spec=GroupedNotificationLabel),
         )
         host.hide_toast = MethodType(TermiaWindow.hide_toast, host)
@@ -32,6 +34,9 @@ class AppToastTests(unittest.TestCase):
         host.toast_revealer.set_reveal_child.assert_called_once_with(True)
         timeout_add.assert_called_once_with(TOAST_VISIBLE_SECONDS, host.hide_toast)
         self.assertEqual(host.toast_hide_id, 11)
+        host.toast_icon.set_from_icon_name.assert_called_once_with(
+            NOTIFICATION_ICONS[NotificationSeverity.INFORMATION]
+        )
 
     def test_messages_are_grouped_in_arrival_order_and_keep_duplicates(self) -> None:
         host = self.host()
@@ -50,6 +55,19 @@ class AppToastTests(unittest.TestCase):
         )
         self.assertEqual(host.toast_hide_id, 9)
 
+    def test_group_keeps_the_highest_severity_icon_until_hidden(self) -> None:
+        host = self.host()
+
+        with patch("termia.app.GLib.timeout_add_seconds", side_effect=[7, 8, 9]):
+            host.show_toast("Connected", NotificationSeverity.SUCCESS)
+            host.show_toast("Connection failed", NotificationSeverity.ERROR)
+            host.show_toast("Closing connection", NotificationSeverity.INFORMATION)
+
+        self.assertEqual(host.toast_severity, NotificationSeverity.ERROR)
+        host.toast_icon.set_from_icon_name.assert_called_with(
+            NOTIFICATION_ICONS[NotificationSeverity.ERROR]
+        )
+
     def test_hide_clears_message_for_future_identical_notifications(self) -> None:
         host = self.host(hide_id=11)
         host.toast_messages.extend(["Global tab limit reached", "Connected"])
@@ -59,6 +77,10 @@ class AppToastTests(unittest.TestCase):
         host.toast_revealer.set_reveal_child.assert_called_once_with(False)
         host.toast_label.set_grouped_text.assert_called_once_with("")
         self.assertEqual(host.toast_messages, [])
+        self.assertEqual(host.toast_severity, NotificationSeverity.INFORMATION)
+        host.toast_icon.set_from_icon_name.assert_called_once_with(
+            NOTIFICATION_ICONS[NotificationSeverity.INFORMATION]
+        )
         self.assertIsNone(host.toast_hide_id)
         self.assertFalse(result)
 

--- a/tests/test_tab_limits.py
+++ b/tests/test_tab_limits.py
@@ -22,7 +22,9 @@ class LimitHost(TerminalSessionsMixin):
     def __init__(self, open_tabs: int, *, detached: bool = False) -> None:
         self.session_registry = sessions(open_tabs, detached=detached)
         self.toast = None
-        self.toast_label = SimpleNamespace(set_label=lambda message: setattr(self, "toast", message))
+        self.toast_label = SimpleNamespace(
+            set_warning=lambda message: setattr(self, "toast", message)
+        )
 
     def t(self, key: str) -> str:
         return {

--- a/tests/test_terminal_panes.py
+++ b/tests/test_terminal_panes.py
@@ -32,6 +32,12 @@ class FakeControl:
     def set_label(self, label: str) -> None:
         self.label = label
 
+    def set_error(self, label: str) -> None:
+        self.label = label
+
+    def set_warning(self, label: str) -> None:
+        self.label = label
+
     def set_sensitive(self, sensitive: bool) -> None:
         self.sensitive = sensitive
 
@@ -539,7 +545,10 @@ class TerminalPaneStateTests(unittest.TestCase):
         self.assertEqual(root_terminal.output, b"")
 
     def test_split_limit_is_enforced_before_creating_a_widget(self) -> None:
-        toast = SimpleNamespace(value="", set_label=lambda value: setattr(toast, "value", value))
+        toast = SimpleNamespace(
+            value="",
+            set_warning=lambda value: setattr(toast, "value", value),
+        )
 
         class Host(TerminalSessionsMixin):
             def __init__(self) -> None:

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -97,7 +97,7 @@ class WorkspaceOpeningTests(unittest.TestCase):
         )
         host = SimpleNamespace(
             toast=None,
-            toast_label=SimpleNamespace(set_label=lambda message: setattr(host, "toast", message)),
+            toast_label=SimpleNamespace(set_warning=lambda message: setattr(host, "toast", message)),
             t=lambda key: {
                 "workspace_pane_limit_exceeded": "Limit {limit}; found {count}",
             }[key],


### PR DESCRIPTION
## Summary
- add standard GTK symbolic icons for information, success, warning, and error notifications
- preserve the highest severity icon while grouped messages remain visible
- classify existing validation, connection, transfer, import, and limit messages without changing notification timing or placement
- preserve the current grouped-notification behavior

## Tests
- `python3 -m py_compile run_termia.py scripts/compile_translations.py src/termia/*.py tests/*.py`
- `PYTHONPATH=src python3 -m unittest discover -s tests` (178 tests)
- `bash -n scripts/termia-setup.sh`
- manual validation of information, warning, error, success, and grouped severity icons

Closes #235
