### PR TITLE
test: cover progressive split geometry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ Changes merged after `0.5.0-beta.3` (released 2026-07-30).
 
 ### Changed
 
+- Expand split regression coverage across progressive one-to-four-pane layouts,
+  every insertion direction, odd sizes, and deferred GTK allocation (`#243`).
 - Define `0.6.0-beta.1` as a stabilization checkpoint, prioritize SCP maturity
   before the first stable release, and allow stable pre-1.0 releases while
   reserving `1.0.0` for the long-term compatibility milestone.

--- a/docs/REGRESSION_CHECKS.md
+++ b/docs/REGRESSION_CHECKS.md
@@ -251,12 +251,15 @@ Before merging changes that touch UI, terminals, tabs, or configuration, verify:
 - Drag a horizontal split divider away from the centre, then show and hide its
   pane status bar from both the context menu and `Hide` button; the divider
   must remain at the chosen position and long status titles must ellipsize.
-- Create split panes in all four directions and confirm each new pane opens a working shell.
-- Create a three-pane nested layout, move its existing dividers away from their
-  defaults, then open a fourth local and SSH connection by splitting one
-  selected pane. Confirm only that pane is divided approximately 50/50, every
-  previous divider remains fixed, and the new terminal prompt is not repeatedly
-  redrawn while the connection starts.
+- Starting from one pane, create the second, third, and fourth panes. Before
+  every insertion, move all existing dividers away from their defaults. Repeat
+  the sequence as needed to cover left, right, up, and down. Confirm each new
+  split divides only the selected pane approximately 50/50, every previous
+  divider remains fixed, and every new pane opens a working shell.
+- Repeat the progressive one-to-four-pane check with local and SSH connections,
+  including a nested split with an odd-sized selected pane. Confirm the
+  one-pixel difference is the largest imbalance and the terminal prompt is not
+  repeatedly redrawn while the connection starts.
 - From an SSH pane, use `Open connection in split…` to open a different SSH
   server and then a saved local terminal; verify each pane's status bar, PID,
   elapsed time, saved-password action, SCP target, statistics, and history.

--- a/tests/test_split_panes.py
+++ b/tests/test_split_panes.py
@@ -95,6 +95,20 @@ class FakePaned(FakeWidget):
             callback(self, object())
 
 
+class FakeRoot(FakeWidget):
+    def __init__(self, child) -> None:
+        super().__init__()
+        self.child = child
+        child.parent = self
+
+    def replace(self, target, replacement):
+        if self.child is not target:
+            return False
+        self.child = replacement
+        replacement.parent = self
+        return True
+
+
 class SplitPaneControllerTests(unittest.TestCase):
     def controller(self, target, new_terminal, new_pane, ancestor, outer_ancestor):
         def replace_terminal(_target, replacement):
@@ -169,6 +183,165 @@ class SplitPaneControllerTests(unittest.TestCase):
         paned.emit_max_position_changed()
         self.assertEqual(paned.position, 150)
         self.assertEqual(paned.handlers, {})
+
+    def test_every_direction_splits_only_the_target_in_half(self) -> None:
+        cases = (
+            ("left", Gtk.Orientation.HORIZONTAL, 401, 260, 200, True),
+            ("right", Gtk.Orientation.HORIZONTAL, 401, 260, 200, False),
+            ("up", Gtk.Orientation.VERTICAL, 401, 261, 130, True),
+            ("down", Gtk.Orientation.VERTICAL, 401, 261, 130, False),
+        )
+
+        for direction, orientation, width, height, expected, new_first in cases:
+            with self.subTest(direction=direction):
+                target_terminal = FakeTerminal()
+                target = FakeWidget(width=width, height=height)
+                root = FakeRoot(target)
+                new_terminal = FakeTerminal()
+                new_pane = FakeWidget()
+
+                controller = SplitPaneController(
+                    lambda _session: new_terminal,
+                    lambda _session, selected: (
+                        new_pane if selected is new_terminal else target
+                    ),
+                    root.replace,
+                )
+
+                with (
+                    patch("termia.split_panes.Gtk.Paned", FakePaned),
+                    patch("termia.split_panes.GLib.idle_add"),
+                    patch("termia.split_panes.GLib.timeout_add") as timeout_add,
+                ):
+                    controller.split_terminal(
+                        SimpleNamespace(), target_terminal, direction
+                    )
+
+                created_split = root.child
+                self.assertEqual(created_split.orientation, orientation)
+                self.assertEqual(created_split.position, expected)
+                self.assertIs(
+                    created_split.start_child,
+                    new_pane if new_first else target,
+                )
+                self.assertIs(
+                    created_split.end_child,
+                    target if new_first else new_pane,
+                )
+                timeout_add.assert_not_called()
+
+    def test_progressive_second_third_and_fourth_panes_preserve_geometry(self) -> None:
+        session = SimpleNamespace()
+        first_terminal = FakeTerminal()
+        first_pane = FakeWidget(width=801, height=601)
+        root = FakeRoot(first_pane)
+        panes = {first_terminal: first_pane}
+        idle_callbacks = []
+
+        def create_terminal(_session):
+            terminal = FakeTerminal()
+            panes[terminal] = FakeWidget()
+            return terminal
+
+        def replace_terminal(target, replacement):
+            parent = target.parent
+            if isinstance(parent, FakeRoot):
+                replaced = parent.replace(target, replacement)
+            elif parent.start_child is target:
+                parent.set_start_child(replacement)
+                replaced = True
+            elif parent.end_child is target:
+                parent.set_end_child(replacement)
+                replaced = True
+            else:
+                replaced = False
+
+            current = replacement.parent
+            while isinstance(current, FakePaned):
+                current.position = -1
+                current = current.parent
+            return replaced
+
+        controller = SplitPaneController(
+            create_terminal,
+            lambda _session, terminal: panes[terminal],
+            replace_terminal,
+        )
+
+        def split_and_check(terminal, direction, expected_position):
+            target = panes[terminal]
+            ancestors = []
+            parent = target.parent
+            while isinstance(parent, FakePaned):
+                ancestors.append((parent, parent.position))
+                parent = parent.parent
+
+            result = controller.split_terminal(session, terminal, direction)
+            created_split = target.parent
+            self.assertEqual(created_split.position, expected_position)
+            for ancestor, position in ancestors:
+                self.assertEqual(ancestor.position, position)
+
+            for ancestor, _position in ancestors:
+                ancestor.position = -2
+            callback, args = idle_callbacks.pop()
+            callback(*args)
+            for ancestor, position in ancestors:
+                self.assertEqual(ancestor.position, position)
+            return result, created_split
+
+        with (
+            patch("termia.split_panes.Gtk.Paned", FakePaned),
+            patch(
+                "termia.split_panes.GLib.idle_add",
+                side_effect=lambda callback, *args: idle_callbacks.append(
+                    (callback, args)
+                ),
+            ),
+            patch("termia.split_panes.GLib.timeout_add") as timeout_add,
+        ):
+            second_terminal, outer = split_and_check(first_terminal, "right", 400)
+
+            outer.position = 347
+            first_pane.width = 400
+            first_pane.height = 601
+            third_terminal, lower_split = split_and_check(
+                first_terminal, "down", 300
+            )
+
+            outer.position = 347
+            lower_split.position = 219
+            panes[third_terminal].width = 401
+            panes[third_terminal].height = 300
+            _fourth_terminal, _inner_split = split_and_check(
+                third_terminal, "left", 200
+            )
+
+        self.assertIsNotNone(second_terminal)
+        self.assertEqual(len(panes), 4)
+        self.assertEqual(outer.position, 347)
+        self.assertEqual(lower_split.position, 219)
+        timeout_add.assert_not_called()
+
+    def test_unallocated_split_centers_for_both_orientations(self) -> None:
+        cases = (
+            (Gtk.Orientation.HORIZONTAL, 303, 99, 151),
+            (Gtk.Orientation.VERTICAL, 99, 305, 152),
+        )
+
+        for orientation, width, height, expected in cases:
+            with self.subTest(orientation=orientation):
+                paned = FakePaned(orientation=orientation)
+
+                SplitPaneController.initialize_split_position(
+                    paned, orientation, 0
+                )
+                paned.width = width
+                paned.height = height
+                paned.emit_max_position_changed()
+
+                self.assertEqual(paned.position, expected)
+                self.assertEqual(paned.handlers, {})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- cover left, right, up, and down split insertion semantics
- exercise progressive one-to-four-pane nested layouts while preserving every ancestor divider
- cover odd dimensions and deferred GTK allocation without fixed timers
- expand the protected manual regression matrix

## Validation
- `python3 -m py_compile src/termia/split_panes.py tests/test_split_panes.py`
- `PYTHONPATH=src python3 -m unittest tests.test_split_panes` (5 tests)
- `PYTHONPATH=src python3 -m unittest discover -s tests` (184 tests)
- `python3 -m py_compile run_termia.py scripts/compile_translations.py src/termia/*.py tests/*.py`
- `bash -n scripts/termia-setup.sh`
- `scripts/compile_translations.py --check`
- `git diff --check`

Closes #243