### PR TITLE
fix: preserve siblings when closing failed root pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Changes merged after `0.5.0-beta.3` (released 2026-07-30).
 
 ### Fixed
 
+- Keep connected and failed sibling splits open when closing an original pane
+  that is waiting for reconnection (`#249`).
 - Remove explicitly disconnected original split panes and clear completed local
   and SSH process identities before later window or application cleanup (`#247`).
 - Restore hidden workspace tabs' split proportions when GTK first allocates

--- a/docs/REGRESSION_CHECKS.md
+++ b/docs/REGRESSION_CHECKS.md
@@ -78,6 +78,9 @@ Protected behavior does not mean the code cannot change. It means regressions sh
   tab must remove and collapse that pane just like any later split, keep sibling
   panes usable, and clear its process identity so detached-window, tab, and
   application shutdown never signal the completed process again.
+- Closing an original/first pane that is waiting to reconnect must remove only
+  that pane while any connected or failed sibling remains; the whole tab closes
+  only when its final pane is closed.
 - Directional split actions must duplicate the selected pane, while `Open
   connection in split…` must allow a different saved SSH or local-terminal
   profile and enforce the 16-pane limit. Its connection selector must filter
@@ -298,6 +301,9 @@ Before merging changes that touch UI, terminals, tabs, or configuration, verify:
 - Trigger a failed SSH connection in a split and confirm its status bar appears
   automatically with a `Close` action; use it and confirm the failed pane
   closes without reconnecting while its sibling remains usable.
+- Start with a failed original SSH pane, add both failed and successfully
+  connected SSH splits, and close the original pane. Confirm only that pane is
+  removed, every sibling keeps its own state, and the tab remains open.
 - Trigger a failed connection in a tab with only one pane and confirm its
   automatically displayed `Close` action closes the tab.
 - Confirm a seventeenth pane is rejected without changing the current layout.

--- a/src/termia/terminal_sessions.py
+++ b/src/termia/terminal_sessions.py
@@ -1877,7 +1877,12 @@ class TerminalSessionsMixin:
             self.remove_terminal_pane_if_split(terminal, session)
 
     def should_close_tab_after_terminal_exit(self, session: TerminalSession) -> bool:
-        return self.store.data.app.close_tab_on_ssh_exit and not session.active_terminal_ids
+        has_pending_reconnect = any(pane.pending_reconnect for pane in session.panes.values())
+        return (
+            self.store.data.app.close_tab_on_ssh_exit
+            and not session.active_terminal_ids
+            and not has_pending_reconnect
+        )
 
     def replace_split_container(self, paned: Gtk.Paned, replacement: Gtk.Widget) -> bool:
         parent = paned.get_parent()
@@ -2130,7 +2135,9 @@ class TerminalSessionsMixin:
     ) -> None:
         pane = self.pane_state(session, terminal)
         pane.pending_reconnect = False
-        if terminal is not session.terminal:
+        if len(session.panes) > 1:
+            if terminal is session.terminal:
+                session.pending_reconnect = False
             self.discard_unstarted_split_pane(session, terminal)
             return
         self.close_tab(session.id, session.page, disconnect=False)

--- a/tests/test_terminal_panes.py
+++ b/tests/test_terminal_panes.py
@@ -608,6 +608,69 @@ class TerminalPaneStateTests(unittest.TestCase):
 
         self.assertEqual(host.closed, (session.id, session.page, False))
 
+    def test_failed_root_pane_closes_independently_while_a_sibling_remains(self) -> None:
+        for sibling_pending_reconnect in (False, True):
+            with self.subTest(sibling_pending_reconnect=sibling_pending_reconnect):
+                root_terminal = FakeTerminal()
+                sibling_terminal = FakeTerminal()
+                root = make_pane(root_terminal, "root", server_id="server-a")
+                sibling = make_pane(sibling_terminal, "sibling", server_id="server-b")
+                root.connected = False
+                root.pending_reconnect = True
+                sibling.connected = not sibling_pending_reconnect
+                sibling.pending_reconnect = sibling_pending_reconnect
+                session = make_session(root_terminal, root)
+                session.connected = sibling.connected
+                session.pending_reconnect = True
+                session.active_terminal_ids.discard(id(root_terminal))
+                if sibling.connected:
+                    session.active_terminal_ids.add(id(sibling_terminal))
+                session.panes[id(sibling_terminal)] = sibling
+
+                class Host(TerminalSessionsMixin):
+                    def __init__(self) -> None:
+                        self.discarded = None
+                        self.closed = None
+
+                    def discard_unstarted_split_pane(self, current_session, terminal):
+                        self.discarded = (current_session, terminal)
+
+                    def close_tab(self, session_id, page, *, disconnect):
+                        self.closed = (session_id, page, disconnect)
+
+                host = Host()
+                host.on_request_disconnect_pane(None, session, root_terminal)
+
+                self.assertEqual(host.discarded, (session, root_terminal))
+                self.assertIsNone(host.closed)
+                self.assertFalse(root.pending_reconnect)
+                self.assertFalse(session.pending_reconnect)
+                self.assertEqual(sibling.pending_reconnect, sibling_pending_reconnect)
+                self.assertIn(id(sibling_terminal), session.panes)
+
+    def test_pending_reconnect_sibling_prevents_automatic_tab_close(self) -> None:
+        root_terminal = FakeTerminal()
+        sibling_terminal = FakeTerminal()
+        root = make_pane(root_terminal, "root", server_id="server-a")
+        sibling = make_pane(sibling_terminal, "sibling", server_id="server-b")
+        root.connected = False
+        sibling.connected = False
+        sibling.pending_reconnect = True
+        session = make_session(root_terminal, root)
+        session.active_terminal_ids.clear()
+        session.panes[id(sibling_terminal)] = sibling
+
+        host = TerminalSessionsMixin()
+        host.store = SimpleNamespace(
+            data=SimpleNamespace(app=SimpleNamespace(close_tab_on_ssh_exit=True))
+        )
+
+        self.assertFalse(host.should_close_tab_after_terminal_exit(session))
+
+        sibling.pending_reconnect = False
+
+        self.assertTrue(host.should_close_tab_after_terminal_exit(session))
+
     def test_same_connection_split_uses_the_selected_pane_identity(self) -> None:
         root_terminal = FakeTerminal()
         source_terminal = FakeTerminal()


### PR DESCRIPTION
## Summary

- close a failed original/root pane independently while sibling splits remain
- preserve connected and pending-reconnect siblings instead of closing the whole tab
- close the tab only when its final pane is removed
- add automated and manual regression coverage for mixed failed/active layouts

## Validation

- `python3 -m py_compile src/termia/terminal_sessions.py tests/test_terminal_panes.py`
- `PYTHONPATH=src python3 -m unittest tests.test_terminal_panes tests.test_terminal_processes` (38 tests)
- `PYTHONPATH=src python3 -m unittest discover -s tests` (197 tests)
- complete repository syntax, shell, translation, and diff checks
- manual validation with failed root panes, failed siblings, and active SSH siblings
- debug-log inspection confirmed no sibling termination or premature tab closure

Closes #249
