### PR TITLE
Define the stabilization roadmap for Termia

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,9 @@ Changes merged after `0.5.0-beta.3` (released 2026-07-30).
 
 ### Changed
 
+- Define `0.6.0-beta.1` as a stabilization checkpoint, prioritize SCP maturity
+  before the first stable release, and allow stable pre-1.0 releases while
+  reserving `1.0.0` for the long-term compatibility milestone.
 - Make closing a detached window close its session, and provide an explicit
   action to reattach the live session to the main window (`#228`).
 - Make debug logging focus on privacy-safe Termia lifecycle events, retain

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,51 +1,135 @@
 # Roadmap
 
-This document tracks planned work and longer-term ideas for Termia.
-It is not a release log or a regression checklist.
+This document describes the planned direction of Termia. It is not a release
+log or a regression checklist; completed changes belong in `CHANGELOG.md`.
 
-## Beta Exit
+## Current Target: 0.6.0-beta.1
 
-Goals for moving Termia from a beta release line to a stable release line.
+The current feature set is frozen while Termia stabilizes the workspace,
+session, split-pane, detached-window, notification, and managed-process work
+added since `0.5.0-beta.3`. Large new features are postponed until after this
+stabilization release.
 
-- [ ] Keep the current layout, menu structure, and keyboard behavior stable
-      across beta releases.
-- [ ] Expand automated coverage for the behaviors in
-      `docs/REGRESSION_CHECKS.md` where practical, starting with pure logic and
-      high-risk flows.
-- [ ] Reduce duplicate configuration paths so terminal, prompt, keybinding, and
-      security settings have a single source of truth.
-- [ ] Tighten documentation so README, localized docs, and in-app labels all
-      describe the same supported behavior.
-- [ ] Review defaults and destructive actions so first-run behavior is
-      predictable and reversible.
-- [ ] Treat data migration, import/export, and read-only-instance behavior as
-      release-blocking if they regress.
-- [x] Define a versioning policy for stable releases, including what counts as
-      a breaking change.
+Before publishing `0.6.0-beta.1`:
 
-## Near Term
+- [ ] Exercise large mixed workspaces containing local and SSH panes.
+- [ ] Verify previous-session restoration, including titles, split layouts,
+      saved connection references, and local working directories.
+- [ ] Verify clean shutdown with tabs, nested splits, detached windows, failed
+      connections, and pending reconnect states.
+- [ ] Confirm that no managed terminal processes remain after Termia closes.
+- [ ] Test encrypted, locked, read-only, import/export, history, and migration
+      paths without losing user data.
+- [ ] Install and upgrade the Debian package on every documented Ubuntu
+      version and verify desktop launchers, icons, and application data.
+- [ ] Complete the relevant checks in `docs/REGRESSION_CHECKS.md` and keep the
+      full automated suite passing.
+- [ ] Confirm that debug logging captures actionable lifecycle failures without
+      flooding the system journal.
+- [ ] Keep README files, translated documentation, in-app version text,
+      changelog, Debian metadata, tag, release, and download links consistent.
 
-- [ ] Unify local terminal configuration so font, prompt, palette, startup directory, and related defaults are defined in one place and applied consistently to new terminals and duplicated sessions.
-- [ ] Simplify and standardize configuration menus, especially the `Configuration` menu hierarchy and labels, so terminal, prompt, keybindings, and security settings are easier to find.
-- [ ] Review terminal context menus to reduce duplication between local terminals, SSH sessions, split panes, and sidebar or server actions.
+Publish another `0.6.0-beta.N` when source changes are required after the beta
+has been distributed. Packaging-only rebuilds increment only the Debian
+revision as defined in `docs/VERSIONING.md`. The 0.6 line is a stabilization
+checkpoint, not a commitment to publish stable `0.6.0` immediately afterward.
 
-## Next
+## 0.7.0-beta: Mature File Transfers
 
-- [ ] Continue menu cleanup by consolidating shared actions and aligning icon and label choices across popovers and context menus.
-- [ ] Audit keyboard shortcuts and menu accelerators for consistency with the new configuration layout.
-- [ ] Improve the discoverability of favorite servers and other sidebar actions if they remain split across several entry points.
+SCP is part of Termia's remote-administration workflow and should be mature
+before the first stable release. Improve it without attempting to build a full
+graphical SFTP client.
 
-## Session Workspaces
+- [ ] Separate transfer command construction, execution state, and GTK
+      presentation so each layer can be tested independently.
+- [ ] Define explicit pending, preparing, transferring, completed, cancelled,
+      and failed states.
+- [ ] Report useful progress and errors without exposing passwords, private
+      keys, local personal paths, or remote command output unnecessarily.
+- [ ] Make cancellation terminate only the managed transfer process and keep
+      application shutdown clean.
+- [ ] Support reliable retry behavior after a failed or cancelled transfer.
+- [ ] Review destination selection and handling of multiple files and
+      directories.
+- [ ] Cover command construction, state transitions, cancellation, retry, and
+      failure paths without requiring a real SSH server in automated tests.
+- [ ] Keep the design reusable for a possible future SFTP backend without
+      including remote file browsing in this release scope.
 
-- [ ] Save the sessions that are open when Termia closes and, on the next
-      launch, ask whether to reconnect all of them.
-- [x] Allow each pane in a split layout to run an independent remote
-      connection instead of limiting every pane to the same connection.
-- [x] Save and reopen reusable composite workspaces containing multiple remote
-      connections arranged in split panes.
+This work is expected to justify `0.7.0-beta.1` because it materially expands
+transfer behavior and refactors a user-facing subsystem.
 
-## Longer Term
+## Foundations Before Stable
 
-- [ ] Consider richer local terminal profiles if the current single settings model is still too limited after the configuration refactor.
-- [ ] Revisit menu structure and action placement if future features make the current layout feel crowded.
-- [ ] Evaluate whether any protected behaviors from `docs/REGRESSION_CHECKS.md` should become automated tests before larger UI refactors.
+- [ ] Version the workspace and previous-session snapshot formats and define
+      explicit forward migration and safe fallback behavior.
+- [ ] Keep SSH command construction and connection-option validation separate
+      from GTK presentation and terminal lifecycle code.
+- [ ] Expand automated coverage for option combinations, format migrations,
+      mixed layouts, transfer state, and failure/reconnect paths.
+- [ ] Continue consolidating terminal, prompt, keybinding, and security
+      settings around clear sources of truth.
+
+## Later Beta Feature Lines
+
+### Quick Access
+
+- [ ] Add Quick Connect for saved SSH connections, local-terminal profiles,
+      and workspaces.
+- [ ] Evolve Quick Connect into a keyboard-oriented command palette for common
+      Termia actions without duplicating menu behavior.
+
+### OpenSSH Integration
+
+- [ ] Integrate with explicit hosts from `~/.ssh/config` without copying keys
+      or sensitive configuration into Termia storage.
+- [ ] Prefer OpenSSH itself for resolving aliases, `Include`, identity,
+      hostname, user, port, and precedence semantics.
+- [ ] Add explicit ProxyJump and bastion-host configuration where Termia needs
+      a saved per-connection override.
+- [ ] Improve SSH-agent and identity visibility without handling private-key
+      material directly.
+
+### Later Remote Administration
+
+- [ ] Add local, remote, and dynamic/SOCKS SSH port forwarding with a clear
+      view of active tunnels and managed cleanup.
+- [ ] Add reusable global and group-scoped command snippets with prompted
+      variables and no implicit remote execution.
+- [ ] Consider broadcast input only with explicit pane selection, a persistent
+      visual warning, easy cancellation, and safeguards against accidental
+      multi-host execution.
+- [ ] Improve connection-health states, background activity indicators,
+      reconnect policy, and configurable notifications.
+- [ ] Consider a CLI for opening saved connections and workspaces from scripts
+      and desktop launchers.
+
+## Release Candidate and First Stable Release
+
+Do not assign the first stable release number only because a planned beta line
+has finished. Review release readiness after SCP and the core persisted formats
+have matured.
+
+Advance from beta to a release candidate when:
+
+- no critical or important reproducible bugs remain open;
+- no known crash, data-loss, orphan-process, transfer-cleanup, or security
+  regression remains;
+- application behavior and persisted formats are frozen for the release;
+- automated and manual regression checks pass; and
+- only release-blocking fixes, packaging, and documentation changes remain in
+  scope.
+
+Publish another release candidate when a fix changes application source or
+behavior. Publish stable only after a release candidate has received
+representative daily use without an important regression and every release
+artifact has been verified. At that review, choose a stable pre-1.0 version or
+`1.0.0` according to the compatibility guarantees Termia is ready to make.
+
+## Deliberately Deferred
+
+Termia should remain focused on terminal-based remote administration. A full
+SFTP client, RDP/VNC, Kubernetes or Docker GUIs, embedded web browsing, broad
+monitoring, and file editing are not immediate roadmap goals. They should be
+considered only when they strengthen the core workflow without turning Termia
+into an unfocused all-in-one application.

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -14,23 +14,31 @@ Termia versions use `MAJOR.MINOR.PATCH` with an optional prerelease suffix:
 0.5.0-beta.2
 0.5.1-beta.1
 0.6.0-beta.1
+0.9.0-beta.1
+0.9.0-rc.1
+0.9.0
 1.0.0
 ```
 
-While Termia remains in beta:
+Before `1.0.0`:
 
-- Increment the trailing prerelease number for each published iteration of the
-  same planned application version. New source changes published after
-  `0.5.0-beta.1` therefore become `0.5.0-beta.2`.
+- While a release remains in prerelease, increment the trailing prerelease
+  number for each published iteration of the same planned application version.
+  New source changes published after `0.5.0-beta.1` therefore become
+  `0.5.0-beta.2`.
 - Increment `PATCH` when accumulated fixes and improvements justify a new
   application version without introducing an important new feature set. A new
   prerelease line starts at `.1`, for example `0.5.1-beta.1`.
 - Increment `MINOR` for important features, substantial user-facing changes,
   compatibility changes, or a materially expanded release scope. A new line
   starts at `.1`, for example `0.6.0-beta.1`.
-- Reserve `1.0.0` for the first stable release. After `1.0.0`, increment
-  `MAJOR` for incompatible changes to documented behavior, supported data, or
-  other public compatibility guarantees.
+- A pre-1.0 line can become stable when it satisfies the documented release
+  criteria. For example, a future `0.9.0-beta.1` could advance through
+  `0.9.0-rc.1` to stable `0.9.0` without renaming the release to `1.0.0`.
+- Reserve `1.0.0` for the first long-term compatibility milestone, when public
+  behavior and persisted formats carry explicit compatibility guarantees.
+  After `1.0.0`, increment `MAJOR` for incompatible changes to those
+  guarantees.
 
 Alpha, beta, and release-candidate versions are prereleases. GitHub releases
 for them must be marked as prereleases.
@@ -63,12 +71,21 @@ version. The mapping is:
 | `0.5.0-beta.3` | `0.5.0~beta.3-1` |
 | `0.5.1-beta.1` | `0.5.1~beta.1-1` |
 | `0.6.0-beta.1` | `0.6.0~beta.1-1` |
+| `0.9.0-beta.1` | `0.9.0~beta.1-1` |
+| `0.9.0-rc.1` | `0.9.0~rc.1-1` |
+| `0.9.0` | `0.9.0-1` |
 | `0.5.0` | `0.5.0-1` |
 
 This produces the required upgrade ordering:
 
 ```text
 0.5.0~beta.1-1 < 0.5.0~beta.2-1 < 0.5.0~beta.3-1 < 0.5.0-1
+```
+
+For a release line that includes a release candidate, Debian ordering is:
+
+```text
+0.9.0~beta.1-1 < 0.9.0~rc.1-1 < 0.9.0-1
 ```
 
 The Debian revision starts at `-1` for every Termia application version.


### PR DESCRIPTION
## Summary
- define `0.6.0-beta.1` as a stabilization checkpoint rather than an immediate stable-release commitment
- prioritize SCP architecture and transfer maturity for the `0.7.0-beta` line
- define release-readiness gates for advancing from beta to RC and stable
- allow stable pre-1.0 versions while reserving `1.0.0` for long-term compatibility guarantees
- sequence Quick Access, OpenSSH integration, and later remote-administration work without expanding the current release

## Validation
- reviewed Markdown structure and local documentation references
- verified Debian ordering with `dpkg --compare-versions`
- confirmed the diff contains no personal paths or sensitive data
- manually reviewed `ROADMAP.md`, `docs/VERSIONING.md`, and `CHANGELOG.md`

Closes #239
