### PR TITLE
fix: close disconnected first split panes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Changes merged after `0.5.0-beta.3` (released 2026-07-30).
 
 ### Fixed
 
+- Remove explicitly disconnected original split panes and clear completed local
+  and SSH process identities before later window or application cleanup (`#247`).
 - Restore hidden workspace tabs' split proportions when GTK first allocates
   them so every pane is visible without requiring interaction (`#245`).
 - Preserve ancestor divider positions and split only the selected pane 50/50

--- a/docs/REGRESSION_CHECKS.md
+++ b/docs/REGRESSION_CHECKS.md
@@ -74,6 +74,10 @@ Protected behavior does not mean the code cannot change. It means regressions sh
   status bar, reconnect state, history entry, statistics, and context actions.
 - Disconnecting one pane must terminate only its managed process; closing the
   tab or Termia must terminate all pane processes.
+- Explicitly disconnecting the original/first pane of a multi-pane local or SSH
+  tab must remove and collapse that pane just like any later split, keep sibling
+  panes usable, and clear its process identity so detached-window, tab, and
+  application shutdown never signal the completed process again.
 - Directional split actions must duplicate the selected pane, while `Open
   connection in split…` must allow a different saved SSH or local-terminal
   profile and enforce the 16-pane limit. Its connection selector must filter
@@ -268,6 +272,10 @@ Before merging changes that touch UI, terminals, tabs, or configuration, verify:
   server and then a saved local terminal; verify each pane's status bar, PID,
   elapsed time, saved-password action, SCP target, statistics, and history.
 - Disconnect one mixed-connection pane and confirm its siblings remain usable.
+- In attached and detached tabs with at least three panes, explicitly disconnect
+  the original/first local and SSH pane. Confirm it disappears, the remaining
+  split fills the space, focus stays usable, and later window/application close
+  reports no failed or duplicate termination for the disconnected process.
 - Open several SSH and local-terminal tabs with mixed split panes, use the
   sidebar save-workspace button, name the workspace, and confirm it appears
   with a grid icon in the `Workspaces` section.

--- a/src/termia/terminal_processes.py
+++ b/src/termia/terminal_processes.py
@@ -111,6 +111,16 @@ def signal_terminal_process(process: TerminalProcess, signum: int) -> bool:
     return True
 
 
+def terminal_process_is_active(process: TerminalProcess) -> bool:
+    """Return whether the captured VTE process or any session group still exists."""
+    if process.session_id is not None and process_groups_in_session(process.session_id):
+        return True
+    current_start_time = process_start_time(process.pid)
+    if process.start_time is not None:
+        return current_start_time == process.start_time
+    return current_start_time is not None
+
+
 def spawn_terminal_process(
     terminal: Vte.Terminal,
     working_directory: str | None,

--- a/src/termia/terminal_sessions.py
+++ b/src/termia/terminal_sessions.py
@@ -37,7 +37,12 @@ from .terminal_config import (
     build_terminal_environment,
     split_layout_plan,
 )
-from .terminal_processes import TerminalProcess, signal_terminal_process, spawn_terminal_process
+from .terminal_processes import (
+    TerminalProcess,
+    signal_terminal_process,
+    spawn_terminal_process,
+    terminal_process_is_active,
+)
 from .terminal_view import TerminalViewFactory
 from .ui_state import TerminalPane, TerminalSession
 from .workspace_layout import (
@@ -313,6 +318,7 @@ class TerminalSessionsMixin:
     def on_process_terminal_exited(self, terminal: Vte.Terminal, _status: int, session: TerminalSession) -> None:
         self.mark_terminal_inactive(terminal, session)
         pane = self.pane_state(session, terminal)
+        self.clear_terminal_process_state(session, terminal, pane)
         self.record_session_duration(session)
         self.save_statistics_now()
         result = "disconnected" if pane.disconnect_requested else (
@@ -336,7 +342,7 @@ class TerminalSessionsMixin:
             return
         session.connected = bool(session.active_terminal_ids)
         if pane.disconnect_requested:
-            session.status_label.set_label(self.t("session_disconnected_status").format(title=session.title))
+            self.finish_disconnected_root_pane_exit(session, terminal)
             return
         if self.child_status_successful(_status):
             if self.should_close_tab_after_terminal_exit(session):
@@ -1723,10 +1729,9 @@ class TerminalSessionsMixin:
 
     def on_split_terminal_exited(self, terminal: Vte.Terminal, _status: int, session: TerminalSession) -> None:
         pane = session.pane_for_terminal(terminal)
-        session.split_child_pids.pop(id(terminal), None)
-        session.split_processes.pop(id(terminal), None)
         self.mark_terminal_inactive(terminal, session)
         if pane is not None:
+            self.clear_terminal_process_state(session, terminal, pane)
             self.record_pane_duration(pane)
             result = "disconnected" if pane.disconnect_requested else (
                 "closed" if self.child_status_successful(_status) else "failed"
@@ -1845,6 +1850,31 @@ class TerminalSessionsMixin:
 
     def mark_terminal_inactive(self, terminal: Vte.Terminal, session: TerminalSession) -> None:
         session.active_terminal_ids.discard(id(terminal))
+
+    @staticmethod
+    def clear_terminal_process_state(
+        session: TerminalSession,
+        terminal: Vte.Terminal,
+        pane: TerminalPane,
+    ) -> None:
+        pane.child_pid = None
+        pane.child_process = None
+        if terminal is session.terminal:
+            session.child_pid = None
+            session.child_process = None
+        session.split_child_pids.pop(id(terminal), None)
+        session.split_processes.pop(id(terminal), None)
+
+    def finish_disconnected_root_pane_exit(
+        self,
+        session: TerminalSession,
+        terminal: Vte.Terminal,
+    ) -> None:
+        session.status_label.set_label(
+            self.t("session_disconnected_status").format(title=session.title)
+        )
+        if session.active_terminal_ids:
+            self.remove_terminal_pane_if_split(terminal, session)
 
     def should_close_tab_after_terminal_exit(self, session: TerminalSession) -> bool:
         return self.store.data.app.close_tab_on_ssh_exit and not session.active_terminal_ids
@@ -2049,6 +2079,13 @@ class TerminalSessionsMixin:
         return terminated
 
     def force_terminate_terminal_process(self, process: TerminalProcess) -> bool:
+        if not terminal_process_is_active(process):
+            log_event(
+                "process.force_termination_skipped",
+                pid=process.pid,
+                reason="already_exited",
+            )
+            return GLib.SOURCE_REMOVE
         self.terminate_terminal_process(process, force=True)
         return GLib.SOURCE_REMOVE
 
@@ -2220,6 +2257,7 @@ class TerminalSessionsMixin:
     ) -> None:
         self.mark_terminal_inactive(terminal, session)
         pane = self.pane_state(session, terminal)
+        self.clear_terminal_process_state(session, terminal, pane)
         self.record_session_duration(session)
         self.save_statistics_now()
         result = "disconnected" if pane.disconnect_requested else (
@@ -2243,7 +2281,7 @@ class TerminalSessionsMixin:
             return
         session.connected = bool(session.active_terminal_ids)
         if pane.disconnect_requested:
-            session.status_label.set_label(self.t("session_disconnected_status").format(title=session.title))
+            self.finish_disconnected_root_pane_exit(session, terminal)
             return
         if self.child_status_successful(_status):
             if self.should_close_tab_after_terminal_exit(session):

--- a/tests/test_terminal_panes.py
+++ b/tests/test_terminal_panes.py
@@ -418,6 +418,128 @@ class TerminalPaneStateTests(unittest.TestCase):
         self.assertFalse(root.disconnect_requested)
         self.assertTrue(split.disconnect_requested)
 
+    def test_explicitly_disconnected_first_pane_is_removed_for_local_and_ssh(self) -> None:
+        for kind in ("local", "ssh"):
+            with self.subTest(kind=kind):
+                root_terminal = FakeTerminal()
+                sibling_terminal = FakeTerminal()
+                root_process = TerminalProcess(10, 100, 1000, "10")
+                sibling_process = TerminalProcess(20, 200, 2000, "20")
+                root = make_pane(
+                    root_terminal,
+                    "root",
+                    server_id="server-a" if kind == "ssh" else None,
+                    process=root_process,
+                )
+                sibling = make_pane(
+                    sibling_terminal,
+                    "sibling",
+                    server_id="server-b",
+                    process=sibling_process,
+                )
+                session = make_session(root_terminal, root)
+                session.detached_window = object()
+                session.child_pid = root_process.pid
+                session.child_process = root_process
+                session.panes[id(sibling_terminal)] = sibling
+                session.active_terminal_ids.add(id(sibling_terminal))
+                session.split_child_pids[id(sibling_terminal)] = sibling_process.pid
+                session.split_processes[id(sibling_terminal)] = sibling_process
+
+                class Host(TerminalSessionsMixin):
+                    def __init__(self) -> None:
+                        self.store = SimpleNamespace(
+                            data=SimpleNamespace(
+                                app=SimpleNamespace(close_tab_on_disconnect=True)
+                            ),
+                            record_history_end=Mock(),
+                        )
+                        self.removed = []
+                        self.terminated = []
+                        self.toast_label = FakeControl()
+
+                    def terminate_terminal_process(self, process, *, force=False):
+                        self.terminated.append((process, force))
+                        return True
+
+                    def record_session_duration(self, _session):
+                        pass
+
+                    def save_statistics_now(self):
+                        pass
+
+                    def remove_terminal_pane_if_split(self, terminal, current_session):
+                        self.removed.append((terminal, current_session))
+
+                    def t(self, key):
+                        return {
+                            "session_disconnected_status": "{title} disconnected",
+                            "session_disconnected_terminal": "Disconnected",
+                            "session_disconnected_toast": "{title} disconnected",
+                        }[key]
+
+                host = Host()
+                host.disconnect_pane(session, root_terminal)
+                if kind == "local":
+                    host.on_process_terminal_exited(root_terminal, 65280, session)
+                else:
+                    host.on_terminal_exited(
+                        root_terminal,
+                        65280,
+                        Server(
+                            id="server-a",
+                            name="Server A",
+                            host="server-a.test",
+                            user="admin",
+                        ),
+                        session,
+                    )
+
+                self.assertEqual(host.terminated, [(root_process, False)])
+                self.assertEqual(host.removed, [(root_terminal, session)])
+                self.assertNotIn(id(root_terminal), session.active_terminal_ids)
+                self.assertIn(id(sibling_terminal), session.active_terminal_ids)
+                self.assertIsNone(root.child_pid)
+                self.assertIsNone(root.child_process)
+                self.assertIsNone(session.child_pid)
+                self.assertIsNone(session.child_process)
+                self.assertEqual(
+                    session.split_processes[id(sibling_terminal)],
+                    sibling_process,
+                )
+
+    def test_completed_split_process_identity_is_cleared_without_touching_siblings(self) -> None:
+        root_terminal = FakeTerminal()
+        split_terminal = FakeTerminal()
+        other_terminal = FakeTerminal()
+        split_process = TerminalProcess(20, 200, 2000, "20")
+        other_process = TerminalProcess(30, 300, 3000, "30")
+        root = make_pane(root_terminal, "root")
+        split = make_pane(split_terminal, "split", process=split_process)
+        session = make_session(root_terminal, root)
+        session.panes[id(split_terminal)] = split
+        session.split_child_pids = {
+            id(split_terminal): split_process.pid,
+            id(other_terminal): other_process.pid,
+        }
+        session.split_processes = {
+            id(split_terminal): split_process,
+            id(other_terminal): other_process,
+        }
+
+        TerminalSessionsMixin.clear_terminal_process_state(
+            session,
+            split_terminal,
+            split,
+        )
+
+        self.assertIsNone(split.child_pid)
+        self.assertIsNone(split.child_process)
+        self.assertNotIn(id(split_terminal), session.split_child_pids)
+        self.assertNotIn(id(split_terminal), session.split_processes)
+        self.assertEqual(session.split_child_pids[id(other_terminal)], other_process.pid)
+        self.assertEqual(session.split_processes[id(other_terminal)], other_process)
+
     def test_failed_split_can_be_closed_instead_of_forcing_reconnect(self) -> None:
         root_terminal = FakeTerminal()
         split_terminal = FakeTerminal()

--- a/tests/test_terminal_processes.py
+++ b/tests/test_terminal_processes.py
@@ -3,7 +3,12 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
-from termia.terminal_processes import TerminalProcess, signal_terminal_process, spawn_terminal_process
+from termia.terminal_processes import (
+    TerminalProcess,
+    signal_terminal_process,
+    spawn_terminal_process,
+    terminal_process_is_active,
+)
 from termia.terminal_sessions import TerminalSessionsMixin
 from termia.session_registry import SessionRegistry
 
@@ -15,6 +20,28 @@ class FakeTerminal:
 
 
 class TerminalProcessTests(unittest.TestCase):
+    @patch("termia.terminal_processes.process_groups_in_session", return_value={99})
+    def test_terminal_process_is_active_while_a_session_group_remains(self, groups) -> None:
+        process = TerminalProcess(42, 99, 500, "42")
+
+        self.assertTrue(terminal_process_is_active(process))
+
+        groups.assert_called_once_with(500)
+
+    @patch("termia.terminal_processes.process_start_time", return_value=None)
+    @patch("termia.terminal_processes.process_groups_in_session", return_value=set())
+    def test_terminal_process_is_inactive_after_every_session_process_exits(
+        self,
+        groups,
+        start_time,
+    ) -> None:
+        process = TerminalProcess(42, 99, 500, "42")
+
+        self.assertFalse(terminal_process_is_active(process))
+
+        groups.assert_called_once_with(500)
+        start_time.assert_called_once_with(42)
+
     def test_spawn_helper_centralizes_vte_arguments(self) -> None:
         terminal = FakeTerminal()
         environment = ["TERM=xterm-256color"]
@@ -127,6 +154,38 @@ class TerminalProcessTests(unittest.TestCase):
         signal_process.assert_called_once_with(process, signal.SIGTERM)
         timeout_add.assert_not_called()
 
+    @patch("termia.terminal_sessions.log_event")
+    @patch("termia.terminal_sessions.terminal_process_is_active", return_value=False)
+    def test_forced_cleanup_skips_a_process_that_already_exited(
+        self,
+        is_active,
+        log_event,
+    ) -> None:
+        process = TerminalProcess(pid=42, process_group_id=99, session_id=500, start_time="42")
+        host = TerminalSessionsMixin()
+        host.terminate_terminal_process = Mock()
+
+        host.force_terminate_terminal_process(process)
+
+        is_active.assert_called_once_with(process)
+        host.terminate_terminal_process.assert_not_called()
+        log_event.assert_called_once_with(
+            "process.force_termination_skipped",
+            pid=42,
+            reason="already_exited",
+        )
+
+    @patch("termia.terminal_sessions.terminal_process_is_active", return_value=True)
+    def test_forced_cleanup_still_kills_remaining_session_processes(self, is_active) -> None:
+        process = TerminalProcess(pid=42, process_group_id=99, session_id=500, start_time="42")
+        host = TerminalSessionsMixin()
+        host.terminate_terminal_process = Mock()
+
+        host.force_terminate_terminal_process(process)
+
+        is_active.assert_called_once_with(process)
+        host.terminate_terminal_process.assert_called_once_with(process, force=True)
+
     def test_ssh_exit_during_shutdown_does_not_reconnect_or_notify(self) -> None:
         terminal = object()
         pane = SimpleNamespace(
@@ -135,13 +194,19 @@ class TerminalProcessTests(unittest.TestCase):
             disconnect_requested=False,
             pending_reconnect=True,
             disconnect_button=Mock(),
+            child_pid=42,
+            child_process=object(),
         )
         session = SimpleNamespace(
             id="session",
             terminal=terminal,
+            child_pid=42,
+            child_process=pane.child_process,
             disconnect_requested=False,
             pending_reconnect=True,
             panes={id(terminal): pane},
+            split_child_pids={},
+            split_processes={},
         )
 
         class Host(TerminalSessionsMixin):
@@ -187,13 +252,19 @@ class TerminalProcessTests(unittest.TestCase):
             connected=True,
             disconnect_requested=True,
             disconnect_button=Mock(),
+            child_pid=42,
+            child_process=object(),
         )
         session = SimpleNamespace(
             id="session",
             title="Example",
             terminal=terminal,
+            child_pid=42,
+            child_process=pane.child_process,
             panes={id(terminal): pane},
             active_terminal_ids=set(),
+            split_child_pids={},
+            split_processes={},
             status_label=Mock(),
             connected=True,
         )
@@ -244,9 +315,12 @@ class TerminalProcessTests(unittest.TestCase):
             pending_reconnect=True,
             disconnect_button=Mock(),
             status_label=Mock(),
+            child_pid=42,
+            child_process=object(),
         )
         session = SimpleNamespace(
             id="session",
+            terminal=object(),
             disconnect_requested=False,
             pending_reconnect=True,
             panes={id(terminal): pane},


### PR DESCRIPTION
## Summary

- remove the original/first pane after an intentional SSH or local disconnection when sibling panes remain
- clear completed root and split process identities so later detached-window or application shutdown is idempotent
- skip unnecessary forced cleanup after a managed process has already exited
- add automated and manual regression coverage for first-pane lifecycle handling

## Validation

- `python3 -m py_compile src/termia/terminal_processes.py src/termia/terminal_sessions.py tests/test_terminal_panes.py tests/test_terminal_processes.py`
- `PYTHONPATH=src python3 -m unittest tests.test_terminal_panes tests.test_terminal_processes` (36 tests)
- `PYTHONPATH=src python3 -m unittest discover -s tests` (195 tests)
- complete checks from `docs/REGRESSION_CHECKS.md`
- manual SSH and local validation in attached and detached three-pane tabs

Closes #247
