### PR TITLE
Avoid duplicate SSH disconnected notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Changes merged after `0.5.0-beta.3` (released 2026-07-30).
 
 ### Fixed
 
+- Avoid showing the same SSH disconnected notification twice when closing an
+  active tab.
 - Treat managed terminal exits during application shutdown as intentional,
   suppress reconnect notifications, and avoid duplicate forced termination
   requests (`#233`).

--- a/src/termia/terminal_sessions.py
+++ b/src/termia/terminal_sessions.py
@@ -2217,7 +2217,6 @@ class TerminalSessionsMixin:
         session.connected = bool(session.active_terminal_ids)
         if pane.disconnect_requested:
             session.status_label.set_label(self.t("session_disconnected_status").format(title=session.title))
-            self.toast_label.set_label(self.t("session_disconnected_toast").format(title=session.title))
             return
         if self.child_status_successful(_status):
             if self.should_close_tab_after_terminal_exit(session):

--- a/tests/test_terminal_processes.py
+++ b/tests/test_terminal_processes.py
@@ -180,6 +180,59 @@ class TerminalProcessTests(unittest.TestCase):
         self.assertFalse(host.reconnect_requested)
         host.toast_label.set_label.assert_not_called()
 
+    def test_ssh_exit_after_requested_disconnect_does_not_notify_twice(self) -> None:
+        terminal = object()
+        pane = SimpleNamespace(
+            id="pane",
+            connected=True,
+            disconnect_requested=True,
+            disconnect_button=Mock(),
+        )
+        session = SimpleNamespace(
+            id="session",
+            title="Example",
+            terminal=terminal,
+            panes={id(terminal): pane},
+            active_terminal_ids=set(),
+            status_label=Mock(),
+            connected=True,
+        )
+
+        class Host(TerminalSessionsMixin):
+            def __init__(self) -> None:
+                self.shutdown_in_progress = False
+                self.store = SimpleNamespace(record_history_end=Mock())
+                self.toast_label = Mock()
+
+            def mark_terminal_inactive(self, _terminal, _session) -> None:
+                pass
+
+            def pane_state(self, _session, _terminal):
+                return pane
+
+            def record_session_duration(self, _session) -> None:
+                pass
+
+            def save_statistics_now(self) -> None:
+                pass
+
+            def t(self, key):
+                return {
+                    "session_disconnected_status": "Disconnected: {title}",
+                }[key]
+
+        host = Host()
+        host.on_terminal_exited(
+            terminal,
+            0,
+            SimpleNamespace(name="Example"),
+            session,
+        )
+
+        host.store.record_history_end.assert_called_once_with(session, "disconnected")
+        session.status_label.set_label.assert_called_once_with("Disconnected: Example")
+        host.toast_label.set_label.assert_not_called()
+
     def test_split_exit_during_shutdown_does_not_reconnect_or_touch_widgets(self) -> None:
         terminal = object()
         pane = SimpleNamespace(


### PR DESCRIPTION
## Summary
- avoid emitting `Session disconnected` again from the SSH child-exit callback after an explicit disconnect
- preserve status updates, history finalization, process cleanup, and unexpected-exit behavior
- add lifecycle coverage proving an explicit disconnect produces no second notification

## Tests
- `python3 -m py_compile run_termia.py scripts/compile_translations.py src/termia/*.py tests/*.py`
- `PYTHONPATH=src python3 -m unittest discover -s tests` (179 tests)
- `bash -n scripts/termia-setup.sh`
- manually closed SSH tabs from the close button and context menu and confirmed one disconnect notification

Closes #237
