### PR TITLE
fix: restore nested workspace split visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Changes merged after `0.5.0-beta.3` (released 2026-07-30).
 
 ### Fixed
 
+- Restore hidden workspace tabs' split proportions when GTK first allocates
+  them so every pane is visible without requiring interaction (`#245`).
 - Preserve ancestor divider positions and split only the selected pane 50/50
   when adding a terminal to an existing nested layout.
 - Avoid showing the same SSH disconnected notification twice when closing an

--- a/docs/REGRESSION_CHECKS.md
+++ b/docs/REGRESSION_CHECKS.md
@@ -260,6 +260,10 @@ Before merging changes that touch UI, terminals, tabs, or configuration, verify:
   including a nested split with an odd-sized selected pane. Confirm the
   one-pixel difference is the largest imbalance and the terminal prompt is not
   repeatedly redrawn while the connection starts.
+- Save and reopen a workspace containing several tabs with nested local and SSH
+  splits. Visit every restored tab and confirm all left/right and top/bottom
+  panes are visible immediately, without opening a context menu, while saved
+  divider proportions remain intact.
 - From an SSH pane, use `Open connection in split…` to open a different SSH
   server and then a saved local terminal; verify each pane's status bar, PID,
   elapsed time, saved-password action, SCP target, statistics, and history.

--- a/src/termia/split_panes.py
+++ b/src/termia/split_panes.py
@@ -72,13 +72,19 @@ class SplitPaneController:
         session: TerminalSession,
         terminal: Vte.Terminal,
         direction: str,
+        *,
+        preserve_ancestor_positions: bool = True,
     ) -> Vte.Terminal | None:
         target = self.pane_container(session, terminal)
         if target is None:
             return None
         target_width = target.get_width()
         target_height = target.get_height()
-        ancestor_positions = self.capture_ancestor_positions(target)
+        ancestor_positions = (
+            self.capture_ancestor_positions(target)
+            if preserve_ancestor_positions
+            else ()
+        )
 
         new_terminal = self.create_terminal(session)
         new_pane = self.pane_container(session, new_terminal)
@@ -119,8 +125,9 @@ class SplitPaneController:
             else target_height
         )
         self.initialize_split_position(paned, orientation, target_size)
-        self.restore_ancestor_positions(ancestor_positions)
-        GLib.idle_add(self.restore_ancestor_positions, ancestor_positions)
+        if ancestor_positions:
+            self.restore_ancestor_positions(ancestor_positions)
+            GLib.idle_add(self.restore_ancestor_positions, ancestor_positions)
         new_terminal.grab_focus()
         return new_terminal
 

--- a/src/termia/terminal_sessions.py
+++ b/src/termia/terminal_sessions.py
@@ -550,7 +550,12 @@ class TerminalSessionsMixin:
             return
         orientation = node["orientation"]
         direction = "right" if orientation == "horizontal" else "down"
-        new_terminal = self.split_terminal_pane(session, terminal, direction)
+        new_terminal = self.split_terminal_pane(
+            session,
+            terminal,
+            direction,
+            preserve_ancestor_positions=False,
+        )
         if new_terminal is None:
             return
         end = node["end"]
@@ -590,17 +595,32 @@ class TerminalSessionsMixin:
         )
         return True
 
-    def restore_workspace_split_position(self, paned: Gtk.Paned, ratio: float, attempts: int = 4) -> None:
-        def apply_position() -> bool:
-            size = paned.get_width() if paned.get_orientation() == Gtk.Orientation.HORIZONTAL else paned.get_height()
-            if size <= 0 and attempts > 0:
-                GLib.timeout_add(80, self.restore_workspace_split_position, paned, ratio, attempts - 1)
+    def restore_workspace_split_position(self, paned: Gtk.Paned, ratio: float) -> None:
+        clamped_ratio = max(0.1, min(ratio, 0.9))
+        handlers: list[int] = []
+        applied = {"done": False}
+
+        def apply_position(current: Gtk.Paned, *_args: object) -> bool:
+            if applied["done"]:
                 return GLib.SOURCE_REMOVE
-            if size > 0:
-                paned.set_position(round(size * max(0.1, min(ratio, 0.9))))
+            if not current.get_mapped() or current.get_property("max-position") <= 0:
+                return GLib.SOURCE_REMOVE
+            size = current.get_width() if current.get_orientation() == Gtk.Orientation.HORIZONTAL else current.get_height()
+            if size <= 0:
+                return GLib.SOURCE_REMOVE
+            current.set_position(round(size * clamped_ratio))
+            applied["done"] = True
+            for handler_id in handlers:
+                current.disconnect(handler_id)
+            handlers.clear()
             return GLib.SOURCE_REMOVE
 
-        GLib.idle_add(apply_position)
+        def apply_after_mapping(current: Gtk.Paned, *_args: object) -> None:
+            GLib.idle_add(apply_position, current)
+
+        handlers.append(paned.connect("map", apply_after_mapping))
+        handlers.append(paned.connect("notify::max-position", apply_position))
+        GLib.idle_add(apply_position, paned)
 
     def start_ssh_session(self, server: Server, session: TerminalSession, *, split_layout: str = "none") -> None:
         terminal = session.terminal
@@ -1099,6 +1119,8 @@ class TerminalSessionsMixin:
         session: TerminalSession,
         terminal: Vte.Terminal,
         direction: str,
+        *,
+        preserve_ancestor_positions: bool = True,
     ) -> Vte.Terminal | None:
         if len(session.panes) >= MAX_TERMINAL_PANES:
             self.toast_label.set_warning(self.t("split_pane_limit").format(limit=MAX_TERMINAL_PANES))
@@ -1107,7 +1129,12 @@ class TerminalSessionsMixin:
             self.create_split_terminal,
             self.terminal_pane_container,
             self.replace_terminal_pane,
-        ).split_terminal(session, terminal, direction)
+        ).split_terminal(
+            session,
+            terminal,
+            direction,
+            preserve_ancestor_positions=preserve_ancestor_positions,
+        )
         if new_terminal is not None:
             pane = session.pane_for_terminal(new_terminal)
             log_event(

--- a/tests/test_split_panes.py
+++ b/tests/test_split_panes.py
@@ -284,8 +284,9 @@ class SplitPaneControllerTests(unittest.TestCase):
 
             for ancestor, _position in ancestors:
                 ancestor.position = -2
-            callback, args = idle_callbacks.pop()
-            callback(*args)
+            if ancestors:
+                callback, args = idle_callbacks.pop()
+                callback(*args)
             for ancestor, position in ancestors:
                 self.assertEqual(ancestor.position, position)
             return result, created_split
@@ -342,6 +343,41 @@ class SplitPaneControllerTests(unittest.TestCase):
 
                 self.assertEqual(paned.position, expected)
                 self.assertEqual(paned.handlers, {})
+
+    def test_workspace_reconstruction_skips_provisional_ancestor_restore(self) -> None:
+        outer = FakePaned(orientation=Gtk.Orientation.HORIZONTAL)
+        outer.position = 0
+        target = FakeWidget(width=400, height=300, parent=outer)
+        outer.set_end_child(target)
+        new_terminal = FakeTerminal()
+        new_pane = FakeWidget()
+
+        def replace_terminal(_target, replacement):
+            outer.position = 37
+            outer.set_end_child(replacement)
+            return True
+
+        controller = SplitPaneController(
+            lambda _session: new_terminal,
+            lambda _session, selected: (
+                new_pane if selected is new_terminal else target
+            ),
+            replace_terminal,
+        )
+
+        with (
+            patch("termia.split_panes.Gtk.Paned", FakePaned),
+            patch("termia.split_panes.GLib.idle_add") as idle_add,
+        ):
+            controller.split_terminal(
+                SimpleNamespace(),
+                FakeTerminal(),
+                "down",
+                preserve_ancestor_positions=False,
+            )
+
+        self.assertEqual(outer.position, 37)
+        idle_add.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -2,11 +2,12 @@ import tempfile
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import patch
 
 from termia.models import LocalTerminalProfile, Server, Workspace
 from termia.sidebar import SidebarMixin
 from termia.session_registry import SessionRegistry
-from termia.terminal_sessions import TerminalSessionsMixin
+from termia.terminal_sessions import Gtk, TerminalSessionsMixin
 from termia.workspace_layout import MAX_WORKSPACE_PANES
 
 
@@ -16,6 +17,53 @@ def pane(connection_type: str, connection_id: str) -> dict[str, str]:
 
 def workspace_tabs(count: int) -> list[dict[str, dict[str, str]]]:
     return [{"layout": pane("server", "web")} for _index in range(count)]
+
+
+class FakePaned:
+    next_handler_id = 1
+
+    def __init__(self, orientation, *, width=0, height=0, mapped=False) -> None:
+        self.orientation = orientation
+        self.width = width
+        self.height = height
+        self.mapped = mapped
+        self.max_position = max(width, height) - 1 if mapped else 0
+        self.position = 0
+        self.handlers = {}
+
+    def get_orientation(self):
+        return self.orientation
+
+    def get_width(self):
+        return self.width
+
+    def get_height(self):
+        return self.height
+
+    def get_mapped(self):
+        return self.mapped
+
+    def get_property(self, name):
+        if name != "max-position":
+            raise AssertionError(f"unexpected property: {name}")
+        return self.max_position
+
+    def set_position(self, position):
+        self.position = position
+
+    def connect(self, signal, callback):
+        handler_id = self.next_handler_id
+        type(self).next_handler_id += 1
+        self.handlers[handler_id] = (signal, callback)
+        return handler_id
+
+    def disconnect(self, handler_id):
+        self.handlers.pop(handler_id)
+
+    def emit(self, signal):
+        for _handler_id, (registered_signal, callback) in tuple(self.handlers.items()):
+            if registered_signal == signal:
+                callback(self, object())
 
 
 class WorkspaceOpeningTests(unittest.TestCase):
@@ -240,3 +288,190 @@ class WorkspaceOpeningTests(unittest.TestCase):
         self.assertEqual(pane_state.title, "Project shell")
         self.assertEqual(host.updated, (session, "Project shell"))
         self.assertTrue(host.synced)
+
+    def test_hidden_workspace_split_waits_for_real_allocation(self) -> None:
+        paned = FakePaned(Gtk.Orientation.HORIZONTAL, width=80, height=40)
+        idle_callbacks = []
+
+        with (
+            patch(
+                "termia.terminal_sessions.GLib.idle_add",
+                side_effect=lambda callback, *args: idle_callbacks.append(
+                    (callback, args)
+                ),
+            ),
+            patch("termia.terminal_sessions.GLib.timeout_add") as timeout_add,
+        ):
+            TerminalSessionsMixin.restore_workspace_split_position(
+                SimpleNamespace(), paned, 0.25
+            )
+
+            callback, args = idle_callbacks.pop()
+            callback(*args)
+            self.assertEqual(paned.position, 0)
+            self.assertEqual(len(paned.handlers), 2)
+
+            paned.width = 800
+            paned.max_position = 799
+            paned.emit("notify::max-position")
+            self.assertEqual(paned.position, 0)
+
+            paned.mapped = True
+            paned.emit("map")
+            callback, args = idle_callbacks.pop()
+            callback(*args)
+
+        self.assertEqual(paned.position, 200)
+        self.assertEqual(paned.handlers, {})
+        timeout_add.assert_not_called()
+
+    def test_visible_workspace_splits_restore_both_orientations_once(self) -> None:
+        cases = (
+            (Gtk.Orientation.HORIZONTAL, 801, 300, 0.25, 200),
+            (Gtk.Orientation.VERTICAL, 400, 601, 0.75, 451),
+        )
+
+        for orientation, width, height, ratio, expected in cases:
+            with self.subTest(orientation=orientation):
+                paned = FakePaned(
+                    orientation,
+                    width=width,
+                    height=height,
+                    mapped=True,
+                )
+                idle_callbacks = []
+
+                with patch(
+                    "termia.terminal_sessions.GLib.idle_add",
+                    side_effect=lambda callback, *args: idle_callbacks.append(
+                        (callback, args)
+                    ),
+                ):
+                    TerminalSessionsMixin.restore_workspace_split_position(
+                        SimpleNamespace(), paned, ratio
+                    )
+                    callback, args = idle_callbacks.pop()
+                    callback(*args)
+
+                self.assertEqual(paned.position, expected)
+                self.assertEqual(paned.handlers, {})
+
+    def test_multiple_hidden_workspace_splits_restore_independently(self) -> None:
+        outer = FakePaned(Gtk.Orientation.HORIZONTAL)
+        nested = FakePaned(Gtk.Orientation.VERTICAL)
+        idle_callbacks = []
+
+        with patch(
+            "termia.terminal_sessions.GLib.idle_add",
+            side_effect=lambda callback, *args: idle_callbacks.append(
+                (callback, args)
+            ),
+        ):
+            TerminalSessionsMixin.restore_workspace_split_position(
+                SimpleNamespace(), outer, 0.4
+            )
+            TerminalSessionsMixin.restore_workspace_split_position(
+                SimpleNamespace(), nested, 0.6
+            )
+            for callback, args in idle_callbacks:
+                callback(*args)
+
+            self.assertEqual(len(outer.handlers), 2)
+            self.assertEqual(len(nested.handlers), 2)
+
+            outer.width = 1000
+            outer.max_position = 999
+            outer.mapped = True
+            outer.emit("notify::max-position")
+            self.assertEqual(outer.position, 400)
+            self.assertEqual(outer.handlers, {})
+            self.assertEqual(nested.position, 0)
+
+            nested.height = 500
+            nested.max_position = 499
+            nested.mapped = True
+            nested.emit("notify::max-position")
+
+        self.assertEqual(nested.position, 300)
+        self.assertEqual(nested.handlers, {})
+
+    def test_workspace_tree_uses_noninteractive_split_reconstruction(self) -> None:
+        layout = {
+            "type": "split",
+            "orientation": "horizontal",
+            "position": 0.5,
+            "start": pane("local", ""),
+            "end": {
+                "type": "split",
+                "orientation": "vertical",
+                "position": 0.5,
+                "start": pane("local", ""),
+                "end": pane("local", ""),
+            },
+        }
+        split_calls = []
+        terminals = iter(("right", "bottom"))
+        outer = FakePaned(
+            Gtk.Orientation.HORIZONTAL,
+            width=800,
+            height=600,
+            mapped=True,
+        )
+        nested = FakePaned(
+            Gtk.Orientation.VERTICAL,
+            width=400,
+            height=600,
+            mapped=True,
+        )
+        parents = {"right": outer, "bottom": nested}
+        idle_callbacks = []
+
+        def split_terminal(_session, terminal, direction, **kwargs):
+            split_calls.append((terminal, direction, kwargs))
+            return next(terminals)
+
+        host = SimpleNamespace(
+            split_terminal_pane=split_terminal,
+            start_workspace_pane=lambda *_args: True,
+            discard_unstarted_split_pane=lambda *_args: None,
+            terminal_pane_container=lambda _session, terminal: SimpleNamespace(
+                get_parent=lambda: parents[terminal]
+            ),
+            restore_workspace_node=None,
+            restore_workspace_split_position=None,
+        )
+        host.restore_workspace_node = lambda session, terminal, node: (
+            TerminalSessionsMixin.restore_workspace_node(host, session, terminal, node)
+        )
+        host.restore_workspace_split_position = lambda paned, ratio: (
+            TerminalSessionsMixin.restore_workspace_split_position(
+                host, paned, ratio
+            )
+        )
+
+        with (
+            patch("termia.terminal_sessions.Gtk.Paned", FakePaned),
+            patch(
+                "termia.terminal_sessions.GLib.idle_add",
+                side_effect=lambda callback, *args: idle_callbacks.append(
+                    (callback, args)
+                ),
+            ),
+        ):
+            TerminalSessionsMixin.restore_workspace_node(
+                host, "session", "left", layout
+            )
+            for callback, args in idle_callbacks:
+                callback(*args)
+
+        self.assertEqual(
+            split_calls,
+            [
+                ("left", "right", {"preserve_ancestor_positions": False}),
+                ("right", "down", {"preserve_ancestor_positions": False}),
+            ],
+        )
+        self.assertEqual(outer.position, 400)
+        self.assertEqual(nested.position, 300)
+        self.assertEqual(outer.handlers, {})
+        self.assertEqual(nested.handlers, {})


### PR DESCRIPTION
## Summary
- separate interactive split preservation from workspace-tree reconstruction
- restore saved divider ratios only after hidden tabs are mapped and allocated
- cover the asymmetric three-pane layout with a large left pane and two stacked right panes
- protect manual split geometry and workspace restoration independently

## Validation
- `python3 -m py_compile src/termia/split_panes.py src/termia/terminal_sessions.py tests/test_split_panes.py tests/test_workspaces.py`
- `PYTHONPATH=src python3 -m unittest tests.test_split_panes tests.test_workspaces` (18 tests)
- `PYTHONPATH=src python3 -m unittest discover -s tests` (189 tests)
- `python3 -m py_compile run_termia.py scripts/compile_translations.py src/termia/*.py tests/*.py`
- `bash -n scripts/termia-setup.sh`
- `scripts/compile_translations.py --check`
- `git diff --check`
- manually validated with a copied encrypted profile and a multi-tab nested workspace

Closes #245