### PR TITLE
Fix known_hosts matching for configured SSH endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ Changes merged after `0.5.0-beta.3` (released 2026-07-30).
   requests (`#233`).
 - Inspect SSH known-host files asynchronously so connection and SCP startup
   cannot block the GTK interface while `ssh-keygen -F` runs (`#230`).
+- Match OpenSSH known-host resolution for non-standard SSH ports to avoid false
+  new-host prompts when a compatible entry is stored without the port (`#258`).
 - Bind session-specific dialogs, confirmations, terminal preferences, and SCP
   flows to the detached window that initiated them (`#226`).
 - Keep a detached window's native and header titles synchronized when its tab

--- a/docs/REGRESSION_CHECKS.md
+++ b/docs/REGRESSION_CHECKS.md
@@ -58,6 +58,10 @@ Protected behavior does not mean the code cannot change. It means regressions sh
 - Local terminal prompt customization must apply to newly opened and duplicated local terminals.
 - SSH sessions must not send arbitrary commands automatically to remote servers.
 - SSH fingerprint prompts must remain visible and interactive in the terminal.
+- Known-host inspection must prefer the configured endpoint (`host` on port 22
+  or `[host]:port` otherwise), then mirror OpenSSH's non-standard-port fallback
+  to `host` without modifying any known_hosts file. A genuinely unknown host
+  must still show the interactive fingerprint prompt.
 - Starting a password-backed SSH connection or SCP transfer must leave the
   interface responsive while the SSH known-host lookup completes.
 - `Send files to server` must open its selector from both a saved server's

--- a/src/termia/known_hosts.py
+++ b/src/termia/known_hosts.py
@@ -19,11 +19,12 @@ def known_host_lookup_commands(
     ssh_keygen: str,
     known_hosts_files: Iterable[Path],
 ) -> list[list[str]]:
-    lookup_host = f"[{host}]:{port}" if port != 22 else host
+    lookup_hosts = [host] if port == 22 else [f"[{host}]:{port}", host]
     return [
         [ssh_keygen, "-F", lookup_host, "-f", str(path)]
         for path in known_hosts_files
         if path.exists()
+        for lookup_host in lookup_hosts
     ]
 
 

--- a/tests/test_known_hosts.py
+++ b/tests/test_known_hosts.py
@@ -46,8 +46,26 @@ class KnownHostsTests(unittest.TestCase):
 
         self.assertEqual(
             commands,
-            [["/usr/bin/ssh-keygen", "-F", "[example.test]:2200", "-f", str(existing)]],
+            [
+                ["/usr/bin/ssh-keygen", "-F", "[example.test]:2200", "-f", str(existing)],
+                ["/usr/bin/ssh-keygen", "-F", "example.test", "-f", str(existing)],
+            ],
         )
+
+    def test_uses_only_host_for_default_ssh_port(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            known_hosts = Path(directory) / "known_hosts"
+            known_hosts.touch()
+
+            commands = known_host_lookup_commands(
+                "example.test",
+                22,
+                "/usr/bin/ssh-keygen",
+                [known_hosts],
+            )
+
+        self.assertEqual(len(commands), 1)
+        self.assertEqual(commands[0][2], "example.test")
 
     def test_checks_files_sequentially_until_host_is_found(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -56,7 +74,7 @@ class KnownHostsTests(unittest.TestCase):
             first.touch()
             second.touch()
             commands: list[list[str]] = []
-            launcher = FakeLauncher([False, True], commands)
+            launcher = FakeLauncher([False, False, True], commands)
             results: list[bool] = []
 
             with (
@@ -65,20 +83,20 @@ class KnownHostsTests(unittest.TestCase):
             ):
                 inspect_known_host_async(
                     "example.test",
-                    22,
+                    2200,
                     results.append,
                     known_hosts_files=[first, second],
                 )
 
         self.assertEqual(results, [True])
-        self.assertEqual(len(commands), 2)
-        self.assertEqual(commands[0][2], "example.test")
+        self.assertEqual(len(commands), 3)
+        self.assertEqual(commands[0][2], "[example.test]:2200")
 
     def test_reports_unknown_after_all_files_fail(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             known_hosts = Path(directory) / "known_hosts"
             known_hosts.touch()
-            launcher = FakeLauncher([False], [])
+            launcher = FakeLauncher([False, False], [])
             results: list[bool] = []
 
             with (


### PR DESCRIPTION
## Summary
- prefer the configured host and port when inspecting known_hosts
- mirror OpenSSH fallback behavior for non-standard ports when a compatible host entry is stored without the port
- preserve asynchronous, read-only inspection and the interactive prompt for unknown hosts
- add regression coverage and update the release checklist

## Automated validation
- `PYTHONPATH=src python3 -m unittest discover -s tests` (217 passed)
- `python3 -m py_compile run_termia.py scripts/compile_translations.py src/termia/*.py tests/*.py`
- `bash -n scripts/termia-setup.sh`
- `scripts/compile_translations.py --check`
- `git diff --check`

## Manual validation
- verified a non-standard SSH endpoint with a host-only known_hosts entry
- confirmed the false new-host prompt no longer appears
- preserved the unknown-host fingerprint flow

Closes #258