### PR TITLE
fix: open SCP selector from server menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Changes merged after `0.5.0-beta.3` (released 2026-07-30).
 
 ### Fixed
 
+- Open the SCP file selector correctly from saved-server context menus while
+  preserving session-window ownership for terminal context actions (`#251`).
 - Keep connected and failed sibling splits open when closing an original pane
   that is waiting for reconnection (`#249`).
 - Remove explicitly disconnected original split panes and clear completed local

--- a/docs/REGRESSION_CHECKS.md
+++ b/docs/REGRESSION_CHECKS.md
@@ -60,6 +60,9 @@ Protected behavior does not mean the code cannot change. It means regressions sh
 - SSH fingerprint prompts must remain visible and interactive in the terminal.
 - Starting a password-backed SSH connection or SCP transfer must leave the
   interface responsive while the SSH known-host lookup completes.
+- `Send files to server` must open its selector from both a saved server's
+  sidebar context menu and a terminal context menu; the latter must use its
+  owning main or detached window, and cancelling either selector must be safe.
 - Failed SSH connections must leave the tab usable and show the reconnect prompt.
 - The reconnect prompt must be readable on both light and dark terminal backgrounds.
 - Pressing Enter on a failed SSH tab must reconnect to the same server.

--- a/src/termia/sidebar.py
+++ b/src/termia/sidebar.py
@@ -138,10 +138,9 @@ class SidebarMixin:
         self.render_detail()
 
     def on_server_context_send_files(self, _button: Gtk.Button, popover: Gtk.Popover, server_id: str) -> None:
-        popover.popdown()
         server = find_server(self.store.data.servers, server_id)
         if server is not None:
-            self.on_send_files_to_server(popover, server)
+            self.on_send_files_to_server(popover, None, server)
 
     def on_group_context_edit(self, _button: Gtk.Button, popover: Gtk.Popover, group_id: str) -> None:
         popover.popdown()

--- a/src/termia/terminal_sessions.py
+++ b/src/termia/terminal_sessions.py
@@ -1980,12 +1980,12 @@ class TerminalSessionsMixin:
     def on_send_files_to_server(
         self,
         popover: Gtk.Popover,
-        session: TerminalSession,
+        session: TerminalSession | None,
         server: Server,
     ) -> None:
         popover.popdown()
         FileTransferController(
-            self.window_for_session(session),
+            self if session is None else self.window_for_session(session),
             self.t,
             self.toast_label,
             self.add_dialog_action_button,

--- a/tests/test_sidebar_navigation.py
+++ b/tests/test_sidebar_navigation.py
@@ -1,5 +1,6 @@
 import unittest
 from types import SimpleNamespace
+from unittest.mock import Mock
 
 from termia.models import Server
 from termia.sidebar import SidebarMixin
@@ -80,3 +81,12 @@ class SidebarNavigationTests(unittest.TestCase):
 
         self.assertFalse(activated)
         self.assertIsNone(host.opened)
+
+    def test_server_scp_action_uses_no_session_context(self) -> None:
+        host, server = self.build_host([])
+        popover = Mock()
+        host.on_send_files_to_server = Mock()
+
+        host.on_server_context_send_files(None, popover, server.id)
+
+        host.on_send_files_to_server.assert_called_once_with(popover, None, server)

--- a/tests/test_terminal_panes.py
+++ b/tests/test_terminal_panes.py
@@ -157,6 +157,35 @@ class TerminalPaneStateTests(unittest.TestCase):
         )
         controller.return_value.open_file_selection.assert_called_once_with(server)
 
+    def test_scp_without_session_uses_main_window(self) -> None:
+        server = object()
+        popover = Mock()
+
+        class Host(TerminalSessionsMixin):
+            def __init__(self) -> None:
+                self.toast_label = object()
+                self.add_dialog_action_button = object()
+
+            def window_for_session(self, _session):
+                raise AssertionError("Sidebar SCP must use the main window")
+
+            def t(self, key):
+                return key
+
+        host = Host()
+        with patch("termia.terminal_sessions.FileTransferController") as controller:
+            host.on_send_files_to_server(popover, None, server)
+
+        popover.popdown.assert_called_once_with()
+        controller.assert_called_once_with(
+            host,
+            host.t,
+            host.toast_label,
+            host.add_dialog_action_button,
+            unittest.mock.ANY,
+        )
+        controller.return_value.open_file_selection.assert_called_once_with(server)
+
     def test_session_confirmation_uses_session_window(self) -> None:
         owner = object()
         session = SimpleNamespace()


### PR DESCRIPTION
## Summary

- pass an explicit no-session context from saved-server SCP actions
- use the main Termia window as the sidebar file selector parent
- preserve owning-window behavior for terminal and detached-window SCP actions
- add automated and manual regression coverage for all entry points

## Validation

- `PYTHONPATH=src python3 -m unittest tests.test_sidebar_navigation tests.test_terminal_panes tests.test_file_transfer` (32 tests)
- `PYTHONPATH=src python3 -m unittest discover -s tests` (199 tests)
- complete Python, shell, translation, and diff checks
- manual validation from saved-server, main-terminal, and detached-terminal context menus

Closes #251
