### PR TITLE
Fix split drag area background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 Changes merged after `0.5.0-beta.3` (released 2026-07-30).
 
+### Changed
+
+- Match the split-pane drag area background to the configured terminal background.
+
 ### Added
 
 - Add a validated per-transfer SCP destination prompt, defaulting to

--- a/docs/REGRESSION_CHECKS.md
+++ b/docs/REGRESSION_CHECKS.md
@@ -199,9 +199,23 @@ Protected behavior does not mean the code cannot change. It means regressions sh
 - Context menus and popovers must use readable foreground/background colors and must not inherit terminal colors.
 - Sidebar group/server selection colors must remain readable and must preserve the distinction between folders/groups and server entries.
 - New CSS rules must be scoped to Termia classes where practical and must not unintentionally override GTK/VTE internals.
-- Split pane separators must remain visible, narrow, and readable on both light and dark themes.
-- Showing pane status bars must not enlarge split separators; narrow panes may
-  ellipsize the connection name while keeping the timer and actions usable.
+- Split pane dividers have two deliberately different visual parts that must be
+  checked separately:
+  - The thin visual separator line uses the configured split-separator color
+    (green `#008712` by default) and configured thickness. It must remain
+    distinct from the drag area and must not be replaced by the terminal
+    background color.
+  - The wider draggable area uses the configured terminal background color, so
+    it must change when the terminal background changes and must follow the
+    active terminal theme/background. Its minimum drag size is 5 px, or the
+    configured separator thickness when that is larger; it is vertical for
+    horizontal splits and horizontal for vertical splits.
+- Split dividers must remain readable on both light and dark themes. Confirm
+  that the thin configured line remains visible while the wider drag area
+  blends with the terminal background.
+- Showing pane status bars must not enlarge either the thin separator line or
+  the draggable area; narrow panes may ellipsize the connection name while
+  keeping the timer and actions usable.
 - Showing or hiding a pane status bar must preserve the existing position of
   every affected split divider.
 - Adding a split inside an existing nested layout must preserve every ancestor
@@ -294,6 +308,16 @@ Before merging changes that touch UI, terminals, tabs, or configuration, verify:
 - Drag a horizontal split divider away from the centre, then show and hide its
   pane status bar from both the context menu and `Hide` button; the divider
   must remain at the chosen position and long status titles must ellipsize.
+  Check the divider's two visual parts independently: the thin line must keep
+  its configured color and thickness, while the wider drag area must retain its
+  minimum drag size and terminal-background color.
+- In both light and dark application themes, change the terminal background in
+  Terminal preferences and save it. Confirm that the wider draggable area
+  changes to the new terminal background while the thin separator line keeps
+  its configured color. Change the separator thickness as well and confirm
+  that only the thin line's configured thickness changes, with the drag area
+  remaining at least 5 px wide/tall or growing to the configured thickness when
+  that exceeds 5 px.
 - Starting from one pane, create the second, third, and fourth panes. Before
   every insertion, move all existing dividers away from their defaults. Repeat
   the sequence as needed to cover left, right, up, and down. Confirm each new

--- a/src/termia/app.py
+++ b/src/termia/app.py
@@ -460,6 +460,7 @@ class TermiaWindow(
         provider.load_from_data(
             build_application_css(
                 menu_bg,
+                terminal_settings.background,
                 terminal_settings.split_separator_color,
                 terminal_settings.split_separator_thickness,
             )

--- a/src/termia/styles.py
+++ b/src/termia/styles.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 def build_application_css(
     menu_background: str,
+    terminal_background: str,
     split_separator_color: str,
     split_separator_thickness: int,
 ) -> bytes:
@@ -29,9 +30,9 @@ def build_application_css(
         ".termia-pane-status > label { min-width: 0; } "
         ".termia-terminal-pane.in-split > .termia-pane-status { padding: 6px; } "
         f".termia-split-pane.horizontal > separator {{ min-width: {handle_size}px; "
-        f"background: transparent; border-left: {thickness}px solid {split_separator_color}; }} "
+        f"background: {terminal_background}; border-left: {thickness}px solid {split_separator_color}; }} "
         f".termia-split-pane.vertical > separator {{ min-height: {handle_size}px; "
-        f"background: transparent; border-top: {thickness}px solid {split_separator_color}; }} "
+        f"background: {terminal_background}; border-top: {thickness}px solid {split_separator_color}; }} "
         f".termia-split-pane.horizontal > separator:hover {{ border-left-color: alpha({split_separator_color}, 0.82); }} "
         f".termia-split-pane.vertical > separator:hover {{ border-top-color: alpha({split_separator_color}, 0.82); }} "
         ".termia-read-only-badge { font-weight: 600; } "

--- a/tests/test_styles.py
+++ b/tests/test_styles.py
@@ -11,13 +11,15 @@ from termia.styles import build_application_css
 
 class SplitSeparatorStyleTests(unittest.TestCase):
     def test_visual_line_is_independent_from_the_drag_handle(self) -> None:
-        css = build_application_css("#202020", "#008712", 1).decode()
+        css = build_application_css("#202020", "#202020", "#008712", 1).decode()
 
         self.assertIn(".termia-split-pane.horizontal > separator", css)
         self.assertIn("min-width: 5px", css)
+        self.assertIn("background: #202020; border-left: 1px solid #008712", css)
         self.assertIn("border-left: 1px solid #008712", css)
         self.assertIn(".termia-split-pane.vertical > separator", css)
         self.assertIn("min-height: 5px", css)
+        self.assertIn("background: #202020; border-top: 1px solid #008712", css)
         self.assertIn("border-top: 1px solid #008712", css)
         self.assertIn(".termia-pane-status > label { min-width: 0; }", css)
         self.assertIn(
@@ -26,7 +28,7 @@ class SplitSeparatorStyleTests(unittest.TestCase):
         )
 
     def test_configured_thickness_expands_the_handle_when_needed(self) -> None:
-        css = build_application_css("#202020", "#008712", 8).decode()
+        css = build_application_css("#202020", "#202020", "#008712", 8).decode()
 
         self.assertIn("min-width: 8px", css)
         self.assertIn("min-height: 8px", css)
@@ -38,7 +40,7 @@ class SplitSeparatorStyleTests(unittest.TestCase):
 
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
-            provider.load_from_data(build_application_css("#202020", "#008712", 1))
+            provider.load_from_data(build_application_css("#202020", "#202020", "#008712", 1))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Match the split-pane draggable area to the configured terminal background.
- Keep the thin separator line color and thickness independent.
- Document the distinction and regression checks.

## Validation
- `PYTHONPATH=src python3 -m unittest discover -s tests` (227 passed)
- `python3 -m py_compile run_termia.py scripts/compile_translations.py src/termia/*.py tests/*.py`
- `bash -n scripts/termia-setup.sh`
- `scripts/compile_translations.py --check`

Closes #264