### PR TITLE
Preserve nested split geometry when opening a pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Changes merged after `0.5.0-beta.3` (released 2026-07-30).
 
 ### Fixed
 
+- Preserve ancestor divider positions and split only the selected pane 50/50
+  when adding a terminal to an existing nested layout.
 - Avoid showing the same SSH disconnected notification twice when closing an
   active tab.
 - Treat managed terminal exits during application shutdown as intentional,

--- a/docs/REGRESSION_CHECKS.md
+++ b/docs/REGRESSION_CHECKS.md
@@ -161,6 +161,9 @@ Protected behavior does not mean the code cannot change. It means regressions sh
   ellipsize the connection name while keeping the timer and actions usable.
 - Showing or hiding a pane status bar must preserve the existing position of
   every affected split divider.
+- Adding a split inside an existing nested layout must preserve every ancestor
+  divider and divide only the selected pane approximately 50/50, allowing a
+  one-pixel difference for odd dimensions.
 
 ### Terminal Appearance
 
@@ -249,6 +252,11 @@ Before merging changes that touch UI, terminals, tabs, or configuration, verify:
   pane status bar from both the context menu and `Hide` button; the divider
   must remain at the chosen position and long status titles must ellipsize.
 - Create split panes in all four directions and confirm each new pane opens a working shell.
+- Create a three-pane nested layout, move its existing dividers away from their
+  defaults, then open a fourth local and SSH connection by splitting one
+  selected pane. Confirm only that pane is divided approximately 50/50, every
+  previous divider remains fixed, and the new terminal prompt is not repeatedly
+  redrawn while the connection starts.
 - From an SSH pane, use `Open connection in split…` to open a different SSH
   server and then a saved local terminal; verify each pane's status bar, PID,
   elapsed time, saved-password action, SCP target, statistics, and history.

--- a/src/termia/split_panes.py
+++ b/src/termia/split_panes.py
@@ -13,6 +13,7 @@ from gi.repository import GLib, Gtk, Vte
 from .ui_state import TerminalSession
 
 PaneRect = tuple[float, float, float, float]
+SplitPosition = tuple[Gtk.Paned, int]
 
 
 def directional_pane_neighbor(
@@ -75,6 +76,9 @@ class SplitPaneController:
         target = self.pane_container(session, terminal)
         if target is None:
             return None
+        target_width = target.get_width()
+        target_height = target.get_height()
+        ancestor_positions = self.capture_ancestor_positions(target)
 
         new_terminal = self.create_terminal(session)
         new_pane = self.pane_container(session, new_terminal)
@@ -109,12 +113,58 @@ class SplitPaneController:
             paned.set_start_child(target)
             paned.set_end_child(new_pane)
 
-        def center_split() -> bool:
-            size = paned.get_width() if orientation == Gtk.Orientation.HORIZONTAL else paned.get_height()
-            if size > 0:
-                paned.set_position(size // 2)
-            new_terminal.grab_focus()
-            return GLib.SOURCE_REMOVE
-
-        GLib.timeout_add(80, center_split)
+        target_size = (
+            target_width
+            if orientation == Gtk.Orientation.HORIZONTAL
+            else target_height
+        )
+        self.initialize_split_position(paned, orientation, target_size)
+        self.restore_ancestor_positions(ancestor_positions)
+        GLib.idle_add(self.restore_ancestor_positions, ancestor_positions)
+        new_terminal.grab_focus()
         return new_terminal
+
+    @staticmethod
+    def capture_ancestor_positions(widget: Gtk.Widget) -> tuple[SplitPosition, ...]:
+        positions: list[SplitPosition] = []
+        parent = widget.get_parent()
+        while parent is not None:
+            if isinstance(parent, Gtk.Paned):
+                positions.append((parent, parent.get_position()))
+            parent = parent.get_parent()
+        return tuple(positions)
+
+    @staticmethod
+    def restore_ancestor_positions(positions: tuple[SplitPosition, ...]) -> bool:
+        for paned, position in positions:
+            paned.set_position(position)
+        return GLib.SOURCE_REMOVE
+
+    @staticmethod
+    def initialize_split_position(
+        paned: Gtk.Paned,
+        orientation: Gtk.Orientation,
+        target_size: int,
+    ) -> None:
+        if target_size > 0:
+            paned.set_position(target_size // 2)
+            return
+
+        handler: dict[str, int | None] = {"id": None}
+
+        def center_when_allocated(current: Gtk.Paned, _parameter: object) -> None:
+            size = (
+                current.get_width()
+                if orientation == Gtk.Orientation.HORIZONTAL
+                else current.get_height()
+            )
+            if size <= 0:
+                return
+            current.set_position(size // 2)
+            handler_id = handler["id"]
+            if handler_id is not None:
+                current.disconnect(handler_id)
+                handler["id"] = None
+
+        handler["id"] = paned.connect("notify::max-position", center_when_allocated)
+        center_when_allocated(paned, object())

--- a/tests/test_split_panes.py
+++ b/tests/test_split_panes.py
@@ -1,0 +1,175 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from termia.split_panes import Gtk, SplitPaneController
+
+
+class FakeWidget:
+    def __init__(self, *, width=0, height=0, parent=None) -> None:
+        self.width = width
+        self.height = height
+        self.parent = parent
+        self.classes = []
+
+    def get_width(self):
+        return self.width
+
+    def get_height(self):
+        return self.height
+
+    def get_parent(self):
+        return self.parent
+
+    def add_css_class(self, name):
+        self.classes.append(name)
+
+
+class FakeTerminal:
+    def __init__(self) -> None:
+        self.focused = False
+
+    def grab_focus(self):
+        self.focused = True
+
+
+class FakePaned(FakeWidget):
+    next_handler_id = 1
+
+    def __init__(self, *, orientation, width=0, height=0, parent=None) -> None:
+        super().__init__(width=width, height=height, parent=parent)
+        self.orientation = orientation
+        self.position = 0
+        self.start_child = None
+        self.end_child = None
+        self.handlers = {}
+
+    def set_wide_handle(self, _enabled):
+        pass
+
+    def set_hexpand(self, _enabled):
+        pass
+
+    def set_vexpand(self, _enabled):
+        pass
+
+    def set_resize_start_child(self, _enabled):
+        pass
+
+    def set_resize_end_child(self, _enabled):
+        pass
+
+    def set_shrink_start_child(self, _enabled):
+        pass
+
+    def set_shrink_end_child(self, _enabled):
+        pass
+
+    def set_start_child(self, child):
+        self.start_child = child
+        if child is not None:
+            child.parent = self
+
+    def set_end_child(self, child):
+        self.end_child = child
+        if child is not None:
+            child.parent = self
+
+    def set_position(self, position):
+        self.position = position
+
+    def get_position(self):
+        return self.position
+
+    def connect(self, signal, callback):
+        handler_id = self.next_handler_id
+        type(self).next_handler_id += 1
+        self.handlers[handler_id] = (signal, callback)
+        return handler_id
+
+    def disconnect(self, handler_id):
+        self.handlers.pop(handler_id)
+
+    def emit_max_position_changed(self):
+        for _handler_id, (_signal, callback) in tuple(self.handlers.items()):
+            callback(self, object())
+
+
+class SplitPaneControllerTests(unittest.TestCase):
+    def controller(self, target, new_terminal, new_pane, ancestor, outer_ancestor):
+        def replace_terminal(_target, replacement):
+            ancestor.position = 17
+            outer_ancestor.position = 29
+            ancestor.set_start_child(replacement)
+            return True
+
+        return SplitPaneController(
+            lambda _session: new_terminal,
+            lambda _session, selected: new_pane if selected is new_terminal else target,
+            replace_terminal,
+        )
+
+    def test_nested_split_uses_target_size_and_preserves_ancestor_position(self) -> None:
+        outer_ancestor = FakePaned(orientation=object(), width=1200, height=800)
+        outer_ancestor.position = 520
+        ancestor = FakePaned(
+            orientation=object(),
+            width=900,
+            height=600,
+            parent=outer_ancestor,
+        )
+        outer_ancestor.set_end_child(ancestor)
+        ancestor.position = 360
+        target = FakeWidget(width=401, height=260, parent=ancestor)
+        ancestor.set_start_child(target)
+        new_terminal = FakeTerminal()
+        new_pane = FakeWidget()
+        idle_callbacks = []
+        controller = self.controller(
+            target,
+            new_terminal,
+            new_pane,
+            ancestor,
+            outer_ancestor,
+        )
+
+        with (
+            patch("termia.split_panes.Gtk.Paned", FakePaned),
+            patch(
+                "termia.split_panes.GLib.idle_add",
+                side_effect=lambda callback, *args: idle_callbacks.append((callback, args)),
+            ),
+            patch("termia.split_panes.GLib.timeout_add") as timeout_add,
+        ):
+            result = controller.split_terminal(SimpleNamespace(), object(), "right")
+
+        created_split = ancestor.start_child
+        self.assertIs(result, new_terminal)
+        self.assertEqual(created_split.position, 200)
+        self.assertEqual(ancestor.position, 360)
+        self.assertEqual(outer_ancestor.position, 520)
+        self.assertTrue(new_terminal.focused)
+        timeout_add.assert_not_called()
+
+        ancestor.position = 24
+        outer_ancestor.position = 31
+        callback, args = idle_callbacks.pop()
+        callback(*args)
+        self.assertEqual(ancestor.position, 360)
+        self.assertEqual(outer_ancestor.position, 520)
+
+    def test_unallocated_split_centers_once_when_gtk_assigns_a_size(self) -> None:
+        paned = FakePaned(orientation=Gtk.Orientation.HORIZONTAL)
+
+        SplitPaneController.initialize_split_position(paned, paned.orientation, 0)
+
+        self.assertEqual(paned.position, 0)
+        self.assertEqual(len(paned.handlers), 1)
+        paned.width = 301
+        paned.emit_max_position_changed()
+        self.assertEqual(paned.position, 150)
+        self.assertEqual(paned.handlers, {})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- initialize a new split from the selected pane's existing allocation instead of recentering it after a fixed delay
- preserve every ancestor divider while inserting a nested pane
- wait for a real GTK allocation only when the selected pane has no size yet
- add focused controller tests for nested ancestors, odd-sized 50/50 allocation, deferred sizing, and removal of the delayed timeout
- protect the exact nested local/SSH scenario in the regression checklist

## Tests
- `python3 -m py_compile run_termia.py scripts/compile_translations.py src/termia/*.py tests/*.py`
- `PYTHONPATH=src python3 -m unittest discover -s tests` (181 tests)
- `bash -n scripts/termia-setup.sh`
- manually validated fourth local and SSH panes in nested layouts, existing divider preservation, 50/50 selected-pane allocation, status-bar toggling, maximized/unmaximized windows, and clean SSH prompt rendering

Closes #241
